### PR TITLE
Relax need for account holder name when tokenizing bank account

### DIFF
--- a/types/stripe-js/token-and-sources.d.ts
+++ b/types/stripe-js/token-and-sources.d.ts
@@ -77,7 +77,7 @@ declare module '@stripe/stripe-js' {
 
     account_number: string;
 
-    account_holder_name: string;
+    account_holder_name?: string;
 
     account_holder_type: string;
   }


### PR DESCRIPTION
### Summary & motivation

The Stripe API does not require an account holder name when tokenizing bank account details. Currently the account_holder_name field is required when using stripe-js. This field is not required when using the iOS and Android SDKs. This change relaxes the account_holder_name field requirement.

Stripe API reference:
https://stripe.com/docs/api/external_account_bank_accounts/create#account_create_bank_account-external_account-account_holder_name
