### PR TITLE
Add latest and beta to tested TS versions

### DIFF
--- a/tests/versions/scripts/test.sh
+++ b/tests/versions/scripts/test.sh
@@ -10,6 +10,9 @@ yarn init -sy
 
 versions=(
   "next"
+  "beta"
+  "latest"
+  "3.8.3"
   "3.7.4"
   "3.6.3"
   "3.5.1"


### PR DESCRIPTION

### Summary & motivation

Always test on latest and beta versions
Test on TypeScript 3.8

Avoid skipping versions.


