### PR TITLE
Add payment method data types for createSource

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -354,6 +354,7 @@ const createSourceRaw = async () => {
     type: 'ideal',
     amount: 1099,
     currency: 'eur',
+    statement_descriptor: 'ORDER AT11990',
     owner: {
       name: 'Jenny Rosen',
     },
@@ -370,6 +371,158 @@ const createSourceRaw = async () => {
     console.log(source.type);
   }
 };
+
+stripe.createSource(cardElement, {
+  owner: {
+    name: 'Jenny Rosen',
+    address: {
+      line1: 'Nollendorfstraße 27',
+      city: 'Berlin',
+      postal_code: '10777',
+      country: 'DE',
+    },
+    email: 'jenny.rosen@example.com',
+  },
+});
+
+stripe.createSource({
+  type: 'klarna',
+  amount: 816,
+  currency: 'eur',
+  klarna: {
+    product: 'payment',
+    purchase_country: 'DE',
+  },
+  source_order: {
+    items: [
+      {
+        type: 'sku',
+        description: 'Grey cotton T-shirt',
+        quantity: 2,
+        currency: 'eur',
+        amount: 796,
+      },
+      {
+        type: 'tax',
+        description: 'Taxes',
+        currency: 'eur',
+        amount: 20,
+      },
+      {
+        type: 'shipping',
+        description: 'Free Shipping',
+        currency: 'eur',
+        amount: 0,
+      },
+    ],
+  },
+});
+
+stripe.createSource({
+  type: 'alipay',
+  amount: 1099,
+  currency: 'usd',
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+});
+
+stripe.createSource({
+  type: 'bancontact',
+  amount: 1099,
+  currency: 'eur',
+  bancontact: {
+    preferred_language: 'fr',
+  },
+  owner: {
+    name: 'Jenny Rosen',
+  },
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+});
+
+stripe.createSource({
+  type: 'eps',
+  amount: 1099,
+  currency: 'eur',
+  owner: {
+    name: 'Jenny Rosen',
+  },
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+});
+
+stripe.createSource({
+  type: 'giropay',
+  amount: 1099,
+  currency: 'eur',
+  owner: {
+    name: 'Jenny Rosen',
+  },
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+});
+
+stripe.createSource({
+  type: 'ideal',
+  amount: 1099,
+  currency: 'eur',
+  ideal: {bank: ''},
+  statement_descriptor: 'ORDER AT11990',
+  owner: {
+    name: 'Jenny Rosen',
+  },
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+});
+
+stripe.createSource({
+  type: 'p24',
+  amount: 1099,
+  currency: 'eur',
+  owner: {
+    name: 'Jenny Rosen',
+    email: 'jenny.rosen@example.com',
+  },
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+});
+
+stripe.createSource({
+  type: 'wechat',
+  amount: 1099,
+  currency: 'usd',
+});
+
+stripe.createSource({
+  type: 'multibanco',
+  amount: 1099,
+  currency: 'eur',
+  owner: {
+    name: 'Jenny Rosen',
+    email: 'jenny.rosen@example.com',
+  },
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+});
+
+stripe.createSource({
+  type: 'sofort',
+  amount: 1099,
+  currency: 'eur',
+  redirect: {
+    return_url: 'https://shop.example.com/crtA6B28E1',
+  },
+  sofort: {
+    country: 'DE',
+  },
+});
 
 stripe.retrieveSource({id: '', client_secret: ''}).then((result) => {
   console.log(result.source!.type);

--- a/types/stripe-js/token-and-sources.d.ts
+++ b/types/stripe-js/token-and-sources.d.ts
@@ -90,5 +90,19 @@ declare module '@stripe/stripe-js' {
    * Instead, you must gather card information in an `Element` and use `stripe.createSource(element, sourceData)`.
    * You can also pass an existing card token to convert it into a `Source` object.
    */
-  type CreateSourceData = SourceCreateParams;
+  interface CreateSourceData extends SourceCreateParams {
+    bancontact?: CreateSourceData.DeprecatedMethodData;
+
+    ideal?: CreateSourceData.DeprecatedMethodData;
+
+    klarna?: CreateSourceData.DeprecatedMethodData;
+
+    sepa_debit?: CreateSourceData.DeprecatedMethodData;
+
+    sofort?: CreateSourceData.DeprecatedMethodData;
+  }
+
+  namespace CreateSourceData {
+    type DeprecatedMethodData = Record<string, unknown>;
+  }
 }


### PR DESCRIPTION
### Summary & motivation

While `createSource` is deprecated in favor of the Payment Intents equivalents, existing integrations are still valid. This change allows specifying payment method data without triggering TypeScript's [Excess Property Checking](https://www.typescriptlang.org/docs/handbook/interfaces.html#excess-property-checks) by documenting those fields as `Record<string, unknown>`.

### Testing & documentation

Added type tests for all [documented sources](https://site-admin.stripe.com/docs/sources).
