### PR TITLE
Update error message if Stripe.js loaded but isn't on window

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const stripePromise: Promise<StripeConstructor | null> = Promise.resolve().then(
         if (window.Stripe) {
           resolve(window.Stripe);
         } else {
-          reject(new Error('Failed to load Stripe.js'));
+          reject(new Error('Stripe.js not available'));
         }
       });
 


### PR DESCRIPTION
### Summary & motivation

Differentiate load error messages to help determine cause of error.

Related to #26 