### PR TITLE
Types for CVC recollection

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -402,7 +402,10 @@ stripe.confirmCardPayment('', {payment_method: ''}, {handleActions: false});
 
 stripe.confirmCardPayment('', {payment_method: {card: {token: ''}}});
 
-stripe.confirmCardPayment('');
+stripe.confirmCardPayment('', {
+  payment_method: '',
+  payment_method_options: {card: {cvc: cardCvcElement}},
+});
 
 stripe.confirmCardPayment('');
 

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -269,6 +269,8 @@ stripe
 
 stripe.createToken(cardNumberElement);
 
+stripe.createToken('cvc_update', cardCvcElement);
+
 stripe.createToken('pii', {personal_id_number: ''});
 
 stripe.createToken(ibanElement, {

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -448,15 +448,14 @@ declare module '@stripe/stripe-js' {
     /**
      * Use `stripe.createToken` to tokenize the recollected CVC for a saved card.
 
-     * First, include the `cvc_update_beta_1` flag when creating an instance of the Stripe object.
-     * Next, render an `CardCvcElement` to collect the data.
+     * First, render a `CardCvcElement` to collect the data.
      * Then pass the `CardCvcElement` to `stripe.createToken` to tokenize the collected data.
      *
-     * @docs https://stripe.com/docs/js/tokens_sources/create_token?type=bank_account
+     * @docs https://stripe.com/docs/js/tokens_sources/create_token?type=cvc_update
      */
     createToken(
       tokenType: 'cvc_update',
-      element?: StripeCardCvcElement
+      element: StripeCardCvcElement
     ): Promise<{token?: Token; error?: StripeError}>;
 
     /**

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -298,6 +298,21 @@ declare module '@stripe/stripe-js' {
      * @recommended
      */
     payment_method?: string | Omit<CreatePaymentMethodCardData, 'type'>;
+
+    /**
+     * An object containing payment-method-specific configuration to confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with.
+     */
+    payment_method_options?: {
+      /**
+       * Configuration for this card payment.
+       */
+      card: {
+        /**
+         * Use the provided `CardCvcElement` when confirming the PaymentIntent with an existing PaymentMethod.
+         */
+        cvc?: StripeCardCvcElement;
+      };
+    };
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

Add types CVC recollection on client-side PaymentIntent confirmations
Fix types for CVC update createToken used during server side confirmations

### Testing & documentation

Added type tests for both features