### PR TITLE
feat(types): add shippingAddressCollection to redirectToCheckout

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -245,6 +245,9 @@ stripe
     items: [{sku: 'sku_123', quantity: 1}],
     successUrl: 'https://your-website.com/success',
     cancelUrl: 'https://your-website.com/canceled',
+    shippingAddressCollection: {
+      allowedCountries: ['EN'],
+    },
   })
   .then((result) => {
     console.error(result.error.message);

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -60,6 +60,18 @@ declare module '@stripe/stripe-js' {
     billingAddressCollection?: 'auto' | 'required';
 
     /**
+     * Provides configuration for Checkout to collect a shipping address from a customer.
+     */
+    shippingAddressCollection?: {
+      /**
+       * An array of two-letter ISO country codes representing which countries
+       * Checkout should provide as options for shipping locations. The codes are
+       * expected to be uppercase. Unsupported country codes: AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI.
+       */
+      allowedCountries: string[];
+    };
+
+    /**
      * The [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the locale to display Checkout in.
      * Default is `auto` (Stripe detects the locale of the browser).
      */


### PR DESCRIPTION
### Summary & motivation

The PR adds the [`shippingAddressCollection`](https://stripe.com/docs/js/checkout/redirect_to_checkout#stripe_checkout_redirect_to_checkout-options-shippingAddressCollection) field to `RedirectToCheckoutClientOptions`.

### Testing & documentation

The test file for the types has been updated to use the new option.
