### PR TITLE
Tweak ordering of publish script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js: 'lts/*'
 cache: yarn
 script:
   - yarn run ci
+  - yarn run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: node_js
 node_js: 'lts/*'
 cache: yarn
 script:
-  - yarn run ci
+  - yarn run test
   - yarn run build

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc",
     "build": "yarn clean && yarn rollup -c",
     "clean": "rimraf dist",
-    "ci": "yarn lint && yarn test && yarn test:versions && yarn test:types && yarn typecheck && yarn build",
+    "ci": "yarn lint && yarn test && yarn test:versions && yarn test:types && yarn typecheck",
     "prepublishOnly": "echo \"\nPlease use ./scripts/publish instead\n\" && exit 1",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
     "prettier-list-different": "prettier './**/*.{js,ts,md,html,css}' --list-different"

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   "jsnext:main": "dist/stripe.esm.js",
   "types": "types/index.d.ts",
   "scripts": {
-    "test": "jest",
+    "test": "yarn lint && yarn test:unit && yarn test:versions && yarn test:types && yarn typecheck",
+    "test:unit": "jest",
     "test:versions": "./tests/versions/scripts/test.sh",
     "test:types": "tsc -p ./tests/types && jest --roots '<rootDir>/tests/types'",
     "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-list-different",
     "typecheck": "tsc",
     "build": "yarn clean && yarn rollup -c",
     "clean": "rimraf dist",
-    "ci": "yarn lint && yarn test && yarn test:versions && yarn test:types && yarn typecheck",
     "prepublishOnly": "echo \"\nPlease use ./scripts/publish instead\n\" && exit 1",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
     "prettier-list-different": "prettier './**/*.{js,ts,md,html,css}' --list-different"

--- a/scripts/publish
+++ b/scripts/publish
@@ -121,11 +121,17 @@ fi
 echo "Installing dependencies according to lockfile"
 yarn -s install --frozen-lockfile
 
-echo "Linting, testing, and building"
+echo "Running tests"
 yarn -s run ci
 
-echo "Tagging and publishing $RELEASE_TYPE release"
-yarn -s --ignore-scripts publish --$RELEASE_TYPE --access=public
+echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
+yarn -s version --$RELEASE_TYPE
+
+echo "Building"
+yarn -s run build
+
+echo "Publishing release"
+yarn -s --ignore-scripts publish --non-interactive --access=public
 
 echo "Pushing git commit and tag"
 git push --follow-tags

--- a/scripts/publish
+++ b/scripts/publish
@@ -122,7 +122,7 @@ echo "Installing dependencies according to lockfile"
 yarn -s install --frozen-lockfile
 
 echo "Running tests"
-yarn -s run ci
+yarn -s run test
 
 echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
 yarn -s version --$RELEASE_TYPE


### PR DESCRIPTION
Fixes #51 

Ensures that the `package.json` version is bumped before the package is built, so that the correct version is embedded in the build.

I'll make a similar change to react-stripe-js.