### PR TITLE
Add extra check

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -26,7 +26,7 @@ export const findScript = (): HTMLScriptElement | null => {
   for (let i = 0; i < scripts.length; i++) {
     const script = scripts[i];
 
-    if (!V3_URL_REGEX.test(script.src)) {
+    if (script instanceof HTMLScriptElement && !V3_URL_REGEX.test(script.src)) {
       continue;
     }
 


### PR DESCRIPTION
Looking at the ts this would not seem necessary,

but it turns out that, when using @stripe/stripe-js with snowpack and including its type declarations as a compiler option, the above changed line throws a ts error.

This is because snowpack strips all types and produces js, and if tsc is run to checkJs this is the error it picks, even given the types in @stripe/stripe-js/types

The above change means no error for using @stripe/stripe-js with snowpack when using tsc to checkJs

There are probably other solutions to this, and even tho this check does not change the logic of the above code, it looks like it could be pretty weird to include it.

Would it be an undesirable change?

### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
