### PR TITLE
Reorganize locale types

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -98,40 +98,7 @@ declare module '@stripe/stripe-js' {
      * The [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the locale to display Checkout in.
      * Default is `auto` (Stripe detects the locale of the browser).
      */
-    locale?:
-      | 'auto'
-      | 'bg'
-      | 'cs'
-      | 'da'
-      | 'de'
-      | 'el'
-      | 'en'
-      | 'es'
-      | 'es-419'
-      | 'et'
-      | 'fi'
-      | 'fr'
-      | 'hu'
-      | 'it'
-      | 'ja'
-      | 'lt'
-      | 'lv'
-      | 'ms'
-      | 'mt'
-      | 'nb'
-      | 'nl'
-      | 'pl'
-      | 'pt'
-      | 'pt-BR'
-      | 'ro'
-      | 'ru'
-      | 'sk'
-      | 'sl'
-      | 'sv'
-      | 'tr'
-      | 'zh'
-      | 'zh-HK'
-      | 'zh-TW';
+    locale?: CheckoutLocale;
 
     /**
      * Describes the type of transaction being performed by Checkout in order to customize relevant text on the page, such as the **Submit** button.
@@ -144,4 +111,42 @@ declare module '@stripe/stripe-js' {
   type RedirectToCheckoutOptions =
     | RedirectToCheckoutServerOptions
     | RedirectToCheckoutClientOptions;
+
+  type CheckoutLocale =
+    | 'auto'
+    | 'bg'
+    | 'cs'
+    | 'da'
+    | 'de'
+    | 'el'
+    | 'en'
+    | 'en-GB'
+    | 'es'
+    | 'es-419'
+    | 'et'
+    | 'fi'
+    | 'fr'
+    | 'fr-CA'
+    | 'hu'
+    | 'id'
+    | 'it'
+    | 'ja'
+    | 'lt'
+    | 'lv'
+    | 'ms'
+    | 'mt'
+    | 'nb'
+    | 'nl'
+    | 'pl'
+    | 'pt'
+    | 'pt-BR'
+    | 'ro'
+    | 'ru'
+    | 'sk'
+    | 'sl'
+    | 'sv'
+    | 'tr'
+    | 'zh'
+    | 'zh-HK'
+    | 'zh-TW';
 }

--- a/types/stripe-js/elements.d.ts
+++ b/types/stripe-js/elements.d.ts
@@ -198,6 +198,39 @@ declare module '@stripe/stripe-js' {
     | StripeIdealBankElement
     | StripePaymentRequestButtonElement;
 
+  type StripeElementLocale =
+    | 'auto'
+    | 'ar'
+    | 'bg'
+    | 'cs'
+    | 'da'
+    | 'de'
+    | 'el'
+    | 'en'
+    | 'es'
+    | 'es-419'
+    | 'et'
+    | 'fi'
+    | 'fr'
+    | 'he'
+    | 'id'
+    | 'it'
+    | 'ja'
+    | 'lt'
+    | 'lv'
+    | 'ms'
+    | 'nb'
+    | 'nl'
+    | 'no'
+    | 'pl'
+    | 'pt'
+    | 'pt-BR'
+    | 'ru'
+    | 'sk'
+    | 'sl'
+    | 'sv'
+    | 'zh';
+
   /**
    * Options to create an `Elements` instance with.
    */
@@ -212,38 +245,7 @@ declare module '@stripe/stripe-js' {
      * Default is `auto` (Stripe detects the locale of the browser).
      * Setting the locale does not affect the behavior of postal code validation—a valid postal code for the billing country of the card is still required.
      */
-    locale?:
-      | 'auto'
-      | 'ar'
-      | 'bg'
-      | 'cs'
-      | 'da'
-      | 'de'
-      | 'el'
-      | 'en'
-      | 'es'
-      | 'es-419'
-      | 'et'
-      | 'fi'
-      | 'fr'
-      | 'he'
-      | 'id'
-      | 'it'
-      | 'ja'
-      | 'lt'
-      | 'lv'
-      | 'ms'
-      | 'nb'
-      | 'nl'
-      | 'no'
-      | 'pl'
-      | 'pt'
-      | 'pt-BR'
-      | 'ru'
-      | 'sk'
-      | 'sl'
-      | 'sv'
-      | 'zh';
+    locale?: StripeElementLocale;
   }
 
   /*

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -484,40 +484,7 @@ declare module '@stripe/stripe-js' {
      * Checkout supports a slightly different set of locales than the rest of Stripe.js.
      * If you are planning on using Checkout, make sure to use a [value](#checkout_redirect_to_checkout-options-locale) that it supports.
      */
-    locale?:
-      | 'auto'
-      | 'ar'
-      | 'bg'
-      | 'cs'
-      | 'da'
-      | 'de'
-      | 'el'
-      | 'en'
-      | 'es'
-      | 'es-419'
-      | 'et'
-      | 'fi'
-      | 'fr'
-      | 'he'
-      | 'id'
-      | 'it'
-      | 'ja'
-      | 'lt'
-      | 'lv'
-      | 'ms'
-      | 'nb'
-      | 'nl'
-      | 'no'
-      | 'pl'
-      | 'pt'
-      | 'pt-BR'
-      | 'ru'
-      | 'sk'
-      | 'sl'
-      | 'sv'
-      | 'zh'
-      | 'zh-HK'
-      | 'zh-TW';
+    locale?: StripeElementLocale | CheckoutLocale;
   }
 
   type StripeErrorType =


### PR DESCRIPTION
Introduces a `StripeElementsLocale` and `CheckoutLocale` type. This should make maintenance a bit easier, as we don't have to duplicate adding locales across the `Stripe` / `stripe.redirectToCheckout` / `stripe.elements` param types.

I also found that the `en-GB`, `fr-CA`, and `id` locales were missing for Checkout, so I added them.