### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,5 @@ The `loadStripe.setLoadParameters` function is only available when importing
 ## Stripe.js Documentation
 
 - [Stripe.js Docs](https://stripe.com/docs/stripe-js)
-- [Stripe.js Reference](https://stripe.com/docs/api)
+- [Stripe.js Reference](https://stripe.com/docs/js)
 - [React Stripe.js Docs](https://stripe.com/docs/stripe-js/react)


### PR DESCRIPTION
Minor fix to point the "Stripe.js Reference" link to the correct page

### Summary & motivation

Just wanted to make sure the link goes to the right place!

### Testing & documentation

Minor edit to README, no testing required.
