### PR TITLE
Fixed the type on the height option in a PaymentRequestButton

### DIFF
--- a/types/stripe-js/elements/payment-request-button.d.ts
+++ b/types/stripe-js/elements/payment-request-button.d.ts
@@ -63,7 +63,7 @@ declare module '@stripe/stripe-js' {
         /**
          * The height of the Payment Request Button.
          */
-        height?: number;
+        height?: string;
       };
     };
 


### PR DESCRIPTION
### Summary & motivation

The type is incorrect for the Height option on the request button. A number does nothing. It appears this is a string (similar to the previous react-stripe-elements).

### Testing & documentation
I validated the type change.
