### PR TITLE
Fix rollup example package name

### DIFF
--- a/examples/rollup/package.json
+++ b/examples/rollup/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "parcel",
+  "name": "rollup",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
### Summary & motivation

Fixed a minor typo in the rollup example's `package.json` name field.
