### PR TITLE
Add `startTime` to measure `loadStripe` call timing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ stripePromise.catch((err: Error) => {
 
 export const loadStripe: LoadStripe = (...args) => {
   loadCalled = true;
+  const startTime = Date.now();
 
-  return stripePromise.then((maybeStripe) => initStripe(maybeStripe, args));
+  return stripePromise.then((maybeStripe) =>
+    initStripe(maybeStripe, args, startTime)
+  );
 };

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -15,9 +15,10 @@ export const loadStripe: LoadStripe & {setLoadParameters: SetLoadParams} = (
   ...args
 ) => {
   loadStripeCalled = true;
+  const startTime = Date.now();
 
   return loadScript(loadParams).then((maybeStripe) =>
-    initStripe(maybeStripe, args)
+    initStripe(maybeStripe, args, startTime)
   );
 };
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -55,12 +55,12 @@ const injectScript = (params: null | LoadParams): HTMLScriptElement => {
   return script;
 };
 
-const registerWrapper = (stripe: any): void => {
+const registerWrapper = (stripe: any, startTime: number): void => {
   if (!stripe || !stripe._registerWrapper) {
     return;
   }
 
-  stripe._registerWrapper({name: 'stripe-js', version: _VERSION});
+  stripe._registerWrapper({name: 'stripe-js', version: _VERSION, startTime});
 };
 
 let stripePromise: Promise<StripeConstructor | null> | null = null;
@@ -121,14 +121,15 @@ export const loadScript = (
 
 export const initStripe = (
   maybeStripe: StripeConstructor | null,
-  args: Parameters<StripeConstructor>
+  args: Parameters<StripeConstructor>,
+  startTime: number
 ): Stripe | null => {
   if (maybeStripe === null) {
     return null;
   }
 
   const stripe = maybeStripe.apply(undefined, args);
-  registerWrapper(stripe);
+  registerWrapper(stripe, startTime);
   return stripe;
 };
 


### PR DESCRIPTION
### Summary & motivation

Register the time it took for `loadStripe()` to create the Stripe instance, including script load if applicable.
