### PR TITLE
Add TS types for Bancontact/giropay/P24/EPS

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -411,6 +411,17 @@ stripe.confirmFpxPayment('', {payment_method: {fpx: {bank: ''}}});
 
 stripe.confirmFpxPayment('');
 
+stripe.confirmGiropayPayment('', {
+  payment_method: {billing_details: {name: 'Jenny Rosen'}},
+  return_url: window.location.href,
+});
+
+stripe.confirmGiropayPayment('', {payment_method: ''});
+
+stripe.confirmGiropayPayment('', {payment_method: ''}, {handleActions: false});
+
+stripe.confirmGiropayPayment('');
+
 stripe.confirmIdealPayment('', {
   payment_method: {ideal: idealBankElement},
   return_url: window.location.href,

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -356,6 +356,21 @@ stripe.confirmAuBecsDebitPayment('', {payment_method: ''});
 
 stripe.confirmAuBecsDebitPayment('');
 
+stripe.confirmBancontactPayment('', {
+  payment_method: {billing_details: {name: 'Jenny Rosen'}},
+  return_url: window.location.href,
+});
+
+stripe.confirmBancontactPayment('', {payment_method: ''});
+
+stripe.confirmBancontactPayment(
+  '',
+  {payment_method: ''},
+  {handleActions: false}
+);
+
+stripe.confirmBancontactPayment('');
+
 stripe
   .confirmCardPayment('', {
     payment_method: {card: cardElement, billing_details: {name: ''}},

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -387,6 +387,17 @@ stripe.confirmCardPayment('');
 
 stripe.confirmCardPayment('');
 
+stripe.confirmEpsPayment('', {
+  payment_method: {billing_details: {name: 'Jenny Rosen'}},
+  return_url: window.location.href,
+});
+
+stripe.confirmEpsPayment('', {payment_method: ''});
+
+stripe.confirmEpsPayment('', {payment_method: ''}, {handleActions: false});
+
+stripe.confirmEpsPayment('');
+
 stripe.confirmFpxPayment('', {
   payment_method: {fpx: fpxBankElement},
   return_url: window.location.href,

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -435,6 +435,17 @@ stripe.confirmIdealPayment('', {payment_method: {ideal: {bank: ''}}});
 
 stripe.confirmIdealPayment('');
 
+stripe.confirmP24Payment('', {
+  payment_method: {billing_details: {email: 'jenny@example.com'}},
+  return_url: window.location.href,
+});
+
+stripe.confirmP24Payment('', {payment_method: ''});
+
+stripe.confirmP24Payment('', {payment_method: ''}, {handleActions: false});
+
+stripe.confirmP24Payment('');
+
 stripe.confirmSepaDebitPayment('', {
   payment_method: {
     sepa_debit: ibanElement,

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -130,6 +130,23 @@ declare module '@stripe/stripe-js' {
     ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
 
     /**
+     * Use `stripe.confirmGiropayPayment` in the [giropay Payments with Payment Methods](https://stripe.com/docs/payments/giropay#web) flow when the customer submits your payment form.
+     * When called, it will confirm the `PaymentIntent` with `data` you provide, and it will automatically redirect the customer to the authorize the transaction.
+     * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_giropay_payment
+     */
+    confirmGiropayPayment(
+      clientSecret: string,
+      data?: ConfirmGiropayPaymentData,
+      options?: ConfirmGiropayPaymentOptions
+    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+
+    /**
      * Use `stripe.confirmIdealPayment` in the [iDEAL Payments with Payment Methods](https://stripe.com/docs/payments/ideal) flow when the customer submits your payment form.
      * When called, it will confirm the `PaymentIntent` with `data` you provide, and it will automatically redirect the customer to the authorize the transaction.
      * Once authorization is complete, the customer will be redirected back to your specified `return_url`.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -164,6 +164,23 @@ declare module '@stripe/stripe-js' {
     ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
 
     /**
+     * Use `stripe.confirmP24Payment` in the [Przelewy24 Payments with Payment Methods](https://stripe.com/docs/payments/p24#web) flow when the customer submits your payment form.
+     * When called, it will confirm the `PaymentIntent` with `data` you provide, and it will automatically redirect the customer to the authorize the transaction.
+     * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_p24_payment
+     */
+    confirmP24Payment(
+      clientSecret: string,
+      data?: ConfirmP24PaymentData,
+      options?: ConfirmP24PaymentOptions
+    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+
+    /**
      * Use `stripe.confirmSepaDebitPayment` in the [SEPA Direct Debit Payments](https://stripe.com/docs/payments/sepa-debit) with Payment Methods flow when the customer submits your payment form.
      * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide.
      * Note that there are some additional requirements to this flow that are not covered in this reference.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -96,6 +96,23 @@ declare module '@stripe/stripe-js' {
     ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
 
     /**
+     * Use `stripe.confirmEpsPayment` in the [EPS Payments with Payment Methods](https://stripe.com/docs/payments/eps#web) flow when the customer submits your payment form.
+     * When called, it will confirm the `PaymentIntent` with `data` you provide, and it will automatically redirect the customer to the authorize the transaction.
+     * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_eps_payment
+     */
+    confirmEpsPayment(
+      clientSecret: string,
+      data?: ConfirmEpsPaymentData,
+      options?: ConfirmEpsPaymentOptions
+    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+
+    /**
      * Use `stripe.confirmFpxPayment` in the [FPX Payments with Payment Methods](https://stripe.com/docs/payments/fpx#web) flow when the customer submits your payment form.
      * When called, it will confirm the `PaymentIntent` with `data` you provide, and it will automatically redirect the customer to the authorize the transaction.
      * Once authorization is complete, the customer will be redirected back to your specified `return_url`.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -61,6 +61,23 @@ declare module '@stripe/stripe-js' {
     ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
 
     /**
+     * Use `stripe.confirmBancontactPayment` in the [Bancontact Payments with Payment Methods](https://stripe.com/docs/payments/bancontact#web) flow when the customer submits your payment form.
+     * When called, it will confirm the `PaymentIntent` with `data` you provide, and it will automatically redirect the customer to the authorize the transaction.
+     * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_bancontact_payment
+     */
+    confirmBancontactPayment(
+      clientSecret: string,
+      data?: ConfirmBancontactPaymentData,
+      options?: ConfirmBancontactPaymentOptions
+    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+
+    /**
      * Use `stripe.confirmCardPayment` when the customer submits your payment form.
      * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide and carry out 3DS or other next actions if they are required.
      *

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -9,6 +9,7 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodEpsData
     | CreatePaymentMethodGiropayData
     | CreatePaymentMethodIdealData
+    | CreatePaymentMethodP24Data
     | CreatePaymentMethodFpxData
     | CreatePaymentMethodSepaDebitData;
 
@@ -85,6 +86,20 @@ declare module '@stripe/stripe-js' {
            */
           bank?: string;
         };
+  }
+
+  interface CreatePaymentMethodP24Data extends PaymentMethodCreateParams {
+    type: 'p24';
+
+    /*
+     * The customer's billing details.
+     * `email` is required.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details: PaymentMethodCreateParams.BillingDetails & {
+      email: string;
+    };
   }
 
   interface CreatePaymentMethodSepaDebitData extends PaymentMethodCreateParams {
@@ -349,6 +364,38 @@ declare module '@stripe/stripe-js' {
   interface ConfirmIdealPaymentOptions {
     /*
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/ideal#handle-redirect).
+     * Default is `true`.
+     */
+    handleActions?: boolean;
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmP24Payment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmP24PaymentData extends PaymentIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodP24Data, 'type'>;
+
+    /**
+     * The url your customer will be directed to after they complete authentication.
+     *
+     * @recommended
+     */
+    return_url?: string;
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmP24Payment`.
+   */
+  interface ConfirmP24PaymentOptions {
+    /*
+     * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/p24#handle-redirect).
      * Default is `true`.
      */
     handleActions?: boolean;

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -6,6 +6,7 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodAuBecsDebitData
     | CreatePaymentMethodBancontactData
     | CreatePaymentMethodCardData
+    | CreatePaymentMethodEpsData
     | CreatePaymentMethodIdealData
     | CreatePaymentMethodFpxData
     | CreatePaymentMethodSepaDebitData;
@@ -29,6 +30,20 @@ declare module '@stripe/stripe-js' {
     type: 'card';
 
     card: StripeCardElement | StripeCardNumberElement | {token: string};
+  }
+
+  interface CreatePaymentMethodEpsData extends PaymentMethodCreateParams {
+    type: 'eps';
+
+    /*
+     * The customer's billing details.
+     * `name` is required.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details: PaymentMethodCreateParams.BillingDetails & {
+      name: string;
+    };
   }
 
   interface CreatePaymentMethodFpxData extends PaymentMethodCreateParams {
@@ -171,6 +186,38 @@ declare module '@stripe/stripe-js' {
   interface ConfirmCardPaymentOptions {
     /*
      * Set this to `false` if you want to [handle next actions yourself](https://stripe.com/docs/payments/payment-intents/verifying-status#next-actions), or if you want to defer next action handling until later (e.g. for use in the [PaymentRequest API](https://stripe.com/docs/stripe-js/elements/payment-request-button#complete-payment-intents)).
+     * Default is `true`.
+     */
+    handleActions?: boolean;
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmEpsPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmEpsPaymentData extends PaymentIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodEpsData, 'type'>;
+
+    /**
+     * The url your customer will be directed to after they complete authentication.
+     *
+     * @recommended
+     */
+    return_url?: string;
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmEpsPayment`.
+   */
+  interface ConfirmEpsPaymentOptions {
+    /*
+     * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/eps#handle-redirect).
      * Default is `true`.
      */
     handleActions?: boolean;

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -7,6 +7,7 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodBancontactData
     | CreatePaymentMethodCardData
     | CreatePaymentMethodEpsData
+    | CreatePaymentMethodGiropayData
     | CreatePaymentMethodIdealData
     | CreatePaymentMethodFpxData
     | CreatePaymentMethodSepaDebitData;
@@ -57,6 +58,20 @@ declare module '@stripe/stripe-js' {
            */
           bank: string;
         };
+  }
+
+  interface CreatePaymentMethodGiropayData extends PaymentMethodCreateParams {
+    type: 'giropay';
+
+    /*
+     * The customer's billing details.
+     * `name` is required.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details: PaymentMethodCreateParams.BillingDetails & {
+      name: string;
+    };
   }
 
   interface CreatePaymentMethodIdealData extends PaymentMethodCreateParams {
@@ -270,6 +285,38 @@ declare module '@stripe/stripe-js' {
   interface ConfirmFpxPaymentOptions {
     /*
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/fpx#handle-redirect).
+     * Default is `true`.
+     */
+    handleActions?: boolean;
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmGiropayPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmGiropayPaymentData extends PaymentIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodGiropayData, 'type'>;
+
+    /**
+     * The url your customer will be directed to after they complete authentication.
+     *
+     * @recommended
+     */
+    return_url?: string;
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmGiropayPayment`.
+   */
+  interface ConfirmGiropayPaymentOptions {
+    /*
+     * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/giropay#handle-redirect).
      * Default is `true`.
      */
     handleActions?: boolean;

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -4,10 +4,26 @@ declare module '@stripe/stripe-js' {
 
   type CreatePaymentMethodData =
     | CreatePaymentMethodAuBecsDebitData
+    | CreatePaymentMethodBancontactData
     | CreatePaymentMethodCardData
     | CreatePaymentMethodIdealData
     | CreatePaymentMethodFpxData
     | CreatePaymentMethodSepaDebitData;
+
+  interface CreatePaymentMethodBancontactData
+    extends PaymentMethodCreateParams {
+    type: 'bancontact';
+
+    /*
+     * The customer's billing details.
+     * `name` is required.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details: PaymentMethodCreateParams.BillingDetails & {
+      name: string;
+    };
+  }
 
   interface CreatePaymentMethodCardData extends PaymentMethodCreateParams {
     type: 'card';
@@ -101,6 +117,38 @@ declare module '@stripe/stripe-js' {
       name: string;
       email: string;
     };
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmBancontactPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmBancontactPaymentData extends PaymentIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodBancontactData, 'type'>;
+
+    /**
+     * The url your customer will be directed to after they complete authentication.
+     *
+     * @recommended
+     */
+    return_url?: string;
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmBancontactPayment`.
+   */
+  interface ConfirmBancontactPaymentOptions {
+    /*
+     * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/bancontact#handle-redirect).
+     * Default is `true`.
+     */
+    handleActions?: boolean;
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

This adds TS types for the following methods:

https://stripe.com/docs/js/payment_intents/confirm_bancontact_payment
https://stripe.com/docs/js/payment_intents/confirm_eps_payment
https://stripe.com/docs/js/payment_intents/confirm_giropay_payment
https://stripe.com/docs/js/payment_intents/confirm_p24_payment

These methods are ungated as of yesterday.

I was mainly following the example of FPX here.

### Testing & documentation

Type tests added.
