### PR TITLE
Add publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "yarn clean && yarn rollup -c",
     "clean": "rimraf dist",
     "ci": "yarn lint && yarn test && yarn test:versions && yarn test:types && yarn typecheck && yarn build",
-    "prepublishOnly": "yarn ci",
+    "prepublishOnly": "echo \"\nPlease use ./scripts/publish instead\n\" && exit 1",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
     "prettier-list-different": "prettier './**/*.{js,ts,md,html,css}' --list-different"
   },

--- a/scripts/publish
+++ b/scripts/publish
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+RELEASE_TYPE=${1:-}
+
+echo_help() {
+  cat << EOF
+USAGE:
+    ./scripts/publish <release_type>
+
+ARGS:
+    <release_type>
+            A Semantic Versioning release type used to bump the version number. Either "patch", "minor", or "major".
+EOF
+}
+
+# Show help if no arguments passed
+if [ $# -eq 0 ]; then
+  echo "Error! Missing release type argument"
+  echo ""
+  echo_help
+  exit 1
+fi
+
+# Show help message if -h, --help, or help passed
+if [ $1 = "-h" ] || [ $1 = "--help" ] || [ $1 = help ]; then
+  echo_help
+  exit 0
+fi
+
+# Validate passed release type
+if ! echo $RELEASE_TYPE | grep -q 'patch\|minor\|major'; then
+  echo "Error! Invalid release type supplied"
+  echo ""
+  echo_help
+  exit 1
+fi
+
+# Make sure our working dir is the repo root directory
+cd "$(git rev-parse --show-toplevel)"
+
+echo "Fetching git remotes"
+git fetch
+
+if ! git status | grep -q 'On branch master'; then
+  echo "Error! Must be on master branch to publish"
+  exit 1
+fi
+
+if ! git status | grep -q "Your branch is up to date with 'origin/master'."; then
+  echo "Error! Must be up to date with origin/master to publish"
+  exit 1
+fi
+
+if ! git status | grep -q 'working tree clean'; then
+  echo "Error! Cannot publish with dirty working tree"
+  exit 1
+fi
+
+echo "Installing dependencies according to lockfile"
+yarn -s install --frozen-lockfile
+
+echo "Linting, testing, and building"
+yarn -s run ci
+
+echo "Tagging and publishing $RELEASE_TYPE release"
+yarn -s --ignore-scripts publish --$RELEASE_TYPE --access=public
+
+echo "Pushing git commit and tag"
+git push --follow-tags
+
+cat << EOF
+Publish successful!
+
+Remember to create a release on GitHub with a changelog notes:
+
+    https://github.com/stripe/stripe-js/releases/new
+
+EOF

--- a/scripts/publish
+++ b/scripts/publish
@@ -16,6 +16,60 @@ ARGS:
 EOF
 }
 
+create_github_release() {
+  if which hub | grep -q "not found"; then
+    create_github_release_fallback
+    return
+  fi
+
+  # Get the last two releases. For example, `("v1.3.1" "v1.3.2")`
+  local versions=($(git tag --sort version:refname | grep '^v' | tail -n 2))
+
+  # If we didn't find exactly two previous version versions, give up
+  if [ ${#versions[@]} -ne 2 ]; then
+    create_github_release_fallback
+    return
+  fi
+
+  local previous_version="${versions[0]}"
+  local current_version="${versions[1]}"
+  local commit_titles=$(git log --pretty=format:"- %s" "$previous_version".."$current_version"^)
+  local release_notes="$(cat << EOF
+$current_version
+
+<!-- Please group the following commits into one of the sections below. -->
+<!-- Remove empty sections when done. -->
+
+$commit_titles
+
+### New features
+
+### Fixes
+
+### Changed
+
+EOF
+)"
+
+  local release_url=$(hub release create -em "$release_notes" "$current_version")
+
+  cat << EOF
+Created GitHub release:
+
+    $release_url
+EOF
+
+}
+
+create_github_release_fallback() {
+  cat << EOF
+Remember to create a release on GitHub with a changelog notes:
+
+    https://github.com/stripe/stripe-js/releases/new
+
+EOF
+}
+
 # Show help if no arguments passed
 if [ $# -eq 0 ]; then
   echo "Error! Missing release type argument"
@@ -25,18 +79,25 @@ if [ $# -eq 0 ]; then
 fi
 
 # Show help message if -h, --help, or help passed
-if [ $1 = "-h" ] || [ $1 = "--help" ] || [ $1 = help ]; then
-  echo_help
-  exit 0
-fi
+case $1 in
+  -h | --help | help)
+    echo_help
+    exit 0
+    ;;
+esac
 
 # Validate passed release type
-if ! echo $RELEASE_TYPE | grep -q 'patch\|minor\|major'; then
-  echo "Error! Invalid release type supplied"
-  echo ""
-  echo_help
-  exit 1
-fi
+case $RELEASE_TYPE in
+  patch | minor | major)
+    ;;
+
+  *)
+    echo "Error! Invalid release type supplied"
+    echo ""
+    echo_help
+    exit 1
+    ;;
+esac
 
 # Make sure our working dir is the repo root directory
 cd "$(git rev-parse --show-toplevel)"
@@ -44,17 +105,19 @@ cd "$(git rev-parse --show-toplevel)"
 echo "Fetching git remotes"
 git fetch
 
-if ! git status | grep -q 'On branch master'; then
+GIT_STATUS=$(git status)
+
+if ! grep -q 'On branch master' <<< "$GIT_STATUS"; then
   echo "Error! Must be on master branch to publish"
   exit 1
 fi
 
-if ! git status | grep -q "Your branch is up to date with 'origin/master'."; then
+if ! grep -q "Your branch is up to date with 'origin/master'." <<< "$GIT_STATUS"; then
   echo "Error! Must be up to date with origin/master to publish"
   exit 1
 fi
 
-if ! git status | grep -q 'working tree clean'; then
+if ! grep -q 'working tree clean' <<< "$GIT_STATUS"; then
   echo "Error! Cannot publish with dirty working tree"
   exit 1
 fi
@@ -71,11 +134,7 @@ yarn -s --ignore-scripts publish --$RELEASE_TYPE --access=public
 echo "Pushing git commit and tag"
 git push --follow-tags
 
-cat << EOF
-Publish successful!
+echo "Publish successful!"
+echo ""
 
-Remember to create a release on GitHub with a changelog notes:
-
-    https://github.com/stripe/stripe-js/releases/new
-
-EOF
+create_github_release


### PR DESCRIPTION
Adds a bash script for publishing a new release to npm. This should make publishing a new version safer by automating a few commands:

- Ensure we are on `master` branch and up to date with `origin/master`
- Ensure working dir is clean
- Ensure deps are installed same as last test run in CI / according to lockfile
- Tags are pushed to GitHub

It will also print a reminder after publishing to create a new release on GitHub.

I would also like to add this script to the stripe/stripe-react-js repo.
