### PR TITLE
Adding types for `afterpayClearpayMessage` Element

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -35,6 +35,7 @@ import {
   StripeAuBankAccountElement,
   StripeAuBankAccountElementChangeEvent,
   StripePaymentRequestButtonElement,
+  StripeAfterpayClearpayMessageElement,
   StripeElementType,
   CanMakePaymentResult,
 } from '@stripe/stripe-js';
@@ -193,6 +194,20 @@ const retrievedPaymentRequestButtonElement: StripePaymentRequestButtonElement | 
 
 // Make sure that `paymentRequest` is at least optional;
 retrievedPaymentRequestButtonElement!.update({});
+
+const afterpayClearpayMessageElement = elements.create(
+  'afterpayClearpayMessage',
+  {
+    amount: 2000,
+    currency: 'USD',
+  }
+);
+
+const retrievedAfterpayClearpayMessageElement: StripeAfterpayClearpayMessageElement | null = elements.getElement(
+  'afterpayClearpayMessage'
+);
+
+retrievedAfterpayClearpayMessageElement!.update({currency: 'GBP'});
 
 const epsBankElement = elements.create('epsBank', {
   style: MY_STYLE,

--- a/types/stripe-js/elements.d.ts
+++ b/types/stripe-js/elements.d.ts
@@ -9,6 +9,7 @@
 ///<reference path='./elements/au-bank-account.d.ts' />
 ///<reference path='./elements/eps-bank.d.ts' />
 ///<reference path='./elements/p24-bank.d.ts' />
+///<reference path='./elements/afterpay-clearpay-message.d.ts' />
 
 import {StripeAuBankAccountElement} from '@stripe/stripe-js';
 
@@ -216,6 +217,21 @@ declare module '@stripe/stripe-js' {
     getElement(
       elementType: 'paymentRequestButton'
     ): StripePaymentRequestButtonElement | null;
+
+    /**
+     * Creates an `AfterpayClearpayMessageElement`.
+     */
+    create(
+      elementType: 'afterpayClearpayMessage',
+      options: StripeAfterpayClearpayMessageElementOptions
+    ): StripeAfterpayClearpayMessageElement;
+
+    /**
+     * Looks up a previously created `Element` by its type.
+     */
+    getElement(
+      elementType: 'afterpayClearpayMessage'
+    ): StripeAfterpayClearpayMessageElement | null;
   }
 
   type StripeElementType =
@@ -229,7 +245,8 @@ declare module '@stripe/stripe-js' {
     | 'iban'
     | 'idealBank'
     | 'p24Bank'
-    | 'paymentRequestButton';
+    | 'paymentRequestButton'
+    | 'afterpayClearpayMessage';
 
   type StripeElement =
     | StripeAuBankAccountElement
@@ -242,7 +259,8 @@ declare module '@stripe/stripe-js' {
     | StripeIbanElement
     | StripeIdealBankElement
     | StripeP24BankElement
-    | StripePaymentRequestButtonElement;
+    | StripePaymentRequestButtonElement
+    | StripeAfterpayClearpayMessageElement;
 
   type StripeElementLocale =
     | 'auto'
@@ -253,14 +271,21 @@ declare module '@stripe/stripe-js' {
     | 'de'
     | 'el'
     | 'en'
+    | 'en-AU'
+    | 'en-CA'
+    | 'en-NZ'
+    | 'en-GB'
     | 'es'
+    | 'es-ES'
     | 'es-419'
     | 'et'
     | 'fi'
     | 'fr'
+    | 'fr-FR'
     | 'he'
     | 'id'
     | 'it'
+    | 'it-IT'
     | 'ja'
     | 'lt'
     | 'lv'

--- a/types/stripe-js/elements/afterpay-clearpay-message.d.ts
+++ b/types/stripe-js/elements/afterpay-clearpay-message.d.ts
@@ -1,0 +1,121 @@
+declare module '@stripe/stripe-js' {
+  type StripeAfterpayClearpayMessageElement = {
+    /**
+     * The `element.mount` method attaches your [Element](https://stripe.com/docs/js/element) to the DOM.
+     * `element.mount` accepts either a CSS Selector (e.g., `'#afterpay-clearpay-message'`) or a DOM element.
+     */
+    mount(domElement: string | HTMLElement): void;
+
+    /**
+     * Removes the element from the DOM and destroys it.
+     * A destroyed element can not be re-activated or re-mounted to the DOM.
+     */
+    destroy(): void;
+
+    /**
+     * Unmounts the element from the DOM.
+     * Call `element.mount` to re-attach it to the DOM.
+     */
+    unmount(): void;
+
+    /**
+     * Updates the options the `AfterpayClearpayMessageElement` was initialized with.
+     * Updates are merged into the existing configuration.
+     */
+    update(options: Partial<StripeAfterpayClearpayMessageElementOptions>): void;
+
+    /**
+     * Triggered when the element is fully loaded and ready to perform method calls.
+     */
+    on(
+      eventType: 'ready',
+      handler: () => any
+    ): StripeAfterpayClearpayMessageElement;
+  };
+
+  interface StripeAfterpayClearpayMessageElementOptions {
+    /**
+     * The total amount, divided into 4 installments, in the smallest currency unit.
+     */
+    amount: number;
+
+    /**
+     * The currency to display.
+     */
+    currency: 'USD' | 'AUD' | 'CAD' | 'GBP' | 'NZD' | 'EUR';
+
+    /**
+     * The badge color theme, applied when `logoType` is set to badge.
+     */
+    badgeTheme?:
+      | 'black-on-mint'
+      | 'black-on-white'
+      | 'mint-on-black'
+      | 'white-on-black';
+
+    /**
+     * The leading text for the mesage.
+     */
+    introText?: 'In' | 'in' | 'Or' | 'or' | 'Pay' | 'pay' | 'Pay in' | 'pay in';
+
+    /**
+     * Indicates whether an item is eligible for purchase with Afterpay Clearpay.
+     */
+    isEligible?: boolean;
+
+    /**
+     * Indicates whether an entire cart is eligible for purchase with Afterpay Clearpay.
+     */
+    isCartEligible?: boolean;
+
+    /**
+     * The lockup color theme, applied when `logoType` is set to lockup.
+     */
+    lockupTheme?: 'black' | 'white' | 'mint';
+
+    /**
+     * The logo style to display.
+     */
+    logoType?: 'badge' | 'lockup';
+
+    /**
+     * The maximum `amount` allowed for a purchase. This should match the limit defined in your Stripe dashboard.
+     */
+    max?: number;
+
+    /**
+     * The minimum `amount` allowed for a purchase. This should match the limit defined in your Stripe dashboard.
+     */
+    min?: number;
+
+    /**
+     * The style of modal link to display.
+     */
+    modalLinkStyle?: 'circled-info-icon' | 'learn-more-text' | 'more-info-text';
+
+    /**
+     * The background color for the info modal.
+     */
+    modalTheme?: 'mint' | 'white';
+
+    /**
+     * Determines whether 'interest-free' is displayed in the message.
+     */
+    showInterestFree?: boolean;
+
+    /**
+     * Determines whether 'with' is displayed before the logo.
+     */
+    showLowerLimit?: boolean;
+
+    /**
+     * Determines whether the lower limit is displayed when `amount` exceeds price limits.
+     */
+    showUpperLimit?: boolean;
+
+    /**
+     * Determines whether the upper limit is displayed when `amount` exceeds price limits.
+     */
+    showWith?: boolean;
+  }
+}


### PR DESCRIPTION
### Summary & motivation
Added type support for the new `afterpayClearpayMessage` Element.
<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
Unit tests were added to cover the new types.
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
