### PR TITLE
Add Sofort and iDEAL types

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -483,6 +483,26 @@ stripe.confirmSepaDebitPayment('', {payment_method: ''});
 
 stripe.confirmSepaDebitPayment('');
 
+stripe.confirmSofortPayment('', {
+  payment_method: {
+    sofort: {
+      country: '',
+    },
+    billing_details: {
+      name: '',
+    },
+  },
+  return_url: '',
+});
+
+stripe.confirmSofortPayment('', {
+  payment_method: '',
+});
+
+stripe
+  .confirmSofortPayment('')
+  .then(({paymentIntent}: {paymentIntent?: PaymentIntent}) => {});
+
 stripe
   .handleCardAction('')
   .then(({paymentIntent}: {paymentIntent?: PaymentIntent}) => {});
@@ -546,6 +566,12 @@ stripe.createPaymentMethod({
   type: 'sepa_debit',
   sepa_debit: {iban: ''},
   billing_details: {name: 'Jenny Rosen', email: 'jenny@example.com'},
+});
+
+stripe.createPaymentMethod({
+  type: 'sofort',
+  sofort: {country: ''},
+  billing_details: {name: ''},
 });
 
 stripe.retrievePaymentIntent('{PAYMENT_INTENT_CLIENT_SECRET}');
@@ -640,6 +666,26 @@ stripe.confirmSepaDebitSetup('', {
     billing_details: {name: '', email: ''},
   },
 });
+
+stripe
+  .confirmSofortSetup('', {
+    payment_method: {
+      sofort: {
+        country: '',
+      },
+      billing_details: {
+        name: '',
+      },
+    },
+    return_url: '',
+  })
+  .then((result: {setupIntent?: SetupIntent}) => null);
+
+stripe.confirmSofortSetup('', {
+  payment_method: '',
+});
+
+stripe.confirmSofortSetup('');
 
 stripe
   .retrieveSetupIntent('')

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -598,6 +598,33 @@ stripe
   .confirmCardSetup('')
   .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
 
+stripe
+  .confirmIdealSetup('', {
+    payment_method: {
+      ideal: idealBankElement,
+      billing_details: {
+        name: '',
+        email: '',
+      },
+    },
+  })
+  .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
+
+stripe.confirmIdealSetup('', {payment_method: ''});
+
+stripe.confirmIdealSetup('', {
+  payment_method: {
+    ideal: {
+      bank: '',
+    },
+    billing_details: {
+      name: '',
+      email: '',
+    },
+  },
+  return_url: '',
+});
+
 stripe.confirmSepaDebitSetup('', {
   payment_method: {
     sepa_debit: ibanElement,

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -215,6 +215,22 @@ declare module '@stripe/stripe-js' {
     ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
 
     /**
+     * Use `stripe.confirmSofortPayment` in the [Sofort Payments with Payment Methods](https://stripe.com/docs/payments/sofort) flow when the customer submits your payment form.
+     * When called, it will confirm the `PaymentIntent` with `data` you provide. It will then automatically redirect the customer to authorize the transaction.
+     * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_sofort_payment
+     */
+    confirmSofortPayment(
+      clientSecret: string,
+      data?: ConfirmSofortPaymentData
+    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+
+    /**
      * Use `stripe.handleCardAction` in the Payment Intents API [manual confirmation](https://stripe.com/docs/payments/payment-intents/web-manual) flow to handle a [PaymentIntent](https://stripe.com/docs/api/payment_intents) with the `requires_action` status.
      * It will throw an error if the `PaymentIntent` has a different status.
      *
@@ -285,7 +301,6 @@ declare module '@stripe/stripe-js' {
      * When you confirm a `SetupIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
      * In addition to confirming the `SetupIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
      * It can also be called with an existing `PaymentMethod`, or if you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
-     * These use cases are detailed in the sections that follow.
      *
      * @docs https://stripe.com/docs/js/setup_intents/confirm_bacs_debit_setup
      */
@@ -343,6 +358,22 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitSetup(
       clientSecret: string,
       data?: ConfirmSepaDebitSetupData
+    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+
+    /*
+     * Use `stripe.confirmSofortSetup` in the [Set up future payments](https://stripe.com/docs/payments/sofort/set-up-payment) flow to use SOFORT bank details to set up a SEPA Direct Debit payment method for future payments.
+     * When called, it will confirm a `SetupIntent` with `data` you provide, and it will automatically redirect the customer to authorize the transaction.
+     * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+     * Note that there are some additional requirements to this flow that are not covered in this reference.
+     * Refer to our [integration guide](https://stripe.com/docs/payments/sofort/set-up-payment) for more details.
+     *
+     * When you confirm a `SetupIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `SetupIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * It can also be called with an existing `PaymentMethod`, or if you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     */
+    confirmSofortSetup(
+      clientSecret: string,
+      data?: ConfirmSofortSetupData
     ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
 
     /**

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -311,6 +311,24 @@ declare module '@stripe/stripe-js' {
     ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
 
     /**
+     * Use `stripe.confirmIdealSetup` in the [Set up future payments](https://stripe.com/docs/payments/ideal/set-up-payment) flow to use iDEAL bank details to set up a SEPA Direct Debit payment method for future payments.
+     * When called, it will confirm a `SetupIntent` with `data` you provide, and it will automatically redirect the customer to authorize the transaction.
+     * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+     * Note that there are some additional requirements to this flow that are not covered in this reference.
+     * Refer to our [integration guide](https://stripe.com/docs/payments/ideal/set-up-payment) for more details.
+     *
+     * When you confirm a `SetupIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `SetupIntent`, this method can automatically create and attach a new `PaymentMethod` for you.
+     * It can also be called with an existing `PaymentMethod`, or if you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/setup_intents/confirm_ideal_setup
+     */
+    confirmIdealSetup(
+      clientSecret: string,
+      data?: ConfirmIdealSetupData
+    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+
+    /**
      * Use `stripe.confirmSepaDebitSetup` in the [SEPA Direct Debit with Setup Intents](https://stripe.com/docs/payments/sepa-debit-setup-intents) flow when the customer submits your payment form.
      * When called, it will confirm the `SetupIntent` with `data` you provide.
      * Note that there are some additional requirements to this flow that are not covered in this reference.

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -12,7 +12,8 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodIdealData
     | CreatePaymentMethodP24Data
     | CreatePaymentMethodFpxData
-    | CreatePaymentMethodSepaDebitData;
+    | CreatePaymentMethodSepaDebitData
+    | CreatePaymentMethodSofortData;
 
   interface CreatePaymentMethodAlipayData extends PaymentMethodCreateParams {
     type: 'alipay';
@@ -22,7 +23,7 @@ declare module '@stripe/stripe-js' {
     extends PaymentMethodCreateParams {
     type: 'bancontact';
 
-    /*
+    /**
      * The customer's billing details.
      * `name` is required.
      *
@@ -42,7 +43,7 @@ declare module '@stripe/stripe-js' {
   interface CreatePaymentMethodEpsData extends PaymentMethodCreateParams {
     type: 'eps';
 
-    /*
+    /**
      * The customer's billing details.
      * `name` is required.
      *
@@ -69,7 +70,7 @@ declare module '@stripe/stripe-js' {
   interface CreatePaymentMethodGiropayData extends PaymentMethodCreateParams {
     type: 'giropay';
 
-    /*
+    /**
      * The customer's billing details.
      * `name` is required.
      *
@@ -96,7 +97,7 @@ declare module '@stripe/stripe-js' {
   interface CreatePaymentMethodP24Data extends PaymentMethodCreateParams {
     type: 'p24';
 
-    /*
+    /**
      * The customer's billing details.
      * `email` is required.
      *
@@ -119,7 +120,7 @@ declare module '@stripe/stripe-js' {
           iban: string;
         };
 
-    /*
+    /**
      * The customer's billing details.
      * `name` and `email` are required.
      *
@@ -129,6 +130,25 @@ declare module '@stripe/stripe-js' {
       name: string;
       email: string;
     };
+  }
+
+  interface CreatePaymentMethodSofortData extends PaymentMethodCreateParams {
+    type: 'sofort';
+
+    sofort: {
+      /**
+       * The country code where customer's bank is located.
+       */
+      country: string;
+    };
+
+    /**
+     * The customer's billing details.
+     * Required when `setup_future_usage` is set to `off_session`.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details?: PaymentMethodCreateParams.BillingDetails;
   }
 
   interface CreatePaymentMethodAuBecsDebitData
@@ -157,7 +177,7 @@ declare module '@stripe/stripe-js' {
           account_number: string;
         };
 
-    /*
+    /**
      * The customer's billing details.
      * `name` and `email` are required.
      *
@@ -184,7 +204,7 @@ declare module '@stripe/stripe-js' {
       account_number: string;
     };
 
-    /*
+    /**
      * The customer's billing details.
      * `name`, `email`, and `address` are required.
      *
@@ -207,7 +227,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmBancontactPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -228,7 +248,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmAlipayPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * The `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent` or a new `PaymentMethod` will be created.
      *
@@ -248,7 +268,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmAlipayPayment`.
    */
   interface ConfirmAlipayPaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/alipay/accept-a-payment#handle-redirect).
      * Default is `true`.
      */
@@ -259,7 +279,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmBancontactPayment`.
    */
   interface ConfirmBancontactPaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/bancontact#handle-redirect).
      * Default is `true`.
      */
@@ -271,7 +291,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmCardPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -284,7 +304,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmCardPayment`.
    */
   interface ConfirmCardPaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [handle next actions yourself](https://stripe.com/docs/payments/payment-intents/verifying-status#next-actions), or if you want to defer next action handling until later (e.g. for use in the [PaymentRequest API](https://stripe.com/docs/stripe-js/elements/payment-request-button#complete-payment-intents)).
      * Default is `true`.
      */
@@ -296,7 +316,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmEpsPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -316,7 +336,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmEpsPayment`.
    */
   interface ConfirmEpsPaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/eps#handle-redirect).
      * Default is `true`.
      */
@@ -328,7 +348,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmSepaDebitPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -348,7 +368,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmFpxPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -368,7 +388,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmFpxPayment`.
    */
   interface ConfirmFpxPaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/fpx#handle-redirect).
      * Default is `true`.
      */
@@ -380,7 +400,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmGiropayPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -400,7 +420,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmGiropayPayment`.
    */
   interface ConfirmGiropayPaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/giropay#handle-redirect).
      * Default is `true`.
      */
@@ -412,7 +432,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmIdealPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -432,7 +452,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmIdealPayment`.
    */
   interface ConfirmIdealPaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/ideal#handle-redirect).
      * Default is `true`.
      */
@@ -444,7 +464,7 @@ declare module '@stripe/stripe-js' {
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmP24PaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *
@@ -464,7 +484,7 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmP24Payment`.
    */
   interface ConfirmP24PaymentOptions {
-    /*
+    /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/p24#handle-redirect).
      * Default is `true`.
      */
@@ -472,11 +492,39 @@ declare module '@stripe/stripe-js' {
   }
 
   /**
+   * Data to be sent with a `stripe.confirmSofortPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmSofortPaymentData extends PaymentIntentConfirmParams {
+    /**
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodSofortData, 'type'>;
+
+    /**
+     * The url your customer will be directed to after they complete authentication.
+     *
+     * @recommended
+     */
+    return_url?: string;
+
+    /**
+     * To set up a SEPA Direct Debit payment method using the bank details from this SOFORT payment, set this parameter to `off_session`.
+     * When using this parameter, a `customer` will need to be set on the [PaymentIntent](https://stripe.com/docs/api/payment_intents).
+     * The newly created SEPA Direct Debit [PaymentMethod](https://stripe.com/docs/api/payment_methods) will be attached to this customer.
+     */
+    setup_future_usage?: 'off_session';
+  }
+
+  /**
    * Data to be sent with a `stripe.confirmAuBecsDebitPayment` request.
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
   interface ConfirmAuBecsDebitPaymentData extends PaymentIntentConfirmParams {
-    /*
+    /**
      * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
      * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
      *

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -53,6 +53,20 @@ declare module '@stripe/stripe-js' {
   }
 
   /**
+   * Data to be sent with a `stripe.confirmSofortSetup` request.
+   * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmSofortSetupData extends SetupIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `SetupIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodSofortData, 'type'>;
+  }
+
+  /**
    * Data to be sent with a `stripe.confirmAuBecsDebitSetup` request.
    * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
    */

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -25,6 +25,20 @@ declare module '@stripe/stripe-js' {
   }
 
   /**
+   * Data to be sent with a `stripe.confirmIdealSetup` request.
+   * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmIdealSetupData extends SetupIntentConfirmParams {
+    /*
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `SetupIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodIdealData, 'type'>;
+  }
+
+  /**
    * Data to be sent with a `stripe.confirmSepaDebitSetup` request.
    * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
    */


### PR DESCRIPTION
Adds type definitions for:

- `stripe.confirmIdealSetup`
- `stripe.confirmSofortPayment`
- `stripe.confirmSofortSetup`
- `stripe.createPaymentMethod` with Sofort PM data

Fixes #108 
Fixes #99