### PR TITLE
Test that implementation and module type definitions match

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -42,6 +42,9 @@ const stripeConnectPromise = loadStripe('', {stripeAccount: '', locale: 'en'});
 type TypeModule = typeof import('@stripe/stripe-js');
 type SrcModule = typeof import('../../src/index');
 
+// Makes sure that the implementation matches the type definitions
+// Checking for compatibility both ways ensures that the exports
+// are equivalent with nothing missing on either side.
 import('../../src/index').then((srcModule: TypeModule) => {});
 import('@stripe/stripe-js').then((typeModule: SrcModule) => {});
 

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -42,8 +42,8 @@ const stripeConnectPromise = loadStripe('', {stripeAccount: '', locale: 'en'});
 type TypeModule = typeof import('@stripe/stripe-js');
 type SrcModule = typeof import('../../src/index');
 
-assert<Has<TypeModule, SrcModule>>(true);
-assert<Has<SrcModule, TypeModule>>(true);
+import('../../src/index').then((srcModule: TypeModule) => {});
+import('@stripe/stripe-js').then((typeModule: SrcModule) => {});
 
 declare const stripe: Stripe;
 

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -39,6 +39,12 @@ import {
 const stripePromise: Promise<Stripe | null> = loadStripe('');
 const stripeConnectPromise = loadStripe('', {stripeAccount: '', locale: 'en'});
 
+type TypeModule = typeof import('@stripe/stripe-js');
+type SrcModule = typeof import('../../src/index');
+
+assert<Has<TypeModule, SrcModule>>(true);
+assert<Has<SrcModule, TypeModule>>(true);
+
 declare const stripe: Stripe;
 
 const OPEN_SANS: CssFontSource = {


### PR DESCRIPTION
### Summary & motivation

Since we manually define the types of the module, add a test that the src implementation is compatible with the defined types, and that no export is missing or extra.

