### PR TITLE
Document `once` and `off` of the event emitters

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -214,6 +214,11 @@ cardElement
     }
   });
 
+const onceHandler = () => {};
+cardElement.once('ready', onceHandler);
+cardElement.off('ready', onceHandler);
+cardElement.off('change');
+
 auBankAccountElement.on(
   'change',
   (e: StripeAuBankAccountElementChangeEvent) => {}

--- a/types/stripe-js/elements/au-bank-account.d.ts
+++ b/types/stripe-js/elements/au-bank-account.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeAuBankAccountElementChangeEvent) => any
     ): StripeAuBankAccountElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeAuBankAccountElementChangeEvent) => any
+    ): StripeAuBankAccountElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeAuBankAccountElement;
+    once(eventType: 'ready', handler: () => any): StripeAuBankAccountElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeAuBankAccountElement;
+    once(eventType: 'focus', handler: () => any): StripeAuBankAccountElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeAuBankAccountElement;
+    once(eventType: 'blur', handler: () => any): StripeAuBankAccountElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeAuBankAccountElement;
+    once(eventType: 'escape', handler: () => any): StripeAuBankAccountElement;
 
     /**
      * Updates the options the `AuBankAccountElement` was initialized with.

--- a/types/stripe-js/elements/au-bank-account.d.ts
+++ b/types/stripe-js/elements/au-bank-account.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeAuBankAccountElementChangeEvent) => any
     ): StripeAuBankAccountElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeAuBankAccountElementChangeEvent) => any
+    ): StripeAuBankAccountElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeAuBankAccountElement;
     once(eventType: 'ready', handler: () => any): StripeAuBankAccountElement;
+    off(eventType: 'ready', handler?: () => any): StripeAuBankAccountElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeAuBankAccountElement;
     once(eventType: 'focus', handler: () => any): StripeAuBankAccountElement;
+    off(eventType: 'focus', handler?: () => any): StripeAuBankAccountElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeAuBankAccountElement;
     once(eventType: 'blur', handler: () => any): StripeAuBankAccountElement;
+    off(eventType: 'blur', handler?: () => any): StripeAuBankAccountElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeAuBankAccountElement;
     once(eventType: 'escape', handler: () => any): StripeAuBankAccountElement;
+    off(eventType: 'escape', handler?: () => any): StripeAuBankAccountElement;
 
     /**
      * Updates the options the `AuBankAccountElement` was initialized with.

--- a/types/stripe-js/elements/card-cvc.d.ts
+++ b/types/stripe-js/elements/card-cvc.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardCvcElementChangeEvent) => any
     ): StripeCardCvcElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeCardCvcElementChangeEvent) => any
+    ): StripeCardCvcElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardCvcElement;
+    once(eventType: 'ready', handler: () => any): StripeCardCvcElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardCvcElement;
+    once(eventType: 'focus', handler: () => any): StripeCardCvcElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardCvcElement;
+    once(eventType: 'blur', handler: () => any): StripeCardCvcElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardCvcElement;
+    once(eventType: 'escape', handler: () => any): StripeCardCvcElement;
 
     /**
      * Updates the options the `CardCvcElement` was initialized with.

--- a/types/stripe-js/elements/card-cvc.d.ts
+++ b/types/stripe-js/elements/card-cvc.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardCvcElementChangeEvent) => any
     ): StripeCardCvcElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeCardCvcElementChangeEvent) => any
+    ): StripeCardCvcElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardCvcElement;
     once(eventType: 'ready', handler: () => any): StripeCardCvcElement;
+    off(eventType: 'ready', handler?: () => any): StripeCardCvcElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardCvcElement;
     once(eventType: 'focus', handler: () => any): StripeCardCvcElement;
+    off(eventType: 'focus', handler?: () => any): StripeCardCvcElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardCvcElement;
     once(eventType: 'blur', handler: () => any): StripeCardCvcElement;
+    off(eventType: 'blur', handler?: () => any): StripeCardCvcElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardCvcElement;
     once(eventType: 'escape', handler: () => any): StripeCardCvcElement;
+    off(eventType: 'escape', handler?: () => any): StripeCardCvcElement;
 
     /**
      * Updates the options the `CardCvcElement` was initialized with.

--- a/types/stripe-js/elements/card-expiry.d.ts
+++ b/types/stripe-js/elements/card-expiry.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardExpiryElementChangeEvent) => any
     ): StripeCardExpiryElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeCardExpiryElementChangeEvent) => any
+    ): StripeCardExpiryElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardExpiryElement;
+    once(eventType: 'ready', handler: () => any): StripeCardExpiryElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardExpiryElement;
+    once(eventType: 'focus', handler: () => any): StripeCardExpiryElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardExpiryElement;
+    once(eventType: 'blur', handler: () => any): StripeCardExpiryElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardExpiryElement;
+    once(eventType: 'escape', handler: () => any): StripeCardExpiryElement;
 
     /**
      * Updates the options the `CardExpiryElement` was initialized with.

--- a/types/stripe-js/elements/card-expiry.d.ts
+++ b/types/stripe-js/elements/card-expiry.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardExpiryElementChangeEvent) => any
     ): StripeCardExpiryElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeCardExpiryElementChangeEvent) => any
+    ): StripeCardExpiryElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardExpiryElement;
     once(eventType: 'ready', handler: () => any): StripeCardExpiryElement;
+    off(eventType: 'ready', handler?: () => any): StripeCardExpiryElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardExpiryElement;
     once(eventType: 'focus', handler: () => any): StripeCardExpiryElement;
+    off(eventType: 'focus', handler?: () => any): StripeCardExpiryElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardExpiryElement;
     once(eventType: 'blur', handler: () => any): StripeCardExpiryElement;
+    off(eventType: 'blur', handler?: () => any): StripeCardExpiryElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardExpiryElement;
     once(eventType: 'escape', handler: () => any): StripeCardExpiryElement;
+    off(eventType: 'escape', handler?: () => any): StripeCardExpiryElement;
 
     /**
      * Updates the options the `CardExpiryElement` was initialized with.

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardNumberElementChangeEvent) => any
     ): StripeCardNumberElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeCardNumberElementChangeEvent) => any
+    ): StripeCardNumberElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardNumberElement;
     once(eventType: 'ready', handler: () => any): StripeCardNumberElement;
+    off(eventType: 'ready', handler?: () => any): StripeCardNumberElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardNumberElement;
     once(eventType: 'focus', handler: () => any): StripeCardNumberElement;
+    off(eventType: 'focus', handler?: () => any): StripeCardNumberElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardNumberElement;
     once(eventType: 'blur', handler: () => any): StripeCardNumberElement;
+    off(eventType: 'blur', handler?: () => any): StripeCardNumberElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardNumberElement;
     once(eventType: 'escape', handler: () => any): StripeCardNumberElement;
+    off(eventType: 'escape', handler?: () => any): StripeCardNumberElement;
 
     /**
      * Updates the options the `CardNumberElement` was initialized with.

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardNumberElementChangeEvent) => any
     ): StripeCardNumberElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeCardNumberElementChangeEvent) => any
+    ): StripeCardNumberElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardNumberElement;
+    once(eventType: 'ready', handler: () => any): StripeCardNumberElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardNumberElement;
+    once(eventType: 'focus', handler: () => any): StripeCardNumberElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardNumberElement;
+    once(eventType: 'blur', handler: () => any): StripeCardNumberElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardNumberElement;
+    once(eventType: 'escape', handler: () => any): StripeCardNumberElement;
 
     /**
      * Updates the options the `CardNumberElement` was initialized with.

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardElementChangeEvent) => any
     ): StripeCardElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeCardElementChangeEvent) => any
+    ): StripeCardElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardElement;
     once(eventType: 'ready', handler: () => any): StripeCardElement;
+    off(eventType: 'ready', handler?: () => any): StripeCardElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardElement;
     once(eventType: 'focus', handler: () => any): StripeCardElement;
+    off(eventType: 'focus', handler?: () => any): StripeCardElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardElement;
     once(eventType: 'blur', handler: () => any): StripeCardElement;
+    off(eventType: 'blur', handler?: () => any): StripeCardElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardElement;
     once(eventType: 'escape', handler: () => any): StripeCardElement;
+    off(eventType: 'escape', handler?: () => any): StripeCardElement;
 
     /**
      * Updates the options the `CardElement` was initialized with.

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeCardElementChangeEvent) => any
     ): StripeCardElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeCardElementChangeEvent) => any
+    ): StripeCardElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeCardElement;
+    once(eventType: 'ready', handler: () => any): StripeCardElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeCardElement;
+    once(eventType: 'focus', handler: () => any): StripeCardElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeCardElement;
+    once(eventType: 'blur', handler: () => any): StripeCardElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeCardElement;
+    once(eventType: 'escape', handler: () => any): StripeCardElement;
 
     /**
      * Updates the options the `CardElement` was initialized with.

--- a/types/stripe-js/elements/fpx-bank.d.ts
+++ b/types/stripe-js/elements/fpx-bank.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeFpxBankElementChangeEvent) => any
     ): StripeFpxBankElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeFpxBankElementChangeEvent) => any
+    ): StripeFpxBankElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeFpxBankElement;
+    once(eventType: 'ready', handler: () => any): StripeFpxBankElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeFpxBankElement;
+    once(eventType: 'focus', handler: () => any): StripeFpxBankElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeFpxBankElement;
+    once(eventType: 'blur', handler: () => any): StripeFpxBankElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeFpxBankElement;
+    once(eventType: 'escape', handler: () => any): StripeFpxBankElement;
 
     /**
      * Updates the options the `FpxBankElement` was initialized with.

--- a/types/stripe-js/elements/fpx-bank.d.ts
+++ b/types/stripe-js/elements/fpx-bank.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeFpxBankElementChangeEvent) => any
     ): StripeFpxBankElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeFpxBankElementChangeEvent) => any
+    ): StripeFpxBankElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeFpxBankElement;
     once(eventType: 'ready', handler: () => any): StripeFpxBankElement;
+    off(eventType: 'ready', handler?: () => any): StripeFpxBankElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeFpxBankElement;
     once(eventType: 'focus', handler: () => any): StripeFpxBankElement;
+    off(eventType: 'focus', handler?: () => any): StripeFpxBankElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeFpxBankElement;
     once(eventType: 'blur', handler: () => any): StripeFpxBankElement;
+    off(eventType: 'blur', handler?: () => any): StripeFpxBankElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeFpxBankElement;
     once(eventType: 'escape', handler: () => any): StripeFpxBankElement;
+    off(eventType: 'escape', handler?: () => any): StripeFpxBankElement;
 
     /**
      * Updates the options the `FpxBankElement` was initialized with.

--- a/types/stripe-js/elements/iban.d.ts
+++ b/types/stripe-js/elements/iban.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeIbanElementChangeEvent) => any
     ): StripeIbanElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeIbanElementChangeEvent) => any
+    ): StripeIbanElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeIbanElement;
     once(eventType: 'ready', handler: () => any): StripeIbanElement;
+    off(eventType: 'ready', handler?: () => any): StripeIbanElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeIbanElement;
     once(eventType: 'focus', handler: () => any): StripeIbanElement;
+    off(eventType: 'focus', handler?: () => any): StripeIbanElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeIbanElement;
     once(eventType: 'blur', handler: () => any): StripeIbanElement;
+    off(eventType: 'blur', handler?: () => any): StripeIbanElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeIbanElement;
     once(eventType: 'escape', handler: () => any): StripeIbanElement;
+    off(eventType: 'escape', handler?: () => any): StripeIbanElement;
 
     /**
      * Updates the options the `IbanElement` was initialized with.

--- a/types/stripe-js/elements/iban.d.ts
+++ b/types/stripe-js/elements/iban.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeIbanElementChangeEvent) => any
     ): StripeIbanElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeIbanElementChangeEvent) => any
+    ): StripeIbanElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeIbanElement;
+    once(eventType: 'ready', handler: () => any): StripeIbanElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeIbanElement;
+    once(eventType: 'focus', handler: () => any): StripeIbanElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeIbanElement;
+    once(eventType: 'blur', handler: () => any): StripeIbanElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeIbanElement;
+    once(eventType: 'escape', handler: () => any): StripeIbanElement;
 
     /**
      * Updates the options the `IbanElement` was initialized with.

--- a/types/stripe-js/elements/ideal-bank.d.ts
+++ b/types/stripe-js/elements/ideal-bank.d.ts
@@ -13,30 +13,38 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeIdealBankElementChangeEvent) => any
     ): StripeIdealBankElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripeIdealBankElementChangeEvent) => any
+    ): StripeIdealBankElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeIdealBankElement;
     once(eventType: 'ready', handler: () => any): StripeIdealBankElement;
+    off(eventType: 'ready', handler?: () => any): StripeIdealBankElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeIdealBankElement;
     once(eventType: 'focus', handler: () => any): StripeIdealBankElement;
+    off(eventType: 'focus', handler?: () => any): StripeIdealBankElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeIdealBankElement;
     once(eventType: 'blur', handler: () => any): StripeIdealBankElement;
+    off(eventType: 'blur', handler?: () => any): StripeIdealBankElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeIdealBankElement;
     once(eventType: 'escape', handler: () => any): StripeIdealBankElement;
+    off(eventType: 'escape', handler?: () => any): StripeIdealBankElement;
 
     /**
      * Updates the options the `IdealBankElement` was initialized with.

--- a/types/stripe-js/elements/ideal-bank.d.ts
+++ b/types/stripe-js/elements/ideal-bank.d.ts
@@ -9,26 +9,34 @@ declare module '@stripe/stripe-js' {
       eventType: 'change',
       handler: (event: StripeIdealBankElementChangeEvent) => any
     ): StripeIdealBankElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeIdealBankElementChangeEvent) => any
+    ): StripeIdealBankElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(eventType: 'ready', handler: () => any): StripeIdealBankElement;
+    once(eventType: 'ready', handler: () => any): StripeIdealBankElement;
 
     /**
      * Triggered when the element gains focus.
      */
     on(eventType: 'focus', handler: () => any): StripeIdealBankElement;
+    once(eventType: 'focus', handler: () => any): StripeIdealBankElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(eventType: 'blur', handler: () => any): StripeIdealBankElement;
+    once(eventType: 'blur', handler: () => any): StripeIdealBankElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
      */
     on(eventType: 'escape', handler: () => any): StripeIdealBankElement;
+    once(eventType: 'escape', handler: () => any): StripeIdealBankElement;
 
     /**
      * Updates the options the `IdealBankElement` was initialized with.

--- a/types/stripe-js/elements/payment-request-button.d.ts
+++ b/types/stripe-js/elements/payment-request-button.d.ts
@@ -9,11 +9,19 @@ declare module '@stripe/stripe-js' {
       eventType: 'click',
       handler: (event: StripePaymentRequestButtonElementClickEvent) => any
     ): StripePaymentRequestButtonElement;
+    once(
+      eventType: 'click',
+      handler: (event: StripePaymentRequestButtonElementClickEvent) => any
+    ): StripePaymentRequestButtonElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
      */
     on(
+      eventType: 'ready',
+      handler: () => any
+    ): StripePaymentRequestButtonElement;
+    once(
       eventType: 'ready',
       handler: () => any
     ): StripePaymentRequestButtonElement;
@@ -25,11 +33,19 @@ declare module '@stripe/stripe-js' {
       eventType: 'focus',
       handler: () => any
     ): StripePaymentRequestButtonElement;
+    once(
+      eventType: 'focus',
+      handler: () => any
+    ): StripePaymentRequestButtonElement;
 
     /**
      * Triggered when the element loses focus.
      */
     on(
+      eventType: 'blur',
+      handler: () => any
+    ): StripePaymentRequestButtonElement;
+    once(
       eventType: 'blur',
       handler: () => any
     ): StripePaymentRequestButtonElement;

--- a/types/stripe-js/elements/payment-request-button.d.ts
+++ b/types/stripe-js/elements/payment-request-button.d.ts
@@ -13,6 +13,10 @@ declare module '@stripe/stripe-js' {
       eventType: 'click',
       handler: (event: StripePaymentRequestButtonElementClickEvent) => any
     ): StripePaymentRequestButtonElement;
+    off(
+      eventType: 'click',
+      handler?: (event: StripePaymentRequestButtonElementClickEvent) => any
+    ): StripePaymentRequestButtonElement;
 
     /**
      * Triggered when the element is fully rendered and can accept `element.focus` calls.
@@ -24,6 +28,10 @@ declare module '@stripe/stripe-js' {
     once(
       eventType: 'ready',
       handler: () => any
+    ): StripePaymentRequestButtonElement;
+    off(
+      eventType: 'ready',
+      handler?: () => any
     ): StripePaymentRequestButtonElement;
 
     /**
@@ -37,6 +45,10 @@ declare module '@stripe/stripe-js' {
       eventType: 'focus',
       handler: () => any
     ): StripePaymentRequestButtonElement;
+    off(
+      eventType: 'focus',
+      handler?: () => any
+    ): StripePaymentRequestButtonElement;
 
     /**
      * Triggered when the element loses focus.
@@ -48,6 +60,10 @@ declare module '@stripe/stripe-js' {
     once(
       eventType: 'blur',
       handler: () => any
+    ): StripePaymentRequestButtonElement;
+    off(
+      eventType: 'blur',
+      handler?: () => any
     ): StripePaymentRequestButtonElement;
 
     /**

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -34,6 +34,10 @@ declare module '@stripe/stripe-js' {
       eventType: 'token',
       handler: (event: PaymentRequestTokenEvent) => any
     ): this;
+    off(
+      eventType: 'token',
+      handler?: (event: PaymentRequestTokenEvent) => any
+    ): this;
 
     /**
      * Stripe.js automatically creates a `PaymentMethod` after the customer is done interacting with the browser’s payment interface.
@@ -46,6 +50,10 @@ declare module '@stripe/stripe-js' {
     once(
       eventType: 'paymentmethod',
       handler: (event: PaymentRequestPaymentMethodEvent) => any
+    ): this;
+    off(
+      eventType: 'paymentmethod',
+      handler?: (event: PaymentRequestPaymentMethodEvent) => any
     ): this;
 
     /**
@@ -60,6 +68,10 @@ declare module '@stripe/stripe-js' {
       eventType: 'source',
       handler: (event: PaymentRequestSourceEvent) => any
     ): this;
+    off(
+      eventType: 'source',
+      handler?: (event: PaymentRequestSourceEvent) => any
+    ): this;
 
     /**
      * The cancel event is emitted from a `PaymentRequest` when the browser's payment interface is dismissed.
@@ -70,6 +82,7 @@ declare module '@stripe/stripe-js' {
      */
     on(eventType: 'cancel', handler: () => any): this;
     once(eventType: 'cancel', handler: () => any): this;
+    off(eventType: 'cancel', handler?: () => any): this;
 
     /**
      * The `shippingaddresschange` event is emitted from a `PaymentRequest` whenever the customer selects a new address in the browser's payment interface.
@@ -82,6 +95,10 @@ declare module '@stripe/stripe-js' {
       eventType: 'shippingaddresschange',
       handler: (event: PaymentRequestShippingAddressEvent) => any
     ): this;
+    off(
+      eventType: 'shippingaddresschange',
+      handler?: (event: PaymentRequestShippingAddressEvent) => any
+    ): this;
 
     /**
      * The `shippingoptionchange` event is emitted from a `PaymentRequest` whenever the customer selects a new shipping option in the browser's payment interface.
@@ -93,6 +110,10 @@ declare module '@stripe/stripe-js' {
     once(
       eventType: 'shippingoptionchange',
       handler: (event: PaymentRequestShippingOptionEvent) => any
+    ): this;
+    off(
+      eventType: 'shippingoptionchange',
+      handler?: (event: PaymentRequestShippingOptionEvent) => any
     ): this;
   }
 

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -30,12 +30,20 @@ declare module '@stripe/stripe-js' {
       eventType: 'token',
       handler: (event: PaymentRequestTokenEvent) => any
     ): this;
+    once(
+      eventType: 'token',
+      handler: (event: PaymentRequestTokenEvent) => any
+    ): this;
 
     /**
      * Stripe.js automatically creates a `PaymentMethod` after the customer is done interacting with the browser’s payment interface.
      * To access the created `PaymentMethod`, listen for this event.
      */
     on(
+      eventType: 'paymentmethod',
+      handler: (event: PaymentRequestPaymentMethodEvent) => any
+    ): this;
+    once(
       eventType: 'paymentmethod',
       handler: (event: PaymentRequestPaymentMethodEvent) => any
     ): this;
@@ -48,6 +56,10 @@ declare module '@stripe/stripe-js' {
       eventType: 'source',
       handler: (event: PaymentRequestSourceEvent) => any
     ): this;
+    once(
+      eventType: 'source',
+      handler: (event: PaymentRequestSourceEvent) => any
+    ): this;
 
     /**
      * The cancel event is emitted from a `PaymentRequest` when the browser's payment interface is dismissed.
@@ -57,6 +69,7 @@ declare module '@stripe/stripe-js' {
      * If you’re using the cancel event as a hook for canceling the customer’s order, make sure you also refund the payment that you just created.
      */
     on(eventType: 'cancel', handler: () => any): this;
+    once(eventType: 'cancel', handler: () => any): this;
 
     /**
      * The `shippingaddresschange` event is emitted from a `PaymentRequest` whenever the customer selects a new address in the browser's payment interface.
@@ -65,11 +78,19 @@ declare module '@stripe/stripe-js' {
       eventType: 'shippingaddresschange',
       handler: (event: PaymentRequestShippingAddressEvent) => any
     ): this;
+    once(
+      eventType: 'shippingaddresschange',
+      handler: (event: PaymentRequestShippingAddressEvent) => any
+    ): this;
 
     /**
      * The `shippingoptionchange` event is emitted from a `PaymentRequest` whenever the customer selects a new shipping option in the browser's payment interface.
      */
     on(
+      eventType: 'shippingoptionchange',
+      handler: (event: PaymentRequestShippingOptionEvent) => any
+    ): this;
+    once(
       eventType: 'shippingoptionchange',
       handler: (event: PaymentRequestShippingOptionEvent) => any
     ): this;


### PR DESCRIPTION
### Summary & motivation

Event emitters have `once` and `off` methods that are currently not in our type definitions.

### Testing & documentation

Added type test.