### PR TITLE
Add setLoadParameters API

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ declarations. These changes will not affect Stripe.js itself.
 ## Ensuring Stripe.js is available everywhere
 
 To best leverage Stripe’s advanced fraud functionality, ensure that Stripe.js is
-loaded on every page, not just your checkout page. This allows Stripe to detect
-anomalous behavior that may be indicative of fraud as customers browse your
-website.
+loaded on every page, not just your checkout page. This
+[allows Stripe to detect suspicious behavior](/docs/disputes/prevention/advanced-fraud-detection)
+that may be indicative of fraud as customers browse your website.
 
 By default, this module will insert a `<script>` tag that loads Stripe.js from
 `https://js.stripe.com`. This happens as a side effect immediately upon
@@ -105,7 +105,24 @@ Stripe.js script until `loadStripe` is first called, use the alternative
 import {loadStripe} from '@stripe/stripe-js/pure';
 
 // Stripe.js will not be loaded until `loadStripe` is called
+const stripe = await loadStripe('pk_test_TYooMQauvdEDq54NiTphI7jx');
 ```
+
+### Disabling advanced fraud detection signals
+
+If you would like to
+[disable advanced fraud detection](https://stripe.com/docs/disputes/prevention/advanced-fraud-detection#disabling-advanced-fraud-detection)
+altogether, use `loadStripe.setLoadParameters`:
+
+```
+import {loadStripe} from '@stripe/stripe-js/pure';
+
+loadStripe.setLoadParameters({advancedFraudSignals: false})
+const stripe = await loadStripe('pk_test_TYooMQauvdEDq54NiTphI7jx');
+```
+
+The `loadStripe.setLoadParameters` function is only available when importing
+`loadStripe` from `@stripe/stripe-js/pure`.
 
 ## Stripe.js Documentation
 

--- a/pure.d.ts
+++ b/pure.d.ts
@@ -1,3 +1,5 @@
 ///<reference path='./types/index.d.ts' />
 
-export const loadStripe: typeof import('@stripe/stripe-js').loadStripe;
+export const loadStripe: typeof import('@stripe/stripe-js').loadStripe & {
+  setLoadParameters: (params: {advancedFraudSignals: boolean}) => void;
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -82,6 +82,30 @@ describe('Stripe module loader', () => {
         ).toHaveLength(1);
       });
     });
+
+    test('ignores non-Stripe.js scripts that start with the v3 url', async () => {
+      const script = document.createElement('script');
+      script.src = 'https://js.stripe.com/v3/futureBundle.js';
+      document.body.appendChild(script);
+
+      require('./index');
+
+      await Promise.resolve();
+
+      expect(
+        document.querySelectorAll('script[src^="https://js.stripe.com/v3"]')
+      ).toHaveLength(2);
+
+      expect(
+        document.querySelector(
+          'script[src="https://js.stripe.com/v3/futureBundle.js"]'
+        )
+      ).not.toBe(null);
+
+      expect(
+        document.querySelector('script[src="https://js.stripe.com/v3"]')
+      ).not.toBe(null);
+    });
   });
 
   describe.each(['./index', './pure'])('loadStripe (%s.ts)', (requirePath) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,18 @@
-///<reference path='../types/index.d.ts' />
-import {Stripe as StripeInstance, StripeConstructor} from '@stripe/stripe-js';
-import {loadScript, initStripe} from './shared';
+import {loadScript, initStripe, LoadStripe} from './shared';
 
 // Execute our own script injection after a tick to give users time to do their
 // own script injection.
-const stripePromise = Promise.resolve().then(loadScript);
+const stripePromise = Promise.resolve().then(() => loadScript(null));
 
 let loadCalled = false;
 
-stripePromise.catch((err) => {
+stripePromise.catch((err: Error) => {
   if (!loadCalled) {
     console.warn(err);
   }
 });
 
-export const loadStripe = (
-  ...args: Parameters<StripeConstructor>
-): Promise<StripeInstance | null> => {
+export const loadStripe: LoadStripe = (...args) => {
   loadCalled = true;
 
   return stripePromise.then((maybeStripe) => initStripe(maybeStripe, args));

--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -1,17 +1,25 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const SCRIPT_SELECTOR =
-  'script[src="https://js.stripe.com/v3"], script[src="https://js.stripe.com/v3/"]';
+const SCRIPT_SELECTOR = 'script[src^="https://js.stripe.com/v3"]';
 
 describe('pure module', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockReturnValue();
+  });
+
   afterEach(() => {
-    const script = document.querySelector(SCRIPT_SELECTOR);
-    if (script && script.parentElement) {
-      script.parentElement.removeChild(script);
+    const scripts = Array.from(document.querySelectorAll(SCRIPT_SELECTOR));
+
+    for (const script of scripts) {
+      if (script.parentElement) {
+        script.parentElement.removeChild(script);
+      }
     }
 
     delete window.Stripe;
+
     jest.resetModules();
+    jest.restoreAllMocks();
   });
 
   test('does not inject the script if loadStripe is not called', async () => {
@@ -25,5 +33,101 @@ describe('pure module', () => {
     loadStripe('pk_test_foo');
 
     expect(document.querySelector(SCRIPT_SELECTOR)).not.toBe(null);
+  });
+
+  test('it can load the script with advanced fraud signals disabled', () => {
+    const {loadStripe} = require('./pure');
+
+    loadStripe.setLoadParameters({advancedFraudSignals: false});
+    loadStripe('pk_test_foo');
+
+    expect(
+      document.querySelector(
+        'script[src^="https://js.stripe.com/v3?advancedFraudSignals=false"]'
+      )
+    ).not.toBe(null);
+  });
+
+  test('it should throw when setting invalid load parameters', () => {
+    const {loadStripe} = require('./pure');
+
+    expect(() => {
+      loadStripe.setLoadParameters({howdy: true});
+    }).toThrow('invalid load parameters');
+  });
+
+  test('it should warn when calling loadStripe if a script already exists when parameters are set', () => {
+    const script = document.createElement('script');
+    script.src = 'https://js.stripe.com/v3';
+    document.body.appendChild(script);
+
+    const {loadStripe} = require('./pure');
+    loadStripe.setLoadParameters({advancedFraudSignals: true});
+    loadStripe('pk_test_123');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenLastCalledWith(
+      'loadStripe.setLoadParameters was called but an existing Stripe.js script already exists in the document; existing script parameters will be used'
+    );
+  });
+
+  test('it should warn when calling loadStripe if a script is added after parameters are set', () => {
+    const {loadStripe} = require('./pure');
+    loadStripe.setLoadParameters({advancedFraudSignals: true});
+
+    const script = document.createElement('script');
+    script.src = 'https://js.stripe.com/v3';
+    document.body.appendChild(script);
+
+    loadStripe('pk_test_123');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenLastCalledWith(
+      'loadStripe.setLoadParameters was called but an existing Stripe.js script already exists in the document; existing script parameters will be used'
+    );
+  });
+
+  test('it should warn when window.Stripe already exists if parameters are set', () => {
+    window.Stripe = jest.fn((key) => ({key})) as any;
+
+    const {loadStripe} = require('./pure');
+    loadStripe.setLoadParameters({advancedFraudSignals: true});
+    loadStripe('pk_test_123');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenLastCalledWith(
+      'loadStripe.setLoadParameters was called but an existing Stripe.js script already exists in the document; existing script parameters will be used'
+    );
+  });
+
+  test('it should not warn when a script already exists if parameters are not set', () => {
+    const script = document.createElement('script');
+    script.src = 'https://js.stripe.com/v3';
+    document.body.appendChild(script);
+
+    const {loadStripe} = require('./pure');
+    loadStripe('pk_test_123');
+
+    expect(console.warn).toHaveBeenCalledTimes(0);
+  });
+
+  test('it should not warn when window.Stripe already exists if parameters are not set', () => {
+    window.Stripe = jest.fn((key) => ({key})) as any;
+
+    const {loadStripe} = require('./pure');
+    loadStripe('pk_test_123');
+
+    expect(console.warn).toHaveBeenCalledTimes(0);
+  });
+
+  test('throws an error if calling setLoadParameters after loadStripe', () => {
+    const {loadStripe} = require('./pure');
+
+    loadStripe.setLoadParameters({advancedFraudSignals: false});
+    loadStripe('pk_foo');
+
+    expect(() => {
+      loadStripe.setLoadParameters({advancedFraudSignals: false});
+    }).toThrow('cannot change load parameters');
   });
 });

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,8 +1,32 @@
-///<reference path='../types/index.d.ts' />
-import {Stripe as StripeInstance, StripeConstructor} from '@stripe/stripe-js';
-import {loadScript, initStripe} from './shared';
+import {
+  validateLoadParams,
+  loadScript,
+  initStripe,
+  LoadStripe,
+  LoadParams,
+} from './shared';
 
-export const loadStripe = (
-  ...args: Parameters<StripeConstructor>
-): Promise<StripeInstance | null> =>
-  loadScript().then((maybeStripe) => initStripe(maybeStripe, args));
+type SetLoadParams = (params: LoadParams) => void;
+
+let loadParams: null | LoadParams;
+let loadStripeCalled = false;
+
+export const loadStripe: LoadStripe & {setLoadParameters: SetLoadParams} = (
+  ...args
+) => {
+  loadStripeCalled = true;
+
+  return loadScript(loadParams).then((maybeStripe) =>
+    initStripe(maybeStripe, args)
+  );
+};
+
+loadStripe.setLoadParameters = (params): void => {
+  if (loadStripeCalled) {
+    throw new Error(
+      'You cannot change load parameters after calling loadStripe'
+    );
+  }
+
+  loadParams = validateLoadParams(params);
+};

--- a/src/shared.test.ts
+++ b/src/shared.test.ts
@@ -1,0 +1,65 @@
+import {validateLoadParams, findScript} from './shared';
+
+describe('validateLoadParams', () => {
+  const INVALID_INPUTS: any[] = [
+    [undefined],
+    [false],
+    [null],
+    [true],
+    [{}],
+    [8],
+    [{advancedFraud: true}],
+    [{advancedFraudSignals: true, someOtherKey: true}],
+    [{advancedFraudSignals: 'true'}],
+  ];
+
+  test.each(INVALID_INPUTS)('throws on invalid input: %p', (input) => {
+    expect(() => validateLoadParams(input)).toThrow('invalid load parameters');
+  });
+
+  test('validates valid input', () => {
+    expect(validateLoadParams({advancedFraudSignals: true})).toEqual({
+      advancedFraudSignals: true,
+    });
+
+    expect(validateLoadParams({advancedFraudSignals: false})).toEqual({
+      advancedFraudSignals: false,
+    });
+  });
+});
+
+describe('findScript', () => {
+  const CASES: Array<[string, boolean]> = [
+    ['https://js.stripe.com/v3?advancedFraudSignals=true', true],
+    ['https://js.stripe.com/v3', true],
+    ['https://js.stripe.com/v3/', true],
+    ['https://js.stripe.com/v3?advancedFraudSignals=false', true],
+    ['https://js.stripe.com/v3?ab=cd', true],
+    ['https://js.stripe.com/v3/something.js', false],
+    ['https://js.stripe.com/v3/something.js?advancedFraudSignals=false', false],
+    ['https://js.stripe.com/v3/something.js?ab=cd', false],
+  ];
+
+  afterEach(() => {
+    for (const [url] of CASES) {
+      const script = document.querySelector(`script[src="${url}"]`);
+
+      if (script && script.parentElement) {
+        script.parentElement.removeChild(script);
+      }
+    }
+
+    delete window.Stripe;
+  });
+
+  test.each(CASES)(
+    'findScript with <script src="%s"></script>',
+    (url, shouldBeFound) => {
+      const script = document.createElement('script');
+      script.src = url;
+      document.body.appendChild(script);
+
+      expect(!!findScript()).toBe(shouldBeFound);
+    }
+  );
+});


### PR DESCRIPTION
Adds the `loadStripe.setLoadParameters` function to the pure module, which enables injecting a script via `loadStripe` with supported query parameters.