### PR TITLE
Fix blur and focus types

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -34,6 +34,7 @@ import {
   StripeAuBankAccountElementChangeEvent,
   StripePaymentRequestButtonElement,
   StripeElementType,
+  StripeCardElementEvent,
 } from '@stripe/stripe-js';
 
 const stripePromise: Promise<Stripe | null> = loadStripe('');
@@ -206,8 +207,12 @@ ibanElement.mount('#bogus-container');
 
 cardElement
   .on('ready', () => {})
-  .on('focus', () => {})
-  .on('blur', () => {})
+  .on('focus', (e: StripeCardElementEvent) => {
+    e.elementType === cardElementType
+  })
+  .on('blur', (e: StripeCardElementEvent) => {
+    e.elementType === cardElementType
+  })
   .on('change', (e: StripeCardElementChangeEvent) => {
     if (e.error) {
       console.error(e.error.message);

--- a/types/stripe-js/elements/au-bank-account.d.ts
+++ b/types/stripe-js/elements/au-bank-account.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeAuBankAccountElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeAuBankAccountElementEvent) => any
+    ): StripeAuBankAccountElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeAuBankAccountElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeAuBankAccountElementEvent) => any
+    ): StripeAuBankAccountElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -63,13 +69,9 @@ declare module '@stripe/stripe-js' {
     disabled?: boolean;
   }
 
+  type StripeAuBankAccountElementEvent = StripeElementEvent<'auBankAccount'>;
   interface StripeAuBankAccountElementChangeEvent
-    extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'auBankAccount';
-
+    extends StripeElementChangeEvent<'auBankAccount'> {
     /**
      * The bank name corresponding to the entered BSB.
      */

--- a/types/stripe-js/elements/base.d.ts
+++ b/types/stripe-js/elements/base.d.ts
@@ -1,3 +1,5 @@
+import { StripeElementType } from "@stripe/stripe-js";
+
 declare module '@stripe/stripe-js' {
   type StripeElementBase = {
     /**
@@ -228,12 +230,16 @@ declare module '@stripe/stripe-js' {
     webkitAutoFill?: string;
   }
 
-  interface StripeElementChangeEvent {
+  interface StripeElementEvent<ElementType extends StripeElementType> {
     /**
      * The type of element that emitted this event.
      */
-    elementType: StripeElementType;
+    elementType: ElementType;
+  }
 
+  interface StripeElementChangeEvent<
+    ElementType extends StripeElementType = StripeElementType
+  > extends StripeElementEvent<ElementType> {
     /**
      * `true` if the value is empty.
      */

--- a/types/stripe-js/elements/card-cvc.d.ts
+++ b/types/stripe-js/elements/card-cvc.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeCardCvcElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeCardCvcElementEvent) => any
+    ): StripeCardCvcElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeCardCvcElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeCardCvcElementEvent) => any
+    ): StripeCardCvcElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -54,10 +60,6 @@ declare module '@stripe/stripe-js' {
     disabled?: boolean;
   }
 
-  interface StripeCardCvcElementChangeEvent extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'cardCvc';
-  }
+  type StripeCardCvcElementEvent = StripeElementEvent<'cardCvc'>;
+  type StripeCardCvcElementChangeEvent = StripeElementChangeEvent<'cardCvc'>;
 }

--- a/types/stripe-js/elements/card-expiry.d.ts
+++ b/types/stripe-js/elements/card-expiry.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeCardExpiryElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeCardExpiryElementEvent) => any
+    ): StripeCardExpiryElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeCardExpiryElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeCardExpiryElementEvent) => any
+    ): StripeCardExpiryElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -54,11 +60,6 @@ declare module '@stripe/stripe-js' {
     disabled?: boolean;
   }
 
-  interface StripeCardExpiryElementChangeEvent
-    extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'cardExpiry';
-  }
+  type StripeCardExpiryElementEvent = StripeElementEvent<'cardExpiry'>;
+  type StripeCardExpiryElementChangeEvent = StripeElementChangeEvent<'cardExpiry'>;
 }

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeCardNumberElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeCardNumberElementEvent) => any
+    ): StripeCardNumberElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeCardNumberElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeCardNumberElementEvent) => any
+    ): StripeCardNumberElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -65,13 +71,9 @@ declare module '@stripe/stripe-js' {
     iconStyle?: 'default' | 'solid';
   }
 
+  type StripeCardNumberElementEvent = StripeElementChangeEvent<'cardNumber'>;
   interface StripeCardNumberElementChangeEvent
-    extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'cardNumber';
-
+    extends StripeElementChangeEvent<'cardNumber'> {
     /*
      * The card brand of the card number being entered.
      */

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeCardElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeCardElementEvent) => any
+    ): StripeCardElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeCardElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeCardElementEvent) => any
+    ): StripeCardElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -76,12 +82,8 @@ declare module '@stripe/stripe-js' {
     disabled?: boolean;
   }
 
-  interface StripeCardElementChangeEvent extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'card';
-
+  type StripeCardElementEvent = StripeElementEvent<'card'>;
+  interface StripeCardElementChangeEvent extends StripeElementChangeEvent<'card'> {
     /**
      * An object containing the currently entered `postalCode`.
      */

--- a/types/stripe-js/elements/fpx-bank.d.ts
+++ b/types/stripe-js/elements/fpx-bank.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeFpxBankElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeFpxBankElementEvent) => any
+    ): StripeFpxBankElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeFpxBankElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeFpxBankElementEvent) => any
+    ): StripeFpxBankElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -63,12 +69,8 @@ declare module '@stripe/stripe-js' {
     disabled?: boolean;
   }
 
-  interface StripeFpxBankElementChangeEvent extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'fpxBank';
-
+  type StripeFpxBankElementEvent = StripeElementEvent<'fpxBank'>;
+  interface StripeFpxBankElementChangeEvent extends StripeElementChangeEvent<'fpxBank'> {
     /**
      * The selected bank.
      * Can be one of the banks listed in the [FPX guide](https://stripe.com/docs/payments/fpx#bank-reference).

--- a/types/stripe-js/elements/iban.d.ts
+++ b/types/stripe-js/elements/iban.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeIbanElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeIbanElementEvent) => any
+    ): StripeIbanElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeIbanElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeIbanElementEvent) => any
+    ): StripeIbanElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -67,12 +73,8 @@ declare module '@stripe/stripe-js' {
     disabled?: boolean;
   }
 
-  interface StripeIbanElementChangeEvent extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'iban';
-
+  type StripeIbanElementEvent = StripeElementEvent<'iban'>;
+  interface StripeIbanElementChangeEvent extends StripeElementChangeEvent<'iban'> {
     country: string;
 
     bankName: string;

--- a/types/stripe-js/elements/ideal-bank.d.ts
+++ b/types/stripe-js/elements/ideal-bank.d.ts
@@ -18,12 +18,18 @@ declare module '@stripe/stripe-js' {
     /**
      * Triggered when the element gains focus.
      */
-    on(eventType: 'focus', handler: () => any): StripeIdealBankElement;
+    on(
+      eventType: 'focus',
+      handler: (event: StripeIdealBankElementEvent) => any
+    ): StripeIdealBankElement;
 
     /**
      * Triggered when the element loses focus.
      */
-    on(eventType: 'blur', handler: () => any): StripeIdealBankElement;
+    on(
+      eventType: 'blur',
+      handler: (event: StripeIdealBankElementEvent) => any
+    ): StripeIdealBankElement;
 
     /**
      * Triggered when the escape key is pressed within the element.
@@ -69,12 +75,8 @@ declare module '@stripe/stripe-js' {
     disabled?: boolean;
   }
 
-  interface StripeIdealBankElementChangeEvent extends StripeElementChangeEvent {
-    /**
-     * The type of element that emitted this event.
-     */
-    elementType: 'idealBank';
-
+  type StripeIdealBankElementEvent = StripeElementEvent<'idealBank'>
+  interface StripeIdealBankElementChangeEvent extends StripeElementChangeEvent<'idealBank'> {
     /**
      * The selected bank.
      * Can be one of the banks listed in the [iDEAL guide](https://stripe.com/docs/sources/ideal#specifying-customer-bank).

--- a/types/stripe-js/elements/payment-request-button.d.ts
+++ b/types/stripe-js/elements/payment-request-button.d.ts
@@ -23,7 +23,7 @@ declare module '@stripe/stripe-js' {
      */
     on(
       eventType: 'focus',
-      handler: () => any
+      handler: (event: StripePaymentRequestButtonElementEvent) => any
     ): StripePaymentRequestButtonElement;
 
     /**
@@ -31,7 +31,7 @@ declare module '@stripe/stripe-js' {
      */
     on(
       eventType: 'blur',
-      handler: () => any
+      handler: (event: StripePaymentRequestButtonElementEvent) => any
     ): StripePaymentRequestButtonElement;
 
     /**
@@ -73,6 +73,7 @@ declare module '@stripe/stripe-js' {
     paymentRequest: PaymentRequest;
   }
 
+  type StripePaymentRequestButtonElementEvent = StripeElementEvent<'paymentRequestButton'>;
   interface StripePaymentRequestButtonElementClickEvent {
     preventDefault: () => void;
   }


### PR DESCRIPTION
### Summary & motivation

Adds generic event types that only contain `elementType` and uses them with the blur and focus event handlers.

### Testing & documentation

I updated the typings test with the new type.

No breaking API changes.

