### PR TITLE
Fix rollup example HTML title 

### DIFF
--- a/examples/rollup/public/index.html
+++ b/examples/rollup/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <link rel="stylesheet" href="./styles.css" />
-    <title>Stripe.js Module - Parcel</title>
+    <title>Stripe.js Module - Rollup</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
### Summary & motivation

Fixed a small typo in the HTML title for the `rollup` example.