### PR TITLE
Update link to PCI compliance guide in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Use [Stripe.js](https://stripe.com/docs/stripe-js) as an ES module.
 
 **Note**: To be
-[PCI compliant](https://stripe.com/docs/security#validating-pci-compliance), you
+[PCI compliant](https://stripe.com/docs/security/guide#validating-pci-compliance), you
 must load Stripe.js directly from `https://js.stripe.com`. You cannot include it
 in a bundle or host it yourself. This package wraps the global `Stripe` function
 provided by the Stripe.js script as an ES module.


### PR DESCRIPTION
### Summary & motivation

Updated a slightly broken link in the README to the PCI compliance section of the security guide. 