### PR TITLE
Do not cause unhandled rejections on load errors

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -85,67 +85,59 @@ describe('Stripe module loader', () => {
   });
 
   describe('loadStripe', () => {
-    let consoleWarnSpy: jest.SpyInstance;
-
     beforeEach(() => {
-      consoleWarnSpy = jest.spyOn(console, 'warn');
+      jest.spyOn(console, 'warn').mockReturnValue();
     });
 
-    it('resolves loadStripe with Stripe object', () => {
+    it('resolves loadStripe with Stripe object', async () => {
       const {loadStripe} = require('./index');
       const stripePromise = loadStripe('pk_test_foo');
 
-      return new Promise((resolve) => setTimeout(resolve)).then(() => {
-        window.Stripe = jest.fn((key) => ({key})) as any;
-        dispatchScriptEvent('load');
+      await new Promise((resolve) => setTimeout(resolve));
+      window.Stripe = jest.fn((key) => ({key})) as any;
+      dispatchScriptEvent('load');
 
-        return expect(stripePromise).resolves.toEqual({key: 'pk_test_foo'});
-      });
+      return expect(stripePromise).resolves.toEqual({key: 'pk_test_foo'});
     });
 
-    it('rejects when the script fails', () => {
+    it('rejects when the script fails', async () => {
       const {loadStripe} = require('./index');
       const stripePromise = loadStripe('pk_test_foo');
 
-      return Promise.resolve().then(async () => {
-        dispatchScriptEvent('error');
+      await Promise.resolve();
+      dispatchScriptEvent('error');
 
-        await expect(stripePromise).rejects.toEqual(
-          new Error('Failed to load Stripe.js')
-        );
-        expect(console.warn).not.toHaveBeenCalled();
-      });
+      await expect(stripePromise).rejects.toEqual(
+        new Error('Failed to load Stripe.js')
+      );
+
+      expect(console.warn).not.toHaveBeenCalled();
     });
 
-    it('does not cause unhandled rejects when the script fails', () => {
-      const consoleWarnCalled = new Promise((resolve) => {
-        consoleWarnSpy.mockImplementation(resolve);
-      });
-
+    it('does not cause unhandled rejects when the script fails', async () => {
       require('./index');
 
-      return Promise.resolve().then(async () => {
-        dispatchScriptEvent('error');
+      await Promise.resolve();
+      dispatchScriptEvent('error');
 
-        expect(await consoleWarnCalled).toEqual(
-          new Error('Failed to load Stripe.js')
-        );
+      // Turn the task loop to make sure the internal promise handler has been invoked
+      await new Promise((resolve) => setImmediate(resolve));
 
-        // Turn the task loop to make sure jest's unhandled promise rejection handler didn't trigger
-        return new Promise((resolve) => setImmediate(resolve));
-      });
+      expect(console.warn).toHaveBeenCalledWith(
+        new Error('Failed to load Stripe.js')
+      );
     });
 
-    it('rejects when Stripe is not added to the window for some reason', () => {
+    it('rejects when Stripe is not added to the window for some reason', async () => {
       const {loadStripe} = require('./index');
       const stripePromise = loadStripe('pk_test_foo');
-      return Promise.resolve().then(() => {
-        dispatchScriptEvent('load');
 
-        return expect(stripePromise).rejects.toEqual(
-          new Error('Stripe.js not available')
-        );
-      });
+      await Promise.resolve();
+      dispatchScriptEvent('load');
+
+      return expect(stripePromise).rejects.toEqual(
+        new Error('Stripe.js not available')
+      );
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,9 +56,18 @@ const stripePromise: Promise<StripeConstructor | null> = Promise.resolve().then(
   }
 );
 
+let loadCalled = false;
+
+stripePromise.catch((err) => {
+  if (!loadCalled) console.warn(err);
+});
+
 export const loadStripe = (
   ...args: Parameters<StripeConstructor>
-): Promise<StripeInstance | null> =>
-  stripePromise.then((maybeStripe) =>
+): Promise<StripeInstance | null> => {
+  loadCalled = true;
+
+  return stripePromise.then((maybeStripe) =>
     maybeStripe ? maybeStripe(...args) : null
   );
+};


### PR DESCRIPTION
### Summary & motivation

Prevent unhandled rejections caused by load errors.
Warn instead on load errors if `loadStripe` wasn't called.

Related to #26 

### Testing & documentation

Added unit tests.