### PR TITLE
Relax script detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,9 @@ const stripePromise: Promise<StripeConstructor | null> = Promise.resolve().then(
     }
 
     const script: HTMLScriptElement =
-      document.querySelector(`script[src="${V3_URL}"]`) || injectScript();
+      document.querySelector(
+        `script[src="${V3_URL}"], script[src="${V3_URL}/"]`
+      ) || injectScript();
 
     return new Promise((resolve, reject) => {
       script.addEventListener('load', () => {


### PR DESCRIPTION
Fixes #14

Tweaks the logic for detecting whether Stripe.js has already been loaded.

Previously it would expect Stripe.js to be loaded without a trailing slash on the URL (`https://js.stripe.com/v3`).

Now it will detect the script either with or without a trailing slash appended to this URL (`https://js.stripe.com/v3` or `https://js.stripe.com/v3/`).