### PR TITLE
Add confirmBacsDebitSetup TS types

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -547,6 +547,24 @@ stripe.confirmAuBecsDebitSetup('', {
   },
 });
 
+stripe.confirmBacsDebitSetup('', {payment_method: ''});
+
+stripe.confirmBacsDebitSetup('', {
+  payment_method: {
+    bacs_debit: {sort_code: '', account_number: ''},
+    billing_details: {
+      name: '',
+      email: '',
+      address: {
+        line1: '',
+        city: '',
+        country: '',
+        postal_code: '',
+      },
+    },
+  },
+});
+
 stripe.confirmCardSetup('', {
   payment_method: {card: cardElement, billing_details: {name: ''}},
 });

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -260,12 +260,12 @@ declare module '@stripe/stripe-js' {
     ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
 
     /**
-     * Use `stripe.confirmBacsDebitSetup` in the [Bacs Direct Debit Payments](/docs/payments/payment-methods/bacs-debit) flow when the customer submits your payment form.
-     * When called, it will confirm the [SetupIntent](/docs/api/setup_intents) with `data` you provide.
+     * Use `stripe.confirmBacsDebitSetup` in the [Bacs Direct Debit Payments](https://stripe.com/docs/payments/payment-methods/bacs-debit) flow when the customer submits your payment form.
+     * When called, it will confirm the [SetupIntent](https://stripe.com/docs/api/setup_intents) with `data` you provide.
      * Note that there are some additional requirements to this flow that are not covered in this reference.
-     * Refer to our [integration guide](/docs/payments/payment-methods/bacs-debit) for more details.
+     * Refer to our [integration guide](https://stripe.com/docs/payments/payment-methods/bacs-debit) for more details.
      *
-     * When you confirm a `SetupIntent`, it needs to have an attached [PaymentMethod](/docs/api/payment_methods).
+     * When you confirm a `SetupIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
      * In addition to confirming the `SetupIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
      * It can also be called with an existing `PaymentMethod`, or if you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
      * These use cases are detailed in the sections that follow.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -260,6 +260,24 @@ declare module '@stripe/stripe-js' {
     ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
 
     /**
+     * Use `stripe.confirmBacsDebitSetup` in the [Bacs Direct Debit Payments](/docs/payments/payment-methods/bacs-debit) flow when the customer submits your payment form.
+     * When called, it will confirm the [SetupIntent](/docs/api/setup_intents) with `data` you provide.
+     * Note that there are some additional requirements to this flow that are not covered in this reference.
+     * Refer to our [integration guide](/docs/payments/payment-methods/bacs-debit) for more details.
+     *
+     * When you confirm a `SetupIntent`, it needs to have an attached [PaymentMethod](/docs/api/payment_methods).
+     * In addition to confirming the `SetupIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * It can also be called with an existing `PaymentMethod`, or if you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     * These use cases are detailed in the sections that follow.
+     *
+     * @docs https://stripe.com/docs/js/setup_intents/confirm_bacs_debit_setup
+     */
+    confirmBacsDebitSetup(
+      clientSecret: string,
+      data?: ConfirmBacsDebitSetupData
+    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+
+    /**
      * Use `stripe.confirmCardSetup` in the [Setup Intents API flow](https://stripe.com/docs/payments/save-and-reuse) when the customer submits your payment form.
      * When called, it will confirm the [SetupIntent](https://stripe.com/docs/api/setup_intents) with `data` you provide and carry out 3DS or other next actions if they are required.
      *

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -164,6 +164,39 @@ declare module '@stripe/stripe-js' {
     };
   }
 
+  interface CreatePaymentMethodBacsDebitData extends PaymentMethodCreateParams {
+    type: 'bacs_debit';
+
+    bacs_debit: {
+      /**
+       * A sort code.
+       */
+      sort_code: string;
+
+      /**
+       * An account number.
+       */
+      account_number: string;
+    };
+
+    /*
+     * The customer's billing details.
+     * `name`, `email`, and `address` are required.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details: PaymentMethodCreateParams.BillingDetails & {
+      name: string;
+      email: string;
+      address: PaymentMethodCreateParams.BillingDetails.Address & {
+        line1: string;
+        city: string;
+        country: string;
+        postal_code: string;
+      };
+    };
+  }
+
   /**
    * Data to be sent with a `stripe.confirmBancontactPayment` request.
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -51,4 +51,18 @@ declare module '@stripe/stripe-js' {
      */
     payment_method?: string | Omit<CreatePaymentMethodAuBecsDebitData, 'type'>;
   }
+
+  /**
+   * Data to be sent with a `stripe.confirmBacsDebitSetup` request.
+   * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmBacsDebitSetupData extends SetupIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `SetupIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodBacsDebitData, 'type'>;
+  }
 }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

This adds TypeScript types for [stripe.confirmBacsDebitSetup](https://stripe.com/docs/js/setup_intents/confirm_bacs_debit_setup).

Bacs is GA now 🎉 

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

This is a Types change only. Type tests added.
