### PR TITLE
Improve error for incompatible card data type in `createToken`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest",
     "test:versions": "./tests/versions/scripts/test.sh",
-    "test:types": "tsc -p ./tests/types",
+    "test:types": "tsc -p ./tests/types && jest --roots '<rootDir>/tests/types'",
     "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-list-different",
     "typecheck": "tsc",
     "build": "yarn clean && yarn rollup -c",

--- a/tests/types/errors.test.ts
+++ b/tests/types/errors.test.ts
@@ -21,19 +21,12 @@ const getError = function(fileName: string) {
 };
 
 describe('Typescript errors', () => {
-  test.each([
-    [
-      'createCardTokenExtraPropertyError',
-      `'extra_property' does not exist in type 'CreateTokenCardData'`,
-    ],
-    [
-      'createIbanTokenExtraPropertyError',
-      // In a perfect world it would be `'extra_property' does not exist in type 'CreateTokenIbanData'`,
-      `'StripeIbanElement' is not assignable to parameter of type 'StripeCardElement | StripeCardNumberElement'`,
-    ],
-  ])('%s', (fileName, expectedError) => {
-    expect(
-      getError(path.resolve(__dirname, `./fixtures/${fileName}.ts`))
-    ).toMatch(expectedError);
-  });
+  test.each([['createCardTokenExtraPropertyError', 'extra_property']])(
+    '%s',
+    (fileName, expectedError) => {
+      expect(
+        getError(path.resolve(__dirname, `./fixtures/${fileName}.ts`))
+      ).toMatch(expectedError);
+    }
+  );
 });

--- a/tests/types/errors.test.ts
+++ b/tests/types/errors.test.ts
@@ -1,0 +1,39 @@
+import * as path from 'path';
+import {readFileSync} from 'fs';
+
+import * as ts from 'typescript';
+
+const parsedCommandLine = ts.getParsedCommandLineOfConfigFile(
+  path.resolve(__dirname, 'tsconfig.json'),
+  {},
+  {
+    ...ts.sys,
+    getCurrentDirectory: () => __dirname,
+    onUnRecoverableConfigFileDiagnostic: () => {},
+  }
+)!;
+
+const getError = function(fileName: string) {
+  const program = ts.createProgram([fileName], parsedCommandLine.options);
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+
+  return ts.flattenDiagnosticMessageText(diagnostics[0].messageText, '\n');
+};
+
+describe('Typescript errors', () => {
+  test.each([
+    [
+      'createCardTokenExtraPropertyError',
+      `'extra_property' does not exist in type 'CreateTokenCardData'`,
+    ],
+    [
+      'createIbanTokenExtraPropertyError',
+      // In a perfect world it would be `'extra_property' does not exist in type 'CreateTokenIbanData'`,
+      `'StripeIbanElement' is not assignable to parameter of type 'StripeCardElement | StripeCardNumberElement'`,
+    ],
+  ])('%s', (fileName, expectedError) => {
+    expect(
+      getError(path.resolve(__dirname, `./fixtures/${fileName}.ts`))
+    ).toMatch(expectedError);
+  });
+});

--- a/tests/types/fixtures/createCardTokenExtraPropertyError.ts
+++ b/tests/types/fixtures/createCardTokenExtraPropertyError.ts
@@ -1,0 +1,15 @@
+///<reference path='../../../types/index.d.ts' />
+
+import {Stripe, StripeElements, StripeCardElement} from '@stripe/stripe-js';
+
+declare const stripe: Stripe;
+
+const elements: StripeElements = stripe.elements();
+
+const cardElement: StripeCardElement = elements.create('card');
+
+stripe.createToken(cardElement, {
+  currency: '',
+  name: '',
+  extra_property: '',
+});

--- a/tests/types/fixtures/createIbanTokenExtraPropertyError.ts
+++ b/tests/types/fixtures/createIbanTokenExtraPropertyError.ts
@@ -1,0 +1,15 @@
+///<reference path='../../../types/index.d.ts' />
+
+import {Stripe, StripeElements, StripeIbanElement} from '@stripe/stripe-js';
+
+declare const stripe: Stripe;
+
+const elements: StripeElements = stripe.elements();
+
+const ibanElement: StripeIbanElement = elements.create('iban');
+
+stripe.createToken(ibanElement, {
+  currency: '',
+  account_holder_name: '',
+  extra_property: '',
+});

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -252,16 +252,6 @@ declare module '@stripe/stripe-js' {
     /////////////////////////////
 
     /**
-     * Use `stripe.createToken` to convert information collected by card elements into a single-use [Token](https://stripe.com/docs/api#tokens) that you safely pass to your server to use in an API call.
-     *
-     * @docs https://stripe.com/docs/js/tokens_sources/create_token?type=cardElement
-     */
-    createToken(
-      tokenType: StripeCardElement | StripeCardNumberElement,
-      data?: CreateTokenCardData
-    ): Promise<{token?: Token; error?: StripeError}>;
-
-    /**
      * Use `stripe.createToken` to convert information collected by an `IbanElement` into a single-use [Token](https://stripe.com/docs/api#tokens) that you safely pass to your server to use in an API call.
      *
      * @docs https://stripe.com/docs/js/tokens_sources/create_token?type=ibanElement
@@ -269,6 +259,16 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeIbanElement,
       data: CreateTokenIbanData
+    ): Promise<{token?: Token; error?: StripeError}>;
+
+    /**
+     * Use `stripe.createToken` to convert information collected by card elements into a single-use [Token](https://stripe.com/docs/api#tokens) that you safely pass to your server to use in an API call.
+     *
+     * @docs https://stripe.com/docs/js/tokens_sources/create_token?type=cardElement
+     */
+    createToken(
+      tokenType: StripeCardElement | StripeCardNumberElement,
+      data?: CreateTokenCardData
     ): Promise<{token?: Token; error?: StripeError}>;
 
     /**


### PR DESCRIPTION
Switch order of the `createToken` overload to give precedence to CardElement over IbanElement.

### Summary & motivation

See https://github.com/stripe/react-stripe-js/issues/47

### Testing & documentation

Added tests for expected typescript errors.