### PR TITLE
Add missing properties to createSource types

### DIFF
--- a/types/api/Sources.d.ts
+++ b/types/api/Sources.d.ts
@@ -715,6 +715,46 @@ declare module '@stripe/stripe-js' {
 
       statement_descriptor?: string;
     }
+
+    interface SofortCreate {
+      country: string;
+
+      preferred_language?: string;
+    }
+
+    interface IdealCreate {
+      bank?: string;
+    }
+
+    interface BancontactCreate {
+      preferred_language?: string;
+    }
+
+    interface KlarnaCreate {
+      attachment?: string;
+
+      custom_payment_methods: string;
+
+      first_name: string;
+
+      last_name: string;
+
+      locale?: string;
+
+      product: string;
+
+      purchase_country: string;
+
+      shipping_first_name: string;
+
+      shipping_last_name: string;
+
+      shipping_delay: number;
+    }
+
+    interface SepaDebitCreate {
+      iban: string;
+    }
   }
 
   interface SourceCreateParams {
@@ -791,6 +831,31 @@ declare module '@stripe/stripe-js' {
     type?: string;
 
     usage?: SourceCreateParams.Usage;
+
+    /**
+     * Information about the sofort object.
+     */
+    sofort?: Source.SofortCreate;
+
+    /**
+     * Information about the ideal object.
+     */
+    ideal?: Source.IdealCreate;
+
+    /**
+     * Information about the bancontact object.
+     */
+    bancontact?: Source.Bancontact;
+
+    /**
+     * Information about the klarna object.
+     */
+    klarna?: Source.KlarnaCreate;
+
+    /**
+     * Information about the sepa_debit object.
+     */
+    sepa_debit?: Source.SepaDebitCreate;
   }
 
   namespace SourceCreateParams {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
This PR added missing properties to SourceCreateParams:
- [sofort]( https://stripe.com/docs/sources/sofort#create-source)
- [ideal](https://stripe.com/docs/sources/ideal#custom-client-side-source-creation)
- [bancontact](https://stripe.com/docs/sources/bancontact#create-source)
- [klarna](https://stripe.com/docs/sources/klarna#create-source)
- [sepa_debit](https://stripe.com/docs/sources/sepa-debit#custom-client-side-source-creation)

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Used existing tests.