### PR TITLE
Add auBankAccount element support

### DIFF
--- a/types/stripe-js/elements.d.ts
+++ b/types/stripe-js/elements.d.ts
@@ -5,6 +5,7 @@
 ///<reference path='./elements/iban.d.ts' />
 ///<reference path='./elements/ideal-bank.d.ts' />
 ///<reference path='./elements/payment-request-button.d.ts' />
+///<reference path='./elements/au-bank-account.d.ts' />
 
 declare module '@stripe/stripe-js' {
   interface StripeElements {
@@ -139,7 +140,8 @@ declare module '@stripe/stripe-js' {
     | 'cardCvc'
     | 'iban'
     | 'idealBank'
-    | 'paymentRequestButton';
+    | 'paymentRequestButton'
+    | 'auBankAccount';
 
   type StripeElement =
     | StripeCardElement
@@ -148,7 +150,8 @@ declare module '@stripe/stripe-js' {
     | StripeCardCvcElement
     | StripeIbanElement
     | StripeIdealBankElement
-    | StripePaymentRequestButtonElement;
+    | StripePaymentRequestButtonElement
+    | StripeAuBankAccountElement;
 
   /**
    * Options to create an `Elements` instance with.

--- a/types/stripe-js/elements/au-bank-account.d.ts
+++ b/types/stripe-js/elements/au-bank-account.d.ts
@@ -1,0 +1,80 @@
+///<reference path='./base.d.ts' />
+
+declare module '@stripe/stripe-js' {
+  type StripeAuBankAccountElement = StripeElementBase & {
+    /**
+     * The change event is triggered when the `Element`'s value changes.
+     */
+    on(
+      eventType: 'change',
+      handler: (event: StripeAuBankAccountElementChangeEvent) => any
+    ): void;
+
+    /**
+     * Triggered when the element is fully rendered and can accept `element.focus` calls.
+     */
+    on(eventType: 'ready', handler: () => any): StripeAuBankAccountElement;
+
+    /**
+     * Triggered when the element gains focus.
+     */
+    on(eventType: 'focus', handler: () => any): StripeAuBankAccountElement;
+
+    /**
+     * Triggered when the element loses focus.
+     */
+    on(eventType: 'blur', handler: () => any): StripeAuBankAccountElement;
+
+    /**
+     * Updates the options the `AuBankAccountElement` was initialized with.
+     * Updates are merged into the existing configuration.
+     *
+     * If you collect certain information in a different part of your interface (e.g., ZIP or postal code), use `element.update` with the appropriate information.
+     *
+     * The styles of an `AuBankAccountElement` can be dynamically changed using `element.update`.
+     * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+     */
+    update(options: Partial<StripeAuBankAccountElementOptions>): void;
+  };
+
+  interface StripeAuBankAccountElementOptions {
+    classes?: StripeElementClasses;
+
+    style?: StripeElementStyle;
+
+    /**
+     * Appearance of the icon in the Element.
+     */
+    iconStyle?: 'default' | 'solid';
+
+    /**
+     * Hides the icon in the Element.
+     * Default is `false`.
+     */
+    hideIcon?: boolean;
+
+    /**
+     * Applies a disabled state to the Element such that user input is not accepted.
+     * Default is false.
+     */
+    disabled?: boolean;
+  }
+
+  interface StripeAuBankAccountElementChangeEvent
+    extends StripeElementChangeEvent {
+    /**
+     * The type of element that emitted this event.
+     */
+    elementType: 'auBankAccount';
+
+    /**
+     * The bank name corresponding to the entered BSB.
+     */
+    bankName?: string;
+
+    /**
+     * The branch name corresponding to the entered BSB.
+     */
+    branchName?: string;
+  }
+}

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -50,6 +50,36 @@ declare module '@stripe/stripe-js' {
     };
   }
 
+  interface CreatePaymentMethodAuBecsDebitData
+    extends PaymentMethodCreateParams {
+    type: 'au_becs_debit';
+
+    au_becs_debit:
+      | StripeAuBankAccountElement
+      | {
+          /**
+           * A BSB number.
+           */
+          bsb_number: string;
+
+          /**
+           * An account number.
+           */
+          account_number: string;
+        };
+
+    /*
+     * The customer's billing details.
+     * `name` and `email` are required.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details: PaymentMethodCreateParams.BillingDetails & {
+      name: string;
+      email: string;
+    };
+  }
+
   /**
    * Data to be sent with a `stripe.confirmCardPayment` request.
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
@@ -125,5 +155,25 @@ declare module '@stripe/stripe-js' {
      * Default is `true`.
      */
     handleActions?: boolean;
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmAuBecsDebitPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmAuBecsDebitPaymentData extends PaymentIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodAuBecsDebitData, 'type'>;
+
+    /**
+     * To save the BECS Direct Debit account for reuse, set this parameter to `off_session`.
+     * BECS Direct Debit only accepts an `off_session` value for this parameter.
+     */
+    setup_future_usage?: 'off_session';
   }
 }

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -37,4 +37,18 @@ declare module '@stripe/stripe-js' {
      */
     payment_method?: string | Omit<CreatePaymentMethodSepaDebitData, 'type'>;
   }
+
+  /**
+   * Data to be sent with a `stripe.confirmAuBecsDebitSetup` request.
+   * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmAuBecsDebitSetupData extends SetupIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `SetupIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodAuBecsDebitData, 'type'>;
+  }
 }


### PR DESCRIPTION
### Summary & motivation

Add support for the (beta) `auBankAccount` component.

### Testing & documentation

Confirmed typechecking passes, tested manually downstream with the react-stripe-js repo.

Documentation is planned to be included in the beta docs.