### PR TITLE
Add TypeScript support for providing font-weight as a number

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -127,6 +127,8 @@ const cardNumberElement: StripeCardNumberElement = elements.create(
 );
 
 elements.create('cardNumber', {style: {base: {fontWeight: 500}}});
+elements.create('cardCvc', {style: {base: {fontWeight: 500}}});
+elements.create('cardExpiry', {style: {base: {fontWeight: 500}}});
 
 const retrievedCardNumberElement: StripeCardNumberElement | null = elements.getElement(
   'cardNumber'

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -109,6 +109,8 @@ const cardElement: StripeCardElement = elements.create('card', {
   disabled: false,
 });
 
+elements.create('card', {style: {base: {fontWeight: 500}}});
+
 const cardElementDefaults: StripeCardElement = elements.create('card');
 
 const retrievedCardElement: StripeCardElement | null = elements.getElement(
@@ -123,6 +125,8 @@ const cardNumberElement: StripeCardNumberElement = elements.create(
     iconStyle: 'solid',
   }
 );
+
+elements.create('cardNumber', {style: {base: {fontWeight: 500}}});
 
 const retrievedCardNumberElement: StripeCardNumberElement | null = elements.getElement(
   'cardNumber'
@@ -150,6 +154,11 @@ const fpxBankElement = elements.create('fpxBank', {
   classes: {webkitAutoFill: ''},
 });
 
+elements.create('fpxBank', {
+  style: {base: {fontWeight: 500}},
+  accountHolderType: 'individual',
+});
+
 const retrievedFpxBankElement: StripeFpxBankElement | null = elements.getElement(
   'fpxBank'
 );
@@ -166,6 +175,8 @@ const idealBankElement = elements.create('idealBank', {
   hideIcon: false,
   classes: {webkitAutoFill: ''},
 });
+
+elements.create('idealBank', {style: {base: {fontWeight: 500}}});
 
 const retrievedIdealBankElement: StripeIdealBankElement | null = elements.getElement(
   'idealBank'
@@ -200,6 +211,8 @@ const epsBankElement = elements.create('epsBank', {
   classes: {webkitAutoFill: ''},
 });
 
+elements.create('epsBank', {style: {base: {fontWeight: 500}}});
+
 const retrievedEpsBankElement: StripeEpsBankElement | null = elements.getElement(
   'epsBank'
 );
@@ -209,6 +222,8 @@ const p24BankElement = elements.create('p24Bank', {
   value: '',
   classes: {webkitAutoFill: ''},
 });
+
+elements.create('p24Bank', {style: {base: {fontWeight: 500}}});
 
 const retrievedP24BankElement: StripeP24BankElement | null = elements.getElement(
   'p24Bank'

--- a/types/stripe-js/elements/base.d.ts
+++ b/types/stripe-js/elements/base.d.ts
@@ -137,7 +137,7 @@ declare module '@stripe/stripe-js' {
     /**
      * The [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) CSS property.
      */
-    fontWeight?: string;
+    fontWeight?: string | number;
 
     /**
      * A custom property, used to set the color of the icons that are rendered in an element.


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

The following changes update the type-definitions for [`StripeElementCSSProperties`](https://github.com/stripe/stripe-js/blob/78d094f68bae1c25efb96df7dd581dc7d50ab3c9/types/stripe-js/elements/base.d.ts#L98) to allow for font-weights as numbers. Right now the property is strictly typed as a string, even though Stripe.js allows for both numbers and strings.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->
Added some failing test cases, then made them pass, then verified using`yarn test:types` followed by `yarn test` for good measure.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
