### PR TITLE
Update types and methods for EPS, now that we have beta element

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -430,6 +430,7 @@ stripe.confirmEpsPayment('', {
     eps: epsBankElement,
     billing_details: {name: 'Jenny Rosen'},
   },
+  return_url: window.location.href,
 });
 
 stripe.confirmEpsPayment('', {payment_method: ''});
@@ -437,6 +438,11 @@ stripe.confirmEpsPayment('', {payment_method: ''});
 stripe.confirmEpsPayment('', {payment_method: ''}, {handleActions: false});
 
 stripe.confirmEpsPayment('');
+
+stripe.confirmFpxPayment('', {
+  payment_method: {fpx: fpxBankElement},
+  return_url: window.location.href,
+});
 
 stripe.confirmFpxPayment('', {payment_method: ''});
 

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -28,6 +28,7 @@ import {
   CustomFontSource,
   StripeIbanElement,
   StripeIdealBankElement,
+  StripeEpsBankElement,
   StripeFpxBankElement,
   StripeFpxBankElementChangeEvent,
   StripeAuBankAccountElement,
@@ -189,6 +190,16 @@ const retrievedPaymentRequestButtonElement: StripePaymentRequestButtonElement | 
 
 // Make sure that `paymentRequest` is at least optional;
 retrievedPaymentRequestButtonElement!.update({});
+
+const epsBankElement = elements.create('epsBank', {
+  style: MY_STYLE,
+  value: '',
+  classes: {webkitAutoFill: ''},
+});
+
+const retrievedEpsBankElement: StripeEpsBankElement | null = elements.getElement(
+  'epsBank'
+);
 
 type StripePaymentRequestButtonElementUpdateOptions = Parameters<
   StripePaymentRequestButtonElement['update']
@@ -407,8 +418,18 @@ stripe.confirmCardPayment('');
 stripe.confirmCardPayment('');
 
 stripe.confirmEpsPayment('', {
-  payment_method: {billing_details: {name: 'Jenny Rosen'}},
+  payment_method: {
+    eps: {bank: 'bank_austria'},
+    billing_details: {name: 'Jenny Rosen'},
+  },
   return_url: window.location.href,
+});
+
+stripe.confirmEpsPayment('', {
+  payment_method: {
+    eps: epsBankElement,
+    billing_details: {name: 'Jenny Rosen'},
+  },
 });
 
 stripe.confirmEpsPayment('', {payment_method: ''});
@@ -416,11 +437,6 @@ stripe.confirmEpsPayment('', {payment_method: ''});
 stripe.confirmEpsPayment('', {payment_method: ''}, {handleActions: false});
 
 stripe.confirmEpsPayment('');
-
-stripe.confirmFpxPayment('', {
-  payment_method: {fpx: fpxBankElement},
-  return_url: window.location.href,
-});
 
 stripe.confirmFpxPayment('', {payment_method: ''});
 

--- a/types/api/PaymentMethods.d.ts
+++ b/types/api/PaymentMethods.d.ts
@@ -29,6 +29,8 @@ declare module '@stripe/stripe-js' {
      */
     customer: string | null;
 
+    eps?: PaymentMethod.Eps;
+
     fpx?: PaymentMethod.Fpx;
 
     ideal?: PaymentMethod.Ideal;
@@ -170,6 +172,13 @@ declare module '@stripe/stripe-js' {
     }
 
     interface CardPresent {}
+
+    interface Eps {
+      /**
+       * The customer's bank.
+       */
+      bank: string;
+    }
 
     interface Fpx {
       /**

--- a/types/stripe-js/elements.d.ts
+++ b/types/stripe-js/elements.d.ts
@@ -7,6 +7,7 @@
 ///<reference path='./elements/fpx-bank.d.ts' />
 ///<reference path='./elements/payment-request-button.d.ts' />
 ///<reference path='./elements/au-bank-account.d.ts' />
+///<reference path='./elements/eps-bank.d.ts' />
 
 import {StripeAuBankAccountElement} from '@stripe/stripe-js';
 
@@ -121,6 +122,29 @@ declare module '@stripe/stripe-js' {
     getElement(elementType: 'fpxBank'): StripeFpxBankElement | null;
 
     /////////////////////////////
+    /// epsBank
+    /////////////////////////////
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Creates an `EpsBankElement`.
+     */
+    create(
+      elementType: 'epsBank',
+      options: StripeEpsBankElementOptions
+    ): StripeEpsBankElement;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Looks up a previously created `Element` by its type.
+     */
+    getElement(elementType: 'epsBank'): StripeEpsBankElement | null;
+
+    /////////////////////////////
     /// iban
     /////////////////////////////
 
@@ -182,6 +206,7 @@ declare module '@stripe/stripe-js' {
     | 'cardNumber'
     | 'cardExpiry'
     | 'cardCvc'
+    | 'epsBank'
     | 'fpxBank'
     | 'iban'
     | 'idealBank'
@@ -193,6 +218,7 @@ declare module '@stripe/stripe-js' {
     | StripeCardNumberElement
     | StripeCardExpiryElement
     | StripeCardCvcElement
+    | StripeEpsBankElement
     | StripeFpxBankElement
     | StripeIbanElement
     | StripeIdealBankElement

--- a/types/stripe-js/elements/eps-bank.d.ts
+++ b/types/stripe-js/elements/eps-bank.d.ts
@@ -1,0 +1,90 @@
+///<reference path='./base.d.ts' />
+
+declare module '@stripe/stripe-js' {
+  type StripeEpsBankElement = StripeElementBase & {
+    /**
+     * The change event is triggered when the `Element`'s value changes.
+     */
+    on(
+      eventType: 'change',
+      handler: (event: StripeEpsBankElementChangeEvent) => any
+    ): StripeEpsBankElement;
+
+    /**
+     * Triggered when the element is fully rendered and can accept `element.focus` calls.
+     */
+    on(eventType: 'ready', handler: () => any): StripeEpsBankElement;
+
+    /**
+     * Triggered when the element gains focus.
+     */
+    on(eventType: 'focus', handler: () => any): StripeEpsBankElement;
+
+    /**
+     * Triggered when the element loses focus.
+     */
+    on(eventType: 'blur', handler: () => any): StripeEpsBankElement;
+
+    /**
+     * Triggered when the escape key is pressed within the element.
+     */
+    on(eventType: 'escape', handler: () => any): StripeEpsBankElement;
+
+    /**
+     * Updates the options the `EpsBankElement` was initialized with.
+     * Updates are merged into the existing configuration.
+     *
+     * The styles of an `EpsBankElement` can be dynamically changed using `element.update`.
+     * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+     */
+    update(options: Partial<StripeEpsBankElementOptions>): void;
+  };
+
+  interface StripeEpsBankElementOptions {
+    classes?: StripeElementClasses;
+
+    style?: StripeElementStyle;
+
+    /**
+     * Appearance of the icon in the Element.
+     */
+    iconStyle?: 'default' | 'solid';
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * A pre-filled value for the Element.
+     * Can be one of the banks listed in the [EPS guide](https://stripe.com/docs/payments/eps/accept-a-payment#bank-values) (e.g., `bank_austria`).
+     */
+    value?: string;
+
+    /**
+     * Hides the icon in the Element.
+     * Default is `false`.
+     */
+    hideIcon?: boolean;
+
+    /**
+     * Applies a disabled state to the Element such that user input is not accepted.
+     * Default is false.
+     */
+    disabled?: boolean;
+  }
+
+  interface StripeEpsBankElementChangeEvent extends StripeElementChangeEvent {
+    /**
+     * The type of element that emitted this event.
+     */
+    elementType: 'epsBank';
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * A pre-filled value for the Element.
+     * Can be one of the banks listed in the [EPS guide](https://stripe.com/docs/payments/eps/accept-a-payment#bank-values) (e.g., `bank_austria`).
+     */
+    value?: string;
+  }
+}

--- a/types/stripe-js/elements/eps-bank.d.ts
+++ b/types/stripe-js/elements/eps-bank.d.ts
@@ -51,9 +51,6 @@ declare module '@stripe/stripe-js' {
     iconStyle?: 'default' | 'solid';
 
     /**
-     * Requires beta access:
-     * Contact [Stripe support](https://support.stripe.com/) for more information.
-     *
      * A pre-filled value for the Element.
      * Can be one of the banks listed in the [EPS guide](https://stripe.com/docs/payments/eps/accept-a-payment#bank-values) (e.g., `bank_austria`).
      */
@@ -79,9 +76,6 @@ declare module '@stripe/stripe-js' {
     elementType: 'epsBank';
 
     /**
-     * Requires beta access:
-     * Contact [Stripe support](https://support.stripe.com/) for more information.
-     *
      * A pre-filled value for the Element.
      * Can be one of the banks listed in the [EPS guide](https://stripe.com/docs/payments/eps/accept-a-payment#bank-values) (e.g., `bank_austria`).
      */

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -52,6 +52,19 @@ declare module '@stripe/stripe-js' {
     billing_details: PaymentMethodCreateParams.BillingDetails & {
       name: string;
     };
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     */
+    eps:
+      | StripeEpsBankElement
+      | {
+          /**
+           * The customer's bank
+           */
+          bank?: string;
+        };
   }
 
   interface CreatePaymentMethodFpxData extends PaymentMethodCreateParams {

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -53,10 +53,6 @@ declare module '@stripe/stripe-js' {
       name: string;
     };
 
-    /**
-     * Requires beta access:
-     * Contact [Stripe support](https://support.stripe.com/) for more information.
-     */
     eps:
       | StripeEpsBankElement
       | {


### PR DESCRIPTION
### Summary & motivation
Add type information for the beta EPS Bank Element, as well as update `confirmEpsPayment` method to optionally accept `eps` in the payment method details, in which an EPS Bank Element can be passed, or an object with the appropriate shape.

### Testing & documentation
Added.
