### PR TITLE
Update types and methods for P24, now that we have element 

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -29,6 +29,7 @@ import {
   StripeIbanElement,
   StripeIdealBankElement,
   StripeEpsBankElement,
+  StripeP24BankElement,
   StripeFpxBankElement,
   StripeFpxBankElementChangeEvent,
   StripeAuBankAccountElement,
@@ -199,6 +200,16 @@ const epsBankElement = elements.create('epsBank', {
 
 const retrievedEpsBankElement: StripeEpsBankElement | null = elements.getElement(
   'epsBank'
+);
+
+const p24BankElement = elements.create('p24Bank', {
+  style: MY_STYLE,
+  value: '',
+  classes: {webkitAutoFill: ''},
+});
+
+const retrievedP24BankElement: StripeP24BankElement | null = elements.getElement(
+  'p24Bank'
 );
 
 type StripePaymentRequestButtonElementUpdateOptions = Parameters<
@@ -511,6 +522,49 @@ stripe.confirmP24Payment('', {payment_method: ''});
 stripe.confirmP24Payment('', {payment_method: ''}, {handleActions: false});
 
 stripe.confirmP24Payment('');
+
+stripe.confirmP24Payment('', {
+  payment_method: {
+    p24: {bank: 'ing'},
+    billing_details: {name: 'Jenny Rosen'},
+  },
+  return_url: window.location.href,
+});
+
+stripe.confirmP24Payment('', {
+  payment_method: {
+    p24: p24BankElement,
+    billing_details: {name: 'Jenny Rosen'},
+  },
+  return_url: window.location.href,
+});
+
+stripe.confirmP24Payment('', {
+  payment_method: {
+    p24: {bank: 'ing'},
+    billing_details: {name: 'Jenny Rosen'},
+  },
+  payment_method_options: {
+    p24: {
+      tos_shown_and_accepted: true,
+    }
+  },
+  return_url: window.location.href,
+});
+
+stripe.confirmP24Payment('', {
+  payment_method: {
+    p24: p24BankElement,
+    billing_details: {name: 'Jenny Rosen'},
+  },
+  payment_method_options: {
+    p24: {
+      tos_shown_and_accepted: true,
+    }
+  },
+  return_url: window.location.href,
+});
+
 
 stripe.confirmSepaDebitPayment('', {
   payment_method: {

--- a/types/api/PaymentMethods.d.ts
+++ b/types/api/PaymentMethods.d.ts
@@ -35,6 +35,9 @@ declare module '@stripe/stripe-js' {
 
     ideal?: PaymentMethod.Ideal;
 
+    p24?: PaymentMethod.P24;
+
+
     /**
      * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
      */
@@ -198,6 +201,14 @@ declare module '@stripe/stripe-js' {
        */
       bic: string | null;
     }
+
+    interface P24 {
+      /**
+       * The customer's bank.
+       */
+      bank: string;
+    }
+
 
     interface SepaDebit {
       /**

--- a/types/stripe-js/elements.d.ts
+++ b/types/stripe-js/elements.d.ts
@@ -8,6 +8,7 @@
 ///<reference path='./elements/payment-request-button.d.ts' />
 ///<reference path='./elements/au-bank-account.d.ts' />
 ///<reference path='./elements/eps-bank.d.ts' />
+///<reference path='./elements/p24-bank.d.ts' />
 
 import {StripeAuBankAccountElement} from '@stripe/stripe-js';
 
@@ -126,8 +127,6 @@ declare module '@stripe/stripe-js' {
     /////////////////////////////
 
     /**
-     * Requires beta access:
-     * Contact [Stripe support](https://support.stripe.com/) for more information.
      *
      * Creates an `EpsBankElement`.
      */
@@ -143,6 +142,25 @@ declare module '@stripe/stripe-js' {
      * Looks up a previously created `Element` by its type.
      */
     getElement(elementType: 'epsBank'): StripeEpsBankElement | null;
+
+    /////////////////////////////
+    /// p24Bank
+    /////////////////////////////
+
+    /**
+     *
+     * Creates an `P24BankElement`.
+     */
+    create(
+      elementType: 'p24Bank',
+      options: StripeP24BankElementOptions
+    ): StripeP24BankElement;
+
+    /**
+     *
+     * Looks up a previously created `Element` by its type.
+     */
+    getElement(elementType: 'p24Bank'): StripeP24BankElement | null;
 
     /////////////////////////////
     /// iban
@@ -210,6 +228,7 @@ declare module '@stripe/stripe-js' {
     | 'fpxBank'
     | 'iban'
     | 'idealBank'
+    | 'p24Bank'
     | 'paymentRequestButton';
 
   type StripeElement =
@@ -222,6 +241,7 @@ declare module '@stripe/stripe-js' {
     | StripeFpxBankElement
     | StripeIbanElement
     | StripeIdealBankElement
+    | StripeP24BankElement
     | StripePaymentRequestButtonElement;
 
   type StripeElementLocale =

--- a/types/stripe-js/elements/p24-bank.d.ts
+++ b/types/stripe-js/elements/p24-bank.d.ts
@@ -1,0 +1,100 @@
+///<reference path='./base.d.ts' />
+
+declare module '@stripe/stripe-js' {
+  type StripeP24BankElement = StripeElementBase & {
+    /**
+     * The change event is triggered when the `Element`'s value changes.
+     */
+    on(
+      eventType: 'change',
+      handler: (event: StripeP24BankElementChangeEvent) => any
+    ): StripeP24BankElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripeP24BankElementChangeEvent) => any
+    ): StripeP24BankElement;
+    off(
+      eventType: 'change',
+      handler: (event: StripeP24BankElementChangeEvent) => any
+    ): StripeP24BankElement;
+
+    /**
+     * Triggered when the element is fully rendered and can accept `element.focus` calls.
+     */
+    on(eventType: 'ready', handler: () => any): StripeP24BankElement;
+    once(eventType: 'ready', handler: () => any): StripeP24BankElement;
+    off(eventType: 'ready', handler: () => any): StripeP24BankElement;
+
+    /**
+     * Triggered when the element gains focus.
+     */
+    on(eventType: 'focus', handler: () => any): StripeP24BankElement;
+    once(eventType: 'focus', handler: () => any): StripeP24BankElement;
+    off(eventType: 'focus', handler: () => any): StripeP24BankElement;
+
+    /**
+     * Triggered when the element loses focus.
+     */
+    on(eventType: 'blur', handler: () => any): StripeP24BankElement;
+    once(eventType: 'blur', handler: () => any): StripeP24BankElement;
+    off(eventType: 'blur', handler: () => any): StripeP24BankElement;
+
+    /**
+     * Triggered when the escape key is pressed within the element.
+     */
+    on(eventType: 'escape', handler: () => any): StripeP24BankElement;
+    once(eventType: 'escape', handler: () => any): StripeP24BankElement;
+    off(eventType: 'escape', handler: () => any): StripeP24BankElement;
+
+    /**
+     * Updates the options the `P24BankElement` was initialized with.
+     * Updates are merged into the existing configuration.
+     *
+     * The styles of an `P24BankElement` can be dynamically changed using `element.update`.
+     * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+     */
+    update(options: Partial<StripeP24BankElementOptions>): void;
+  };
+
+  interface StripeP24BankElementOptions {
+    classes?: StripeElementClasses;
+
+    style?: StripeElementStyle;
+
+    /**
+     * Appearance of the icon in the Element.
+     */
+    iconStyle?: 'default' | 'solid';
+
+    /**
+     * A pre-filled value for the Element.
+     * Can be one of the banks listed in the [Przelewy24 guide](https://stripe.com/docs/payments/p24/accept-a-payment#bank-values) (e.g., `bank_austria`).
+     */
+    value?: string;
+
+    /**
+     * Hides the icon in the Element.
+     * Default is `false`.
+     */
+    hideIcon?: boolean;
+
+    /**
+     * Applies a disabled state to the Element such that user input is not accepted.
+     * Default is false.
+     */
+    disabled?: boolean;
+  }
+
+  interface StripeP24BankElementChangeEvent extends StripeElementChangeEvent {
+    /**
+     * The type of element that emitted this event.
+     */
+    elementType: 'p24Bank';
+
+    /**
+     * A pre-filled value for the Element.
+     * Can be one of the banks listed in the [Przelewy24 guide](https://stripe.com/docs/payments/p24/accept-a-payment#bank-values) (e.g., `ing`).
+     */
+    value?: string;
+  }
+}

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -130,6 +130,14 @@ declare module '@stripe/stripe-js' {
     billing_details: PaymentMethodCreateParams.BillingDetails & {
       email: string;
     };
+    p24:
+      | StripeP24BankElement
+      | {
+      /**
+       * The customer's bank.
+       */
+      bank?: string;
+    };
   }
 
   interface CreatePaymentMethodSepaDebitData extends PaymentMethodCreateParams {
@@ -534,6 +542,18 @@ declare module '@stripe/stripe-js' {
      * @recommended
      */
     payment_method?: string | Omit<CreatePaymentMethodP24Data, 'type'>;
+
+    payment_method_options?: {
+      /**
+       * Configuration for this Przelewy24 payment.
+       */
+      p24: {
+        /**
+         * Specify that payer has agreed to the Przelewy24 Terms of Service
+         */
+        tos_shown_and_accepted?: boolean;
+      };
+    };
 
     /**
      * The url your customer will be directed to after they complete authentication.


### PR DESCRIPTION
### Summary & motivation
Add type information for the P24 Bank Element, as well as update confirmP24Payment method to: 
- optionally accept p24 in the payment method details, in which an P24 Bank Element can be passed, or an object with the appropriate shape
- optionally accept p24 in the payment_method_options, in which a boolean parameter of `tos_shown_and_accepted` can be passed.

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
Tests added in 
- `tests/types/index.ts`
- `tests/types/index.ts`
- `tests/types/index.ts`


