### PR TITLE
Fix webpack example HTML title

### DIFF
--- a/examples/webpack/src/index.html
+++ b/examples/webpack/src/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Stripe.js Module - Parcel</title>
+    <title>Stripe.js Module - Webpack</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
### Summary & motivation

Fixed a small typo in the HTML `title` for the webpack example.
