### PR TITLE
Fix padding style type

### DIFF
--- a/types/stripe-js/elements/base.d.ts
+++ b/types/stripe-js/elements/base.d.ts
@@ -167,9 +167,9 @@ declare module '@stripe/stripe-js' {
      * The [padding](https://developer.mozilla.org/en-US/docs/Web/CSS/padding) CSS property.
      *
      * Available for the `idealBank` element.
-     * Accepts integer `px` values.
+     * Accepts integer length with `px` unit as values.
      */
-    padding?: number;
+    padding?: string;
 
     /**
      * The [text-decoration](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration) CSS property.


### PR DESCRIPTION
### Summary & motivation

Padding style is a string whose length values requires a `px` suffix. Reflect that in the types. Documentation changes pending.

