### PR TITLE
Fix partial options update

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/parser": "^2.15.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
+    "conditional-type-checks": "^1.0.5",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.8.0",
     "eslint-plugin-import": "^2.18.2",

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1,5 +1,7 @@
 ///<reference path='../../types/index.d.ts' />
 
+import {assert, Has} from 'conditional-type-checks';
+
 /*
  * This code will not run, but will be typechecked as a test.
  */
@@ -144,6 +146,21 @@ const paymentRequestButtonElement = elements.create('paymentRequestButton', {
 const retrievedPaymentRequestButtonElement: StripePaymentRequestButtonElement | null = elements.getElement(
   'paymentRequestButton'
 );
+
+// Make sure that `paymentRequest` is at least optional;
+retrievedPaymentRequestButtonElement!.update({});
+
+type StripePaymentRequestButtonElementUpdateOptions = Parameters<
+  StripePaymentRequestButtonElement['update']
+>[0];
+
+// Check that giving `paymentRequest` options is not allowed
+assert<
+  Has<
+    Required<StripePaymentRequestButtonElementUpdateOptions>,
+    {paymentRequest: PaymentRequest}
+  >
+>(false);
 
 const cardElementType: StripeElementType = 'card';
 const ibanElementType: StripeElementType = 'iban';

--- a/types/stripe-js/elements/card-cvc.d.ts
+++ b/types/stripe-js/elements/card-cvc.d.ts
@@ -34,7 +34,7 @@ declare module '@stripe/stripe-js' {
      * The styles of an `CardCvcElement` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: StripeCardCvcElementOptions): void;
+    update(options: Partial<StripeCardCvcElementOptions>): void;
   };
 
   interface StripeCardCvcElementOptions {

--- a/types/stripe-js/elements/card-expiry.d.ts
+++ b/types/stripe-js/elements/card-expiry.d.ts
@@ -34,7 +34,7 @@ declare module '@stripe/stripe-js' {
      * The styles of an `CardExpiryElement` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: StripeCardExpiryElementOptions): void;
+    update(options: Partial<StripeCardExpiryElementOptions>): void;
   };
 
   interface StripeCardExpiryElementOptions {

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -34,7 +34,7 @@ declare module '@stripe/stripe-js' {
      * The styles of an `Element` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: StripeCardNumberElementOptions): void;
+    update(options: Partial<StripeCardNumberElementOptions>): void;
   };
 
   interface StripeCardNumberElementOptions {

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -34,7 +34,7 @@ declare module '@stripe/stripe-js' {
      * The styles of an `CardElement` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: StripeCardElementOptions): void;
+    update(options: Partial<StripeCardElementOptions>): void;
   };
 
   interface StripeCardElementOptions {

--- a/types/stripe-js/elements/iban.d.ts
+++ b/types/stripe-js/elements/iban.d.ts
@@ -34,7 +34,7 @@ declare module '@stripe/stripe-js' {
      * The styles of an `IbanElement` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: StripeIbanElementOptions): void;
+    update(options: Partial<StripeIbanElementOptions>): void;
   };
 
   interface StripeIbanElementOptions {

--- a/types/stripe-js/elements/ideal-bank.d.ts
+++ b/types/stripe-js/elements/ideal-bank.d.ts
@@ -34,7 +34,7 @@ declare module '@stripe/stripe-js' {
      * The styles of an `IdealBankElement` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: StripeIdealBankElementOptions): void;
+    update(options: Partial<StripeIdealBankElementOptions>): void;
   };
 
   interface StripeIdealBankElementOptions {

--- a/types/stripe-js/elements/payment-request-button.d.ts
+++ b/types/stripe-js/elements/payment-request-button.d.ts
@@ -43,7 +43,11 @@ declare module '@stripe/stripe-js' {
      * The styles of an `PaymentRequestButtonElement` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: Partial<StripePaymentRequestButtonElementOptions>): void;
+    update(
+      options: Partial<
+        Omit<StripePaymentRequestButtonElementOptions, 'paymentRequest'>
+      >
+    ): void;
   };
 
   interface StripePaymentRequestButtonElementOptions {

--- a/types/stripe-js/elements/payment-request-button.d.ts
+++ b/types/stripe-js/elements/payment-request-button.d.ts
@@ -43,7 +43,7 @@ declare module '@stripe/stripe-js' {
      * The styles of an `PaymentRequestButtonElement` can be dynamically changed using `element.update`.
      * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
      */
-    update(options: StripePaymentRequestButtonElementOptions): void;
+    update(options: Partial<StripePaymentRequestButtonElementOptions>): void;
   };
 
   interface StripePaymentRequestButtonElementOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,6 +1451,11 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
+conditional-type-checks@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/conditional-type-checks/-/conditional-type-checks-1.0.5.tgz#310ecd13c46c3963fbe9a2f8f93511d88cdcc973"
+  integrity sha512-DkfkvmjXVe4ye4llJ1JADtO3dNvqqcQM08cA9BhNt9Oe8pyRW8X1CZyBg9Qst05bDV9BJM01KLmnFh78NcJgNg==
+
 contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"


### PR DESCRIPTION
### Summary & motivation

Update options are partial.
PaymentRequestButton cannot update `paymentRequest` option

### Testing & documentation

Added test to ensure that
- `update` can be called without a `paymentRequest` option
- `paymentRequest` option cannot be given to `update` (property omitted not simply optional)

Added type assertion library because the second test is a negative assertion.

r? @christopher-stripe 