### PR TITLE
Add alternative side-effect free import path

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -26,3 +26,4 @@ rules:
   jest/no-focused-tests: 2
   '@typescript-eslint/no-explicit-any': 0
   '@typescript-eslint/no-empty-interface': 0
+  '@typescript-eslint/triple-slash-reference': 0

--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ one. When you call `loadStripe`, it will use the existing script tag.
 <script src="https://js.stripe.com/v3" async></script>
 ```
 
+### Importing `loadStripe` without side effects
+
+If you would like to use `loadStripe` in your application, but defer loading the
+Stripe.js script until `loadStripe` is first called, use the alternative
+`@stripe/stripe-js/pure` import path:
+
+```
+import {loadStripe} from '@stripe/stripe-js/pure';
+
+// Stripe.js will not be loaded until `loadStripe` is called
+```
+
 ## Stripe.js Documentation
 
 - [Stripe.js Docs](https://stripe.com/docs/stripe-js)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "files": [
     "dist",
     "src",
-    "types"
+    "types",
+    "pure.js",
+    "pure.d.ts"
   ],
   "devDependencies": {
     "@babel/core": "^7.7.2",

--- a/pure.d.ts
+++ b/pure.d.ts
@@ -1,0 +1,3 @@
+///<reference path='./types/index.d.ts' />
+
+export const loadStripe: typeof import('@stripe/stripe-js').loadStripe;

--- a/pure.js
+++ b/pure.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/pure.js');

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,20 @@
 import babel from 'rollup-plugin-babel';
-import pkg from './package.json';
 import ts from 'rollup-plugin-typescript2';
 import replace from '@rollup/plugin-replace';
-import {version} from './package.json';
+
+import pkg from './package.json';
+
+const PLUGINS = [
+  ts({
+    tsconfigOverride: {exclude: ['**/*.test.ts']},
+  }),
+  babel({
+    extensions: ['.ts', '.js', '.tsx', '.jsx'],
+  }),
+  replace({
+    _VERSION: JSON.stringify(pkg.version),
+  }),
+];
 
 export default [
   {
@@ -11,16 +23,11 @@ export default [
       {file: pkg.main, format: 'cjs'},
       {file: pkg.module, format: 'es'},
     ],
-    plugins: [
-      ts({
-        tsconfigOverride: {exclude: ['**/*.test.ts']},
-      }),
-      babel({
-        extensions: ['.ts', '.js', '.tsx', '.jsx'],
-      }),
-      replace({
-        _VERSION: JSON.stringify(version),
-      }),
-    ],
+    plugins: PLUGINS,
+  },
+  {
+    input: 'src/pure.ts',
+    output: [{file: 'dist/pure.js', format: 'cjs'}],
+    plugins: PLUGINS,
   },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,9 @@
 import {Stripe as StripeInstance, StripeConstructor} from '@stripe/stripe-js';
 import {loadScript, initStripe} from './shared';
 
-const stripePromise = loadScript();
+// Execute our own script injection after a tick to give users time to do their
+// own script injection.
+const stripePromise = Promise.resolve().then(loadScript);
 
 let loadCalled = false;
 

--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const SCRIPT_SELECTOR =
+  'script[src="https://js.stripe.com/v3"], script[src="https://js.stripe.com/v3/"]';
+
+describe('pure module', () => {
+  afterEach(() => {
+    const script = document.querySelector(SCRIPT_SELECTOR);
+
+    if (script && script.parentElement) {
+      script.parentElement.removeChild(script);
+    }
+  });
+
+  test('does not inject the script if loadStripe is not called', async () => {
+    require('./pure');
+    await Promise.resolve();
+
+    expect(document.querySelector(SCRIPT_SELECTOR)).toBe(null);
+  });
+
+  test('it injects the script if loadStripe is called', async () => {
+    const {loadStripe} = require('./pure');
+    loadStripe('pk_test_foo');
+    await Promise.resolve();
+
+    expect(document.querySelector(SCRIPT_SELECTOR)).not.toBe(null);
+  });
+});

--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -6,15 +6,16 @@ const SCRIPT_SELECTOR =
 describe('pure module', () => {
   afterEach(() => {
     const script = document.querySelector(SCRIPT_SELECTOR);
-
     if (script && script.parentElement) {
       script.parentElement.removeChild(script);
     }
+
+    delete window.Stripe;
+    jest.resetModules();
   });
 
   test('does not inject the script if loadStripe is not called', async () => {
     require('./pure');
-    await Promise.resolve();
 
     expect(document.querySelector(SCRIPT_SELECTOR)).toBe(null);
   });
@@ -22,7 +23,6 @@ describe('pure module', () => {
   test('it injects the script if loadStripe is called', async () => {
     const {loadStripe} = require('./pure');
     loadStripe('pk_test_foo');
-    await Promise.resolve();
 
     expect(document.querySelector(SCRIPT_SELECTOR)).not.toBe(null);
   });

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -2,16 +2,7 @@
 import {Stripe as StripeInstance, StripeConstructor} from '@stripe/stripe-js';
 import {loadScript, initStripe} from './shared';
 
-let stripePromise: Promise<StripeConstructor | null> | null = null;
-
 export const loadStripe = (
   ...args: Parameters<StripeConstructor>
-): Promise<StripeInstance | null> => {
-  // Ensure we only attempt to load Stripe.js once, no matter how many times
-  // `loadStripe` is called
-  if (!stripePromise) {
-    stripePromise = loadScript();
-  }
-
-  return stripePromise.then((maybeStripe) => initStripe(maybeStripe, args));
-};
+): Promise<StripeInstance | null> =>
+  loadScript().then((maybeStripe) => initStripe(maybeStripe, args));

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -2,20 +2,16 @@
 import {Stripe as StripeInstance, StripeConstructor} from '@stripe/stripe-js';
 import {loadScript, initStripe} from './shared';
 
-const stripePromise = loadScript();
-
-let loadCalled = false;
-
-stripePromise.catch((err) => {
-  if (!loadCalled) {
-    console.warn(err);
-  }
-});
+let stripePromise: Promise<StripeConstructor | null> | null = null;
 
 export const loadStripe = (
   ...args: Parameters<StripeConstructor>
 ): Promise<StripeInstance | null> => {
-  loadCalled = true;
+  // Ensure we only attempt to load Stripe.js once, no matter how many times
+  // `loadStripe` is called
+  if (!stripePromise) {
+    stripePromise = loadScript();
+  }
 
   return stripePromise.then((maybeStripe) => initStripe(maybeStripe, args));
 };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,84 @@
+import {Stripe, StripeConstructor} from '@stripe/stripe-js';
+
+// `_VERSION` will be rewritten by `@rollup/plugin-replace` as a string literal
+// containing the package.json version
+declare const _VERSION: string;
+
+const V3_URL = 'https://js.stripe.com/v3';
+
+const injectScript = (): HTMLScriptElement => {
+  const script = document.createElement('script');
+  script.src = V3_URL;
+
+  const headOrBody = document.head || document.body;
+
+  if (!headOrBody) {
+    throw new Error(
+      'Expected document.body not to be null. Stripe.js requires a <body> element.'
+    );
+  }
+
+  headOrBody.appendChild(script);
+
+  return script;
+};
+
+const registerWrapper = (stripe: any): void => {
+  if (!stripe || !stripe._registerWrapper) {
+    return;
+  }
+
+  stripe._registerWrapper({name: 'stripe-js', version: _VERSION});
+};
+
+export const loadScript = (): Promise<StripeConstructor | null> => {
+  // Execute our own script injection after a tick to give users time to
+  // do their own script injection.
+  const stripePromise: Promise<StripeConstructor | null> = Promise.resolve().then(
+    () => {
+      if (typeof window === 'undefined') {
+        // Resolve to null when imported server side. This makes the module
+        // safe to import in an isomorphic code base.
+        return null;
+      }
+
+      if (window.Stripe) {
+        return window.Stripe;
+      }
+
+      const script: HTMLScriptElement =
+        document.querySelector(
+          `script[src="${V3_URL}"], script[src="${V3_URL}/"]`
+        ) || injectScript();
+
+      return new Promise((resolve, reject) => {
+        script.addEventListener('load', () => {
+          if (window.Stripe) {
+            resolve(window.Stripe);
+          } else {
+            reject(new Error('Stripe.js not available'));
+          }
+        });
+
+        script.addEventListener('error', () => {
+          reject(new Error('Failed to load Stripe.js'));
+        });
+      });
+    }
+  );
+
+  return stripePromise;
+};
+
+export const initStripe = (
+  maybeStripe: StripeConstructor | null,
+  args: Parameters<StripeConstructor>
+): Stripe | null => {
+  if (maybeStripe === null) {
+    return null;
+  }
+
+  const stripe = maybeStripe(...args);
+  registerWrapper(stripe);
+  return stripe;
+};


### PR DESCRIPTION
### Summary & motivation

Adds an alternative path for importing `loadStripe`, which delays loading the Stripe.js script until `loadStripe` is called:

```
import {loadStripe} from '@stripe/stripe-js/pure';
```

### Testing & documentation

- Added 2 tests for the side-effect in `pure.test.ts`
- Configured the `loadStripe` tests to run against both the default module and pure module
- Added section to README documenting the import path
- Tested manually with a create-react-app app
