### PR TITLE
Remove sync Stripe wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,39 +10,22 @@ function provided by the Stripe.js script as an ES module.
 
 [![npm version](https://img.shields.io/npm/v/@stripe/stripe-js.svg?style=flat-square)](https://www.npmjs.com/package/@stripe/stripe-js)
 
+## Installation
+
+Use `npm` to install the Stripe.js module:
+
+```sh
+npm install @stripe/stripe-js
+```
+
 ## Usage
-
-### `Stripe`
-
-To use the exported `Stripe` function, first include the Stripe.js script on
-each page of your site.
-
-```html
-<script src="https://js.stripe.com/v3/"></script>
-```
-
-Then import and use Stripe.js as you would any other module.
-
-```js
-import {Stripe} from '@stripe/stripe-js';
-
-const stripe = Stripe('pk_test_TYooMQauvdEDq54NiTphI7jx');
-```
-
-We’ve placed a random API key in this example. Replace it with your
-[actual publishable API keys](https://dashboard.stripe.com/account/apikeys) to
-test this code through your Stripe account.
-
-For more information on how to use Stripe.js, please refer to the
-[Stripe.js API reference](https://stripe.com/docs/js) or learn to
-[accept a payment](https://stripe.com/docs/payments/accept-a-payment) with
-Stripe.
 
 ### `loadStripe`
 
 This function returns a `Promise` that resolves with a newly created `Stripe`
 object once Stripe.js has loaded. If necessary, it will load Stripe.js for you
-by inserting the Stripe.js script tag.
+by inserting the Stripe.js script tag. If you call `loadStripe` in a server
+environment it will resolve to `null`.
 
 ```js
 import {loadStripe} from '@stripe/stripe-js';

--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ loaded on every page, not just your checkout page. This allows Stripe to detect
 anomalous behavior that may be indicative of fraud as customers browse your
 website.
 
-If you are adding the `<script>` tag manually, make sure you do so on every
-page. If you are relying on the script insertion that this module provides, and
-you utilize code splitting or only include your JavaScript app on your checkout
-page, you will need to take extra steps to ensure Stripe.js is available
-everywhere.
+By default, this module will insert a `<script>` tag that loads Stripe.js from
+`https://js.stripe.com`. This happens as a side effect immediately upon
+importing this module. If you utilize code splitting or only include your
+JavaScript app on your checkout page, the Stripe.js script will only be
+available in parts of your site and you will need to take extra steps to ensure
+Stripe.js is available everywhere.
 
 ### Import as a side effect
 
@@ -68,8 +69,8 @@ import '@stripe/stripe-js';
 ### Manually include the script tag
 
 Manually add the Stripe.js script tag to the `<head>` of each page on your site.
-If you use `loadStripe`, it will use this script tag rather than inserting a new
-one.
+If an existing script tag is already present, this module will not insert a new
+one. When you call `loadStripe`, it will use the existing script tag.
 
 ```html
 <!-- Somewhere in your site's <head> -->

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ By default, this module will insert a `<script>` tag that loads Stripe.js from
 `https://js.stripe.com`. This happens as a side effect immediately upon
 importing this module. If you utilize code splitting or only include your
 JavaScript app on your checkout page, the Stripe.js script will only be
-available in parts of your site and you will need to take extra steps to ensure
-Stripe.js is available everywhere.
+available in parts of your site. To ensure Stripe.js is available everywhere,
+you can perform either of the following steps:
 
 ### Import as a side effect
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 const V3_URL = 'https://js.stripe.com/v3';
 
-let hasInjectedScript = false;
-
 // Execute our own script injection after a tick to give users time to
 // do their own script injection.
 const stripePromise = Promise.resolve().then(() => {
@@ -18,7 +16,6 @@ const stripePromise = Promise.resolve().then(() => {
   let script = document.querySelector(`script[src="${V3_URL}"]`);
 
   if (!script) {
-    hasInjectedScript = true;
     script = document.createElement('script');
     script.src = V3_URL;
 
@@ -48,41 +45,7 @@ const stripePromise = Promise.resolve().then(() => {
   });
 });
 
-let hasCalledLoadStripe = false;
-export const loadStripe = (...args) => {
-  hasCalledLoadStripe = true;
-  return stripePromise.then((maybeStripe) =>
+export const loadStripe = (...args) =>
+  stripePromise.then((maybeStripe) =>
     maybeStripe ? maybeStripe(...args) : null
   );
-};
-
-const STRIPE_NOT_LOADED_ERROR_TEXT = `Stripe.js has not yet loaded. Instead of calling \`Stripe\` directly, try using the \`loadStripe\` utility from this package.
-
-See https://stripe.com/docs/js/including for more information.
-`;
-
-const STRIPE_UNAVAILABLE_ERROR_TEXT = `window.Stripe is not defined. Did you include Stripe.js on your page?
-
-For compliance reasons, Stripe.js must be loaded directly from https://js.stripe.com, and cannot be included in a bundle or hosted yourself. This npm module exists as a convenience, but delegates to window.Stripe.
-
-You can load Stripe.js by using the \`loadStripe\` utility from this package, or by including the following <script> tag on your page:
-
-<script src="${V3_URL}"></script>
-
-See https://stripe.com/docs/js/including for more information.
-`;
-
-const hasUserIncludedScript = () =>
-  document.querySelector(`script[src="${V3_URL}"]`) && !hasInjectedScript;
-
-export const Stripe = (...args) => {
-  if (window && window.Stripe) {
-    return window.Stripe(...args);
-  }
-
-  if (hasCalledLoadStripe || hasUserIncludedScript()) {
-    throw new Error(STRIPE_NOT_LOADED_ERROR_TEXT);
-  }
-
-  throw new Error(STRIPE_UNAVAILABLE_ERROR_TEXT);
-};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -96,46 +96,4 @@ describe('Stripe module loader', () => {
       });
     });
   });
-
-  describe('Stripe proxy', () => {
-    it('proxies to window.Stripe when present', () => {
-      const {Stripe} = require('./index');
-      window.Stripe = jest.fn((key) => ({key}));
-
-      expect(Stripe('pk_test_foo')).toEqual({key: 'pk_test_foo'});
-    });
-
-    it('throws when Stripe.js has not yet loaded from a user injected script', () => {
-      const {Stripe} = require('./index');
-      const script = document.createElement('script');
-      script.src = 'https://js.stripe.com/v3';
-      document.body.appendChild(script);
-
-      expect(() => Stripe('pk_test_foo')).toThrow(
-        'Stripe.js has not yet loaded.'
-      );
-    });
-
-    it('throws when Stripe.js has not yet loaded after calling loadStripe', () => {
-      const {loadStripe, Stripe} = require('./index');
-
-      loadStripe();
-
-      expect(() => Stripe('pk_test_foo')).toThrow(
-        'Stripe.js has not yet loaded.'
-      );
-    });
-
-    it('throws when Stripe.js has not been included', () => {
-      const {Stripe} = require('./index');
-
-      return Promise.resolve(() => {
-        // Wait for next tick to validate this error is thrown
-        // even after our own script has been added.
-        expect(() => Stripe('pk_test_foo')).toThrow(
-          'window.Stripe.js is not defined.'
-        );
-      });
-    });
-  });
 });


### PR DESCRIPTION
### Summary & motivation
Remove the synchronous `Stripe` wrapper in favor of encouraging `loadStripe` as the default way to load Stripe.js using a modern toolchain. The synchronous wrapper was difficult to document and had minimal value.

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
I updated the tests and documentation.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
