### PR TITLE
`Account.Individual.political_exposure` type definition missing

### DIFF
--- a/types/api/Tokens.d.ts
+++ b/types/api/Tokens.d.ts
@@ -304,6 +304,11 @@ declare module '@stripe/stripe-js' {
         phone?: string;
 
         /**
+         * Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
+         */
+        political_exposure?: Individual.PoliticalExposure;
+
+        /**
          * The last four digits of the individual's Social Security Number (U.S. only).
          */
         ssn_last_4?: string;
@@ -363,6 +368,8 @@ declare module '@stripe/stripe-js' {
            */
           year: number;
         }
+
+        type PoliticalExposure = 'none' | 'existing'
 
         interface Verification {
           /**

--- a/types/api/Tokens.d.ts
+++ b/types/api/Tokens.d.ts
@@ -369,7 +369,7 @@ declare module '@stripe/stripe-js' {
           year: number;
         }
 
-        type PoliticalExposure = 'none' | 'existing'
+        type PoliticalExposure = 'none' | 'existing';
 
         interface Verification {
           /**


### PR DESCRIPTION
### Summary

Account token's field `account.individual.political_exposure` (as defined [here](https://stripe.com/docs/api/tokens/create_account#create_account_token-account-individual-political_exposure)) is missing in `Account.Individual` [interface](https://github.com/stripe/stripe-js/blob/570bfbb7e78a00c6a8ef518340c7a9c168b61596/types/api/Tokens.d.ts#L225).

### Other information

Feel free to ignore PR if it's not a proper way to contribute in the repo.
