### PR TITLE
Add isShowing to PaymentRequest

### DIFF
--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -14,6 +14,12 @@ declare module '@stripe/stripe-js' {
     show(): void;
 
     /**
+     * `true` if the browser’s payment interface is showing.
+     * When using the `PaymentRequestButtonElement`, this is called for you automatically.
+     */
+    isShowing: () => boolean;
+
+    /**
      * `PaymentRequest` instances can be updated with an options object.
      *
      * `paymentRequest.update` can only be called when the browser payment interface is not showing.


### PR DESCRIPTION
### Summary & motivation

PaymentRequests have an `isShowing()` boolean method that should be exposed.

### Testing & documentation

Added this type in our own codebase and have been using it without issue.