### PR TITLE
improve api responses to allow narrowing

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -328,6 +328,22 @@ stripe
     console.log(token);
   });
 
+stripe.createToken(cardElement).then(({token, error}) => {
+  if (token) {
+    console.log(token.type);
+  } else if (error) {
+    console.log(error.code);
+  }
+});
+
+stripe.createToken(cardElement).then((res) => {
+  if (res.token) {
+    console.log(res.token.type);
+  } else {
+    console.log(res.error.code);
+  }
+});
+
 stripe.createToken(cardNumberElement);
 
 stripe.createToken('cvc_update', cardCvcElement);
@@ -560,6 +576,22 @@ stripe.retrieveSource({id: '', client_secret: ''}).then((result) => {
   console.log(result.source!.type);
 });
 
+stripe.retrieveSource({id: '', client_secret: ''}).then(({source, error}) => {
+  if (source) {
+    console.log(source.type);
+  } else if (error) {
+    console.log(error.code);
+  }
+});
+
+stripe.retrieveSource({id: '', client_secret: ''}).then((res) => {
+  if (res.source) {
+    console.log(res.source.type);
+  } else {
+    console.log(res.error.code);
+  }
+});
+
 stripe
   .confirmAlipayPayment('', {
     payment_method: '',
@@ -656,6 +688,23 @@ stripe
 stripe
   .confirmCardPayment('')
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe.confirmCardPayment('').then(({paymentIntent, error}) => {
+  if (paymentIntent) {
+    console.log(paymentIntent.id);
+  } else if (error) {
+    console.log(error.code);
+  }
+});
+
+stripe.confirmCardPayment('').then((res) => {
+  if (res.paymentIntent) {
+    console.log(res.paymentIntent.id);
+  } else {
+    console.log(res.error.code);
+  }
+});
+
 
 stripe
   .confirmEpsPayment('', {
@@ -945,6 +994,28 @@ stripe
   });
 
 stripe.createPaymentMethod({
+    type: 'card',
+    card: cardElement,
+  }).then(({paymentMethod, error}) => {
+  if (paymentMethod) {
+    console.log(paymentMethod.id);
+  } else if (error) {
+    console.log(error.code);
+  }
+});
+
+stripe.createPaymentMethod({
+    type: 'card',
+    card: cardElement,
+  }).then((res) => {
+  if (res.paymentMethod) {
+    console.log(res.paymentMethod.id);
+  } else {
+    console.log(res.error.code);
+  }
+});
+
+stripe.createPaymentMethod({
   type: 'fpx',
   fpx: fpxBankElement,
 });
@@ -1079,6 +1150,22 @@ stripe
 stripe
   .confirmCardSetup('')
   .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
+
+stripe.confirmCardSetup('').then(({setupIntent, error}) => {
+  if (setupIntent) {
+    console.log(setupIntent.id);
+  } else if (error) {
+    console.log(error.code);
+  }
+});
+
+stripe.confirmCardSetup('').then((res) => {
+  if (res.setupIntent) {
+    console.log(res.setupIntent.id);
+  } else {
+    console.log(res.error.code);
+  }
+});
 
 stripe
   .confirmIdealSetup('', {

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -329,18 +329,18 @@ stripe
   });
 
 stripe.createToken(cardElement).then(({token, error}) => {
-  if (token) {
-    console.log(token.type);
-  } else if (error) {
+  if (error) {
     console.log(error.code);
+  } else if (token) {
+    console.log(token.id);
   }
 });
 
 stripe.createToken(cardElement).then((res) => {
-  if (res.token) {
-    console.log(res.token.type);
-  } else {
+  if (res.error) {
     console.log(res.error.code);
+  } else {
+    console.log(res.token.id);
   }
 });
 
@@ -577,18 +577,18 @@ stripe.retrieveSource({id: '', client_secret: ''}).then((result) => {
 });
 
 stripe.retrieveSource({id: '', client_secret: ''}).then(({source, error}) => {
-  if (source) {
-    console.log(source.type);
-  } else if (error) {
+  if (error) {
     console.log(error.code);
+  } else if (source) {
+    console.log(source.id);
   }
 });
 
 stripe.retrieveSource({id: '', client_secret: ''}).then((res) => {
-  if (res.source) {
-    console.log(res.source.type);
-  } else {
+  if (res.error) {
     console.log(res.error.code);
+  } else {
+    console.log(res.source.id);
   }
 });
 
@@ -690,18 +690,18 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe.confirmCardPayment('').then(({paymentIntent, error}) => {
-  if (paymentIntent) {
-    console.log(paymentIntent.id);
-  } else if (error) {
+  if (error) {
     console.log(error.code);
+  } else if (paymentIntent) {
+    console.log(paymentIntent.id);
   }
 });
 
 stripe.confirmCardPayment('').then((res) => {
-  if (res.paymentIntent) {
-    console.log(res.paymentIntent.id);
-  } else {
+  if (res.error) {
     console.log(res.error.code);
+  } else {
+    console.log(res.paymentIntent.id);
   }
 });
 
@@ -998,10 +998,10 @@ stripe
     card: cardElement,
   })
   .then(({paymentMethod, error}) => {
-    if (paymentMethod) {
-      console.log(paymentMethod.id);
-    } else if (error) {
+    if (error) {
       console.log(error.code);
+    } else if (paymentMethod) {
+      console.log(paymentMethod.id);
     }
   });
 
@@ -1011,10 +1011,10 @@ stripe
     card: cardElement,
   })
   .then((res) => {
-    if (res.paymentMethod) {
-      console.log(res.paymentMethod.id);
-    } else {
+    if (res.error) {
       console.log(res.error.code);
+    } else {
+      console.log(res.paymentMethod.id);
     }
   });
 
@@ -1155,18 +1155,18 @@ stripe
   .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
 
 stripe.confirmCardSetup('').then(({setupIntent, error}) => {
-  if (setupIntent) {
-    console.log(setupIntent.id);
-  } else if (error) {
+  if (error) {
     console.log(error.code);
+  } else if (setupIntent) {
+    console.log(setupIntent.id);
   }
 });
 
 stripe.confirmCardSetup('').then((res) => {
-  if (res.setupIntent) {
-    console.log(res.setupIntent.id);
-  } else {
+  if (res.error) {
     console.log(res.error.code);
+  } else {
+    console.log(res.setupIntent.id);
   }
 });
 

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -705,7 +705,6 @@ stripe.confirmCardPayment('').then((res) => {
   }
 });
 
-
 stripe
   .confirmEpsPayment('', {
     payment_method: {
@@ -993,27 +992,31 @@ stripe
     }
   });
 
-stripe.createPaymentMethod({
+stripe
+  .createPaymentMethod({
     type: 'card',
     card: cardElement,
-  }).then(({paymentMethod, error}) => {
-  if (paymentMethod) {
-    console.log(paymentMethod.id);
-  } else if (error) {
-    console.log(error.code);
-  }
-});
+  })
+  .then(({paymentMethod, error}) => {
+    if (paymentMethod) {
+      console.log(paymentMethod.id);
+    } else if (error) {
+      console.log(error.code);
+    }
+  });
 
-stripe.createPaymentMethod({
+stripe
+  .createPaymentMethod({
     type: 'card',
     card: cardElement,
-  }).then((res) => {
-  if (res.paymentMethod) {
-    console.log(res.paymentMethod.id);
-  } else {
-    console.log(res.error.code);
-  }
-});
+  })
+  .then((res) => {
+    if (res.paymentMethod) {
+      console.log(res.paymentMethod.id);
+    } else {
+      console.log(res.error.code);
+    }
+  });
 
 stripe.createPaymentMethod({
   type: 'fpx',

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -55,7 +55,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmAlipayPaymentData,
       options?: ConfirmAlipayPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Requires beta access:
@@ -75,7 +75,7 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitPayment(
       clientSecret: string,
       data?: ConfirmAuBecsDebitPaymentData
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmBancontactPayment` in the [Bancontact Payments with Payment Methods](https://stripe.com/docs/payments/bancontact#web) flow when the customer submits your payment form.
@@ -92,7 +92,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmBancontactPaymentData,
       options?: ConfirmBancontactPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmCardPayment` when the customer submits your payment form.
@@ -110,7 +110,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardPaymentData,
       options?: ConfirmCardPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmEpsPayment` in the [EPS Payments with Payment Methods](https://stripe.com/docs/payments/eps#web) flow when the customer submits your payment form.
@@ -127,7 +127,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmEpsPaymentData,
       options?: ConfirmEpsPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmFpxPayment` in the [FPX Payments with Payment Methods](https://stripe.com/docs/payments/fpx#web) flow when the customer submits your payment form.
@@ -144,7 +144,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmFpxPaymentData,
       options?: ConfirmFpxPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmGiropayPayment` in the [giropay Payments with Payment Methods](https://stripe.com/docs/payments/giropay#web) flow when the customer submits your payment form.
@@ -161,7 +161,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGiropayPaymentData,
       options?: ConfirmGiropayPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmGrabPayPayment` in the [GrabPay payments](https://stripe.com/docs/payments/grabpay) flow when the customer submits your payment form.
@@ -175,7 +175,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGrabPayPaymentData,
       options?: ConfirmGrabPayPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmIdealPayment` in the [iDEAL Payments with Payment Methods](https://stripe.com/docs/payments/ideal) flow when the customer submits your payment form.
@@ -192,7 +192,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmIdealPaymentData,
       options?: ConfirmIdealPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmOxxoPayment` in the [OXXO Payment](https://stripe.com/docs/payments/oxxo) with Payment Methods flow when the customer submits your payment form.
@@ -210,7 +210,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmOxxoPaymentData,
       options?: ConfirmOxxoPaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmP24Payment` in the [Przelewy24 Payments with Payment Methods](https://stripe.com/docs/payments/p24#web) flow when the customer submits your payment form.
@@ -227,7 +227,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmP24PaymentData,
       options?: ConfirmP24PaymentOptions
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmSepaDebitPayment` in the [SEPA Direct Debit Payments](https://stripe.com/docs/payments/sepa-debit) with Payment Methods flow when the customer submits your payment form.
@@ -244,7 +244,7 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitPayment(
       clientSecret: string,
       data?: ConfirmSepaDebitPaymentData
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.confirmSofortPayment` in the [Sofort Payments with Payment Methods](https://stripe.com/docs/payments/sofort) flow when the customer submits your payment form.
@@ -260,7 +260,7 @@ declare module '@stripe/stripe-js' {
     confirmSofortPayment(
       clientSecret: string,
       data?: ConfirmSofortPaymentData
-    ): PaymentIntentResponse;
+    ): Promise<PaymentIntentResult>;
 
     /**
      * Use `stripe.handleCardAction` in the Payment Intents API [manual confirmation](https://stripe.com/docs/payments/payment-intents/web-manual) flow to handle a [PaymentIntent](https://stripe.com/docs/api/payment_intents) with the `requires_action` status.
@@ -276,7 +276,7 @@ declare module '@stripe/stripe-js' {
      *
      * @docs https://stripe.com/docs/js/payment_intents/handle_card_action
      */
-    handleCardAction(clientSecret: string): PaymentIntentResponse;
+    handleCardAction(clientSecret: string): Promise<PaymentIntentResult>;
 
     /**
      * Use stripe.createPaymentMethod to convert payment information collected by elements into a [PaymentMethod](https://stripe.com/docs/api/payment_methods) object that you safely pass to your server to use in an API call.
@@ -285,14 +285,14 @@ declare module '@stripe/stripe-js' {
      */
     createPaymentMethod(
       paymentMethodData: CreatePaymentMethodData
-    ): PaymentMethodResponse;
+    ): Promise<PaymentMethodResult>;
 
     /**
      * Retrieve a [PaymentIntent](https://stripe.com/docs/api/payment_intents) using its [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret).
      *
      * @docs https://stripe.com/docs/js/payment_intents/retrieve_payment_intent
      */
-    retrievePaymentIntent(clientSecret: string): PaymentIntentResponse;
+    retrievePaymentIntent(clientSecret: string): Promise<PaymentIntentResult>;
 
     /////////////////////////////
     /// Setup Intents
@@ -318,7 +318,7 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitSetup(
       clientSecret: string,
       data?: ConfirmAuBecsDebitSetupData
-    ): SetupIntentResponse;
+    ): Promise<SetupIntentResult>;
 
     /**
      * Use `stripe.confirmBacsDebitSetup` in the [Bacs Direct Debit Payments](https://stripe.com/docs/payments/payment-methods/bacs-debit) flow when the customer submits your payment form.
@@ -335,7 +335,7 @@ declare module '@stripe/stripe-js' {
     confirmBacsDebitSetup(
       clientSecret: string,
       data?: ConfirmBacsDebitSetupData
-    ): SetupIntentResponse;
+    ): Promise<SetupIntentResult>;
 
     /**
      * Use `stripe.confirmBancontactSetup` in the [Set up future payments](https://stripe.com/docs/payments/bancontact/set-up-payment) flow to use Bancontact bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -353,7 +353,7 @@ declare module '@stripe/stripe-js' {
     confirmBancontactSetup(
       clientSecret: string,
       data?: ConfirmBancontactSetupData
-    ): SetupIntentResponse;
+    ): Promise<SetupIntentResult>;
 
     /**
      * Use `stripe.confirmCardSetup` in the [Setup Intents API flow](https://stripe.com/docs/payments/save-and-reuse) when the customer submits your payment form.
@@ -369,7 +369,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardSetupData,
       options?: ConfirmCardSetupOptions
-    ): SetupIntentResponse;
+    ): Promise<SetupIntentResult>;
 
     /**
      * Use `stripe.confirmIdealSetup` in the [Set up future payments](https://stripe.com/docs/payments/ideal/set-up-payment) flow to use iDEAL bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -387,7 +387,7 @@ declare module '@stripe/stripe-js' {
     confirmIdealSetup(
       clientSecret: string,
       data?: ConfirmIdealSetupData
-    ): SetupIntentResponse;
+    ): Promise<SetupIntentResult>;
 
     /**
      * Use `stripe.confirmSepaDebitSetup` in the [SEPA Direct Debit with Setup Intents](https://stripe.com/docs/payments/sepa-debit-setup-intents) flow when the customer submits your payment form.
@@ -404,7 +404,7 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitSetup(
       clientSecret: string,
       data?: ConfirmSepaDebitSetupData
-    ): SetupIntentResponse;
+    ): Promise<SetupIntentResult>;
 
     /*
      * Use `stripe.confirmSofortSetup` in the [Set up future payments](https://stripe.com/docs/payments/sofort/set-up-payment) flow to use SOFORT bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -420,14 +420,14 @@ declare module '@stripe/stripe-js' {
     confirmSofortSetup(
       clientSecret: string,
       data?: ConfirmSofortSetupData
-    ): SetupIntentResponse;
+    ): Promise<SetupIntentResult>;
 
     /**
      * Retrieve a [SetupIntent](https://stripe.com/docs/api/setup_intents) using its client secret.
      *
      * @docs https://stripe.com/docs/js/setup_intents/retrieve_setup_intent
      */
-    retrieveSetupIntent(clientSecret: string): SetupIntentResponse;
+    retrieveSetupIntent(clientSecret: string): Promise<SetupIntentResult>;
 
     /////////////////////////////
     /// Payment Request
@@ -457,7 +457,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeIbanElement,
       data: CreateTokenIbanData
-    ): TokenResponse;
+    ): Promise<TokenResult>;
 
     /**
      * Use `stripe.createToken` to convert information collected by card elements into a single-use [Token](https://stripe.com/docs/api#tokens) that you safely pass to your server to use in an API call.
@@ -467,14 +467,17 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeCardElement | StripeCardNumberElement,
       data?: CreateTokenCardData
-    ): TokenResponse;
+    ): Promise<TokenResult>;
 
     /**
      * Use `stripe.createToken` to convert personally identifiable information (PII) into a single-use [Token](https://stripe.com/docs/api#tokens) for account identity verification.
      *
      * @docs https://stripe.com/docs/js/tokens_sources/create_token?type=pii
      */
-    createToken(tokenType: 'pii', data: CreateTokenPiiData): TokenResponse;
+    createToken(
+      tokenType: 'pii',
+      data: CreateTokenPiiData
+    ): Promise<TokenResult>;
 
     /**
      * Use `stripe.createToken` to convert bank account information into a single-use token that you safely pass to your server to use in an API call.
@@ -484,7 +487,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'bank_account',
       data: CreateTokenBankAccountData
-    ): TokenResponse;
+    ): Promise<TokenResult>;
 
     /**
      * Use `stripe.createToken` to tokenize the recollected CVC for a saved card.
@@ -497,7 +500,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'cvc_update',
       element: StripeCardCvcElement
-    ): TokenResponse;
+    ): Promise<TokenResult>;
 
     /**
      * Use `stripe.createToken` to create a single-use token that wraps a user’s legal entity information.
@@ -507,7 +510,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'account',
       data: TokenCreateParams.Account
-    ): TokenResponse;
+    ): Promise<TokenResult>;
 
     /**
      * Use `stripe.createToken` to create a single-use token that represents the details for a person.
@@ -517,7 +520,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'person',
       data: TokenCreateParams.Person
-    ): TokenResponse;
+    ): Promise<TokenResult>;
 
     /**
      * Use `stripe.createSource` to convert payment information collected by elements into a `Source` object that you safely pass to your server to use in an API call.
@@ -526,45 +529,41 @@ declare module '@stripe/stripe-js' {
     createSource(
       element: StripeElement,
       sourceData: CreateSourceData
-    ): SourceResponse;
+    ): Promise<SourceResult>;
 
     /**
      * Use `stripe.createSource` to convert raw payment information into a `Source` object that you safely pass to your server to use in an API call.
      * See the [Sources documentation](https://stripe.com/docs/sources) for more information about sources.
      */
-    createSource(sourceData: CreateSourceData): SourceResponse;
+    createSource(sourceData: CreateSourceData): Promise<SourceResult>;
 
     /**
      * Retrieve a [Source](https://stripe.com/docs/api#sources) using its unique ID and client secret.
      *
      * @docs https://stripe.com/docs/js/tokens_sources/retrieve_source
      */
-    retrieveSource(source: RetrieveSourceParam): SourceResponse;
+    retrieveSource(source: RetrieveSourceParam): Promise<SourceResult>;
   }
 
-  type PaymentIntentResponse = Promise<
+  type PaymentIntentResult =
     | {paymentIntent: PaymentIntent; error?: undefined}
-    | {paymentIntent?: undefined; error: StripeError}
-  >;
+    | {paymentIntent?: undefined; error: StripeError};
 
-  type SetupIntentResponse = Promise<
+  type SetupIntentResult =
     | {setupIntent: SetupIntent; error?: undefined}
-    | {setupIntent?: undefined; error: StripeError}
-  >;
+    | {setupIntent?: undefined; error: StripeError};
 
-  type PaymentMethodResponse = Promise<
+  type PaymentMethodResult =
     | {paymentMethod: PaymentMethod; error?: undefined}
-    | {paymentMethod?: undefined; error: StripeError}
-  >;
+    | {paymentMethod?: undefined; error: StripeError};
 
-  type SourceResponse = Promise<
+  type SourceResult =
     | {source: Source; error?: undefined}
-    | {source?: undefined; error: StripeError}
-  >;
+    | {source?: undefined; error: StripeError};
 
-  type TokenResponse = Promise<
-    {token: Token; error?: undefined} | {token?: undefined; error: StripeError}
-  >;
+  type TokenResult =
+    | {token: Token; error?: undefined}
+    | {token?: undefined; error: StripeError};
 
   /**
    * Use `Stripe(publishableKey, options?)` to create an instance of the `Stripe` object.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -55,10 +55,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmAlipayPaymentData,
       options?: ConfirmAlipayPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Requires beta access:
@@ -78,10 +75,7 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitPayment(
       clientSecret: string,
       data?: ConfirmAuBecsDebitPaymentData
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmBancontactPayment` in the [Bancontact Payments with Payment Methods](https://stripe.com/docs/payments/bancontact#web) flow when the customer submits your payment form.
@@ -98,10 +92,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmBancontactPaymentData,
       options?: ConfirmBancontactPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmCardPayment` when the customer submits your payment form.
@@ -119,10 +110,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardPaymentData,
       options?: ConfirmCardPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmEpsPayment` in the [EPS Payments with Payment Methods](https://stripe.com/docs/payments/eps#web) flow when the customer submits your payment form.
@@ -139,10 +127,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmEpsPaymentData,
       options?: ConfirmEpsPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmFpxPayment` in the [FPX Payments with Payment Methods](https://stripe.com/docs/payments/fpx#web) flow when the customer submits your payment form.
@@ -159,10 +144,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmFpxPaymentData,
       options?: ConfirmFpxPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmGiropayPayment` in the [giropay Payments with Payment Methods](https://stripe.com/docs/payments/giropay#web) flow when the customer submits your payment form.
@@ -179,10 +161,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGiropayPaymentData,
       options?: ConfirmGiropayPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmGrabPayPayment` in the [GrabPay payments](https://stripe.com/docs/payments/grabpay) flow when the customer submits your payment form.
@@ -196,10 +175,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGrabPayPaymentData,
       options?: ConfirmGrabPayPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmIdealPayment` in the [iDEAL Payments with Payment Methods](https://stripe.com/docs/payments/ideal) flow when the customer submits your payment form.
@@ -216,10 +192,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmIdealPaymentData,
       options?: ConfirmIdealPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmOxxoPayment` in the [OXXO Payment](https://stripe.com/docs/payments/oxxo) with Payment Methods flow when the customer submits your payment form.
@@ -237,10 +210,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmOxxoPaymentData,
       options?: ConfirmOxxoPaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmP24Payment` in the [Przelewy24 Payments with Payment Methods](https://stripe.com/docs/payments/p24#web) flow when the customer submits your payment form.
@@ -257,10 +227,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmP24PaymentData,
       options?: ConfirmP24PaymentOptions
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmSepaDebitPayment` in the [SEPA Direct Debit Payments](https://stripe.com/docs/payments/sepa-debit) with Payment Methods flow when the customer submits your payment form.
@@ -277,10 +244,7 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitPayment(
       clientSecret: string,
       data?: ConfirmSepaDebitPaymentData
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.confirmSofortPayment` in the [Sofort Payments with Payment Methods](https://stripe.com/docs/payments/sofort) flow when the customer submits your payment form.
@@ -296,10 +260,7 @@ declare module '@stripe/stripe-js' {
     confirmSofortPayment(
       clientSecret: string,
       data?: ConfirmSofortPaymentData
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    ): PaymentIntentResponse;
 
     /**
      * Use `stripe.handleCardAction` in the Payment Intents API [manual confirmation](https://stripe.com/docs/payments/payment-intents/web-manual) flow to handle a [PaymentIntent](https://stripe.com/docs/api/payment_intents) with the `requires_action` status.
@@ -315,12 +276,7 @@ declare module '@stripe/stripe-js' {
      *
      * @docs https://stripe.com/docs/js/payment_intents/handle_card_action
      */
-    handleCardAction(
-      clientSecret: string
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    handleCardAction(clientSecret: string): PaymentIntentResponse;
 
     /**
      * Use stripe.createPaymentMethod to convert payment information collected by elements into a [PaymentMethod](https://stripe.com/docs/api/payment_methods) object that you safely pass to your server to use in an API call.
@@ -329,22 +285,14 @@ declare module '@stripe/stripe-js' {
      */
     createPaymentMethod(
       paymentMethodData: CreatePaymentMethodData
-    ): Promise<
-      | {paymentMethod: PaymentMethod; error?: undefined}
-      | {paymentMethod?: undefined; error: StripeError}
-    >;
+    ): PaymentMethodResponse;
 
     /**
      * Retrieve a [PaymentIntent](https://stripe.com/docs/api/payment_intents) using its [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret).
      *
      * @docs https://stripe.com/docs/js/payment_intents/retrieve_payment_intent
      */
-    retrievePaymentIntent(
-      clientSecret: string
-    ): Promise<
-      | {paymentIntent: PaymentIntent; error?: undefined}
-      | {paymentIntent?: undefined; error: StripeError}
-    >;
+    retrievePaymentIntent(clientSecret: string): PaymentIntentResponse;
 
     /////////////////////////////
     /// Setup Intents
@@ -370,10 +318,7 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitSetup(
       clientSecret: string,
       data?: ConfirmAuBecsDebitSetupData
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    ): SetupIntentResponse;
 
     /**
      * Use `stripe.confirmBacsDebitSetup` in the [Bacs Direct Debit Payments](https://stripe.com/docs/payments/payment-methods/bacs-debit) flow when the customer submits your payment form.
@@ -390,10 +335,7 @@ declare module '@stripe/stripe-js' {
     confirmBacsDebitSetup(
       clientSecret: string,
       data?: ConfirmBacsDebitSetupData
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    ): SetupIntentResponse;
 
     /**
      * Use `stripe.confirmBancontactSetup` in the [Set up future payments](https://stripe.com/docs/payments/bancontact/set-up-payment) flow to use Bancontact bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -411,10 +353,7 @@ declare module '@stripe/stripe-js' {
     confirmBancontactSetup(
       clientSecret: string,
       data?: ConfirmBancontactSetupData
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    ): SetupIntentResponse;
 
     /**
      * Use `stripe.confirmCardSetup` in the [Setup Intents API flow](https://stripe.com/docs/payments/save-and-reuse) when the customer submits your payment form.
@@ -430,10 +369,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardSetupData,
       options?: ConfirmCardSetupOptions
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    ): SetupIntentResponse;
 
     /**
      * Use `stripe.confirmIdealSetup` in the [Set up future payments](https://stripe.com/docs/payments/ideal/set-up-payment) flow to use iDEAL bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -451,10 +387,7 @@ declare module '@stripe/stripe-js' {
     confirmIdealSetup(
       clientSecret: string,
       data?: ConfirmIdealSetupData
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    ): SetupIntentResponse;
 
     /**
      * Use `stripe.confirmSepaDebitSetup` in the [SEPA Direct Debit with Setup Intents](https://stripe.com/docs/payments/sepa-debit-setup-intents) flow when the customer submits your payment form.
@@ -471,10 +404,7 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitSetup(
       clientSecret: string,
       data?: ConfirmSepaDebitSetupData
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    ): SetupIntentResponse;
 
     /*
      * Use `stripe.confirmSofortSetup` in the [Set up future payments](https://stripe.com/docs/payments/sofort/set-up-payment) flow to use SOFORT bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -490,22 +420,14 @@ declare module '@stripe/stripe-js' {
     confirmSofortSetup(
       clientSecret: string,
       data?: ConfirmSofortSetupData
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    ): SetupIntentResponse;
 
     /**
      * Retrieve a [SetupIntent](https://stripe.com/docs/api/setup_intents) using its client secret.
      *
      * @docs https://stripe.com/docs/js/setup_intents/retrieve_setup_intent
      */
-    retrieveSetupIntent(
-      clientSecret: string
-    ): Promise<
-      | {setupIntent: SetupIntent; error?: undefined}
-      | {setupIntent?: undefined; error: StripeError}
-    >;
+    retrieveSetupIntent(clientSecret: string): SetupIntentResponse;
 
     /////////////////////////////
     /// Payment Request
@@ -535,10 +457,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeIbanElement,
       data: CreateTokenIbanData
-    ): Promise<
-      | {token: Token; error?: undefined}
-      | {token?: undefined; error: StripeError}
-    >;
+    ): TokenResponse;
 
     /**
      * Use `stripe.createToken` to convert information collected by card elements into a single-use [Token](https://stripe.com/docs/api#tokens) that you safely pass to your server to use in an API call.
@@ -548,23 +467,14 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeCardElement | StripeCardNumberElement,
       data?: CreateTokenCardData
-    ): Promise<
-      | {token: Token; error?: undefined}
-      | {token?: undefined; error: StripeError}
-    >;
+    ): TokenResponse;
 
     /**
      * Use `stripe.createToken` to convert personally identifiable information (PII) into a single-use [Token](https://stripe.com/docs/api#tokens) for account identity verification.
      *
      * @docs https://stripe.com/docs/js/tokens_sources/create_token?type=pii
      */
-    createToken(
-      tokenType: 'pii',
-      data: CreateTokenPiiData
-    ): Promise<
-      | {token: Token; error?: undefined}
-      | {token?: undefined; error: StripeError}
-    >;
+    createToken(tokenType: 'pii', data: CreateTokenPiiData): TokenResponse;
 
     /**
      * Use `stripe.createToken` to convert bank account information into a single-use token that you safely pass to your server to use in an API call.
@@ -574,10 +484,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'bank_account',
       data: CreateTokenBankAccountData
-    ): Promise<
-      | {token: Token; error?: undefined}
-      | {token?: undefined; error: StripeError}
-    >;
+    ): TokenResponse;
 
     /**
      * Use `stripe.createToken` to tokenize the recollected CVC for a saved card.
@@ -590,10 +497,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'cvc_update',
       element: StripeCardCvcElement
-    ): Promise<
-      | {token: Token; error?: undefined}
-      | {token?: undefined; error: StripeError}
-    >;
+    ): TokenResponse;
 
     /**
      * Use `stripe.createToken` to create a single-use token that wraps a user’s legal entity information.
@@ -603,10 +507,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'account',
       data: TokenCreateParams.Account
-    ): Promise<
-      | {token: Token; error?: undefined}
-      | {token?: undefined; error: StripeError}
-    >;
+    ): TokenResponse;
 
     /**
      * Use `stripe.createToken` to create a single-use token that represents the details for a person.
@@ -616,10 +517,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'person',
       data: TokenCreateParams.Person
-    ): Promise<
-      | {token: Token; error?: undefined}
-      | {token?: undefined; error: StripeError}
-    >;
+    ): TokenResponse;
 
     /**
      * Use `stripe.createSource` to convert payment information collected by elements into a `Source` object that you safely pass to your server to use in an API call.
@@ -628,34 +526,45 @@ declare module '@stripe/stripe-js' {
     createSource(
       element: StripeElement,
       sourceData: CreateSourceData
-    ): Promise<
-      | {source: Source; error?: undefined}
-      | {source?: undefined; error: StripeError}
-    >;
+    ): SourceResponse;
 
     /**
      * Use `stripe.createSource` to convert raw payment information into a `Source` object that you safely pass to your server to use in an API call.
      * See the [Sources documentation](https://stripe.com/docs/sources) for more information about sources.
      */
-    createSource(
-      sourceData: CreateSourceData
-    ): Promise<
-      | {source: Source; error?: undefined}
-      | {source?: undefined; error: StripeError}
-    >;
+    createSource(sourceData: CreateSourceData): SourceResponse;
 
     /**
      * Retrieve a [Source](https://stripe.com/docs/api#sources) using its unique ID and client secret.
      *
      * @docs https://stripe.com/docs/js/tokens_sources/retrieve_source
      */
-    retrieveSource(
-      source: RetrieveSourceParam
-    ): Promise<
-      | {source: Source; error?: undefined}
-      | {source?: undefined; error: StripeError}
-    >;
+    retrieveSource(source: RetrieveSourceParam): SourceResponse;
   }
+
+  type PaymentIntentResponse = Promise<
+    | {paymentIntent: PaymentIntent; error?: undefined}
+    | {paymentIntent?: undefined; error: StripeError}
+  >;
+
+  type SetupIntentResponse = Promise<
+    | {setupIntent: SetupIntent; error?: undefined}
+    | {setupIntent?: undefined; error: StripeError}
+  >;
+
+  type PaymentMethodResponse = Promise<
+    | {paymentMethod: PaymentMethod; error?: undefined}
+    | {paymentMethod?: undefined; error: StripeError}
+  >;
+
+  type SourceResponse = Promise<
+    | {source: Source; error?: undefined}
+    | {source?: undefined; error: StripeError}
+  >;
+
+  type TokenResponse = Promise<
+    {token: Token; error?: undefined} | {token?: undefined; error: StripeError}
+  >;
 
   /**
    * Use `Stripe(publishableKey, options?)` to create an instance of the `Stripe` object.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -55,7 +55,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmAlipayPaymentData,
       options?: ConfirmAlipayPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Requires beta access:
@@ -75,7 +78,10 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitPayment(
       clientSecret: string,
       data?: ConfirmAuBecsDebitPaymentData
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmBancontactPayment` in the [Bancontact Payments with Payment Methods](https://stripe.com/docs/payments/bancontact#web) flow when the customer submits your payment form.
@@ -92,7 +98,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmBancontactPaymentData,
       options?: ConfirmBancontactPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmCardPayment` when the customer submits your payment form.
@@ -110,7 +119,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardPaymentData,
       options?: ConfirmCardPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmEpsPayment` in the [EPS Payments with Payment Methods](https://stripe.com/docs/payments/eps#web) flow when the customer submits your payment form.
@@ -127,7 +139,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmEpsPaymentData,
       options?: ConfirmEpsPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmFpxPayment` in the [FPX Payments with Payment Methods](https://stripe.com/docs/payments/fpx#web) flow when the customer submits your payment form.
@@ -144,7 +159,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmFpxPaymentData,
       options?: ConfirmFpxPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmGiropayPayment` in the [giropay Payments with Payment Methods](https://stripe.com/docs/payments/giropay#web) flow when the customer submits your payment form.
@@ -161,7 +179,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGiropayPaymentData,
       options?: ConfirmGiropayPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmGrabPayPayment` in the [GrabPay payments](https://stripe.com/docs/payments/grabpay) flow when the customer submits your payment form.
@@ -175,7 +196,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGrabPayPaymentData,
       options?: ConfirmGrabPayPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmIdealPayment` in the [iDEAL Payments with Payment Methods](https://stripe.com/docs/payments/ideal) flow when the customer submits your payment form.
@@ -192,7 +216,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmIdealPaymentData,
       options?: ConfirmIdealPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmOxxoPayment` in the [OXXO Payment](https://stripe.com/docs/payments/oxxo) with Payment Methods flow when the customer submits your payment form.
@@ -210,7 +237,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmOxxoPaymentData,
       options?: ConfirmOxxoPaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmP24Payment` in the [Przelewy24 Payments with Payment Methods](https://stripe.com/docs/payments/p24#web) flow when the customer submits your payment form.
@@ -227,7 +257,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmP24PaymentData,
       options?: ConfirmP24PaymentOptions
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmSepaDebitPayment` in the [SEPA Direct Debit Payments](https://stripe.com/docs/payments/sepa-debit) with Payment Methods flow when the customer submits your payment form.
@@ -244,7 +277,10 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitPayment(
       clientSecret: string,
       data?: ConfirmSepaDebitPaymentData
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmSofortPayment` in the [Sofort Payments with Payment Methods](https://stripe.com/docs/payments/sofort) flow when the customer submits your payment form.
@@ -260,7 +296,10 @@ declare module '@stripe/stripe-js' {
     confirmSofortPayment(
       clientSecret: string,
       data?: ConfirmSofortPaymentData
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.handleCardAction` in the Payment Intents API [manual confirmation](https://stripe.com/docs/payments/payment-intents/web-manual) flow to handle a [PaymentIntent](https://stripe.com/docs/api/payment_intents) with the `requires_action` status.
@@ -278,7 +317,10 @@ declare module '@stripe/stripe-js' {
      */
     handleCardAction(
       clientSecret: string
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use stripe.createPaymentMethod to convert payment information collected by elements into a [PaymentMethod](https://stripe.com/docs/api/payment_methods) object that you safely pass to your server to use in an API call.
@@ -287,7 +329,10 @@ declare module '@stripe/stripe-js' {
      */
     createPaymentMethod(
       paymentMethodData: CreatePaymentMethodData
-    ): Promise<{paymentMethod: PaymentMethod; error?: undefined} | {paymentMethod?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentMethod: PaymentMethod; error?: undefined}
+      | {paymentMethod?: undefined; error: StripeError}
+    >;
 
     /**
      * Retrieve a [PaymentIntent](https://stripe.com/docs/api/payment_intents) using its [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret).
@@ -296,7 +341,10 @@ declare module '@stripe/stripe-js' {
      */
     retrievePaymentIntent(
       clientSecret: string
-    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {paymentIntent: PaymentIntent; error?: undefined}
+      | {paymentIntent?: undefined; error: StripeError}
+    >;
 
     /////////////////////////////
     /// Setup Intents
@@ -322,7 +370,10 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitSetup(
       clientSecret: string,
       data?: ConfirmAuBecsDebitSetupData
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmBacsDebitSetup` in the [Bacs Direct Debit Payments](https://stripe.com/docs/payments/payment-methods/bacs-debit) flow when the customer submits your payment form.
@@ -339,7 +390,10 @@ declare module '@stripe/stripe-js' {
     confirmBacsDebitSetup(
       clientSecret: string,
       data?: ConfirmBacsDebitSetupData
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmBancontactSetup` in the [Set up future payments](https://stripe.com/docs/payments/bancontact/set-up-payment) flow to use Bancontact bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -357,7 +411,10 @@ declare module '@stripe/stripe-js' {
     confirmBancontactSetup(
       clientSecret: string,
       data?: ConfirmBancontactSetupData
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmCardSetup` in the [Setup Intents API flow](https://stripe.com/docs/payments/save-and-reuse) when the customer submits your payment form.
@@ -373,7 +430,10 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardSetupData,
       options?: ConfirmCardSetupOptions
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmIdealSetup` in the [Set up future payments](https://stripe.com/docs/payments/ideal/set-up-payment) flow to use iDEAL bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -391,7 +451,10 @@ declare module '@stripe/stripe-js' {
     confirmIdealSetup(
       clientSecret: string,
       data?: ConfirmIdealSetupData
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.confirmSepaDebitSetup` in the [SEPA Direct Debit with Setup Intents](https://stripe.com/docs/payments/sepa-debit-setup-intents) flow when the customer submits your payment form.
@@ -408,7 +471,10 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitSetup(
       clientSecret: string,
       data?: ConfirmSepaDebitSetupData
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /*
      * Use `stripe.confirmSofortSetup` in the [Set up future payments](https://stripe.com/docs/payments/sofort/set-up-payment) flow to use SOFORT bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -424,7 +490,10 @@ declare module '@stripe/stripe-js' {
     confirmSofortSetup(
       clientSecret: string,
       data?: ConfirmSofortSetupData
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /**
      * Retrieve a [SetupIntent](https://stripe.com/docs/api/setup_intents) using its client secret.
@@ -433,7 +502,10 @@ declare module '@stripe/stripe-js' {
      */
     retrieveSetupIntent(
       clientSecret: string
-    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
+    ): Promise<
+      | {setupIntent: SetupIntent; error?: undefined}
+      | {setupIntent?: undefined; error: StripeError}
+    >;
 
     /////////////////////////////
     /// Payment Request
@@ -463,7 +535,10 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeIbanElement,
       data: CreateTokenIbanData
-    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
+    ): Promise<
+      | {token: Token; error?: undefined}
+      | {token?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createToken` to convert information collected by card elements into a single-use [Token](https://stripe.com/docs/api#tokens) that you safely pass to your server to use in an API call.
@@ -473,7 +548,10 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeCardElement | StripeCardNumberElement,
       data?: CreateTokenCardData
-    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
+    ): Promise<
+      | {token: Token; error?: undefined}
+      | {token?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createToken` to convert personally identifiable information (PII) into a single-use [Token](https://stripe.com/docs/api#tokens) for account identity verification.
@@ -483,7 +561,10 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'pii',
       data: CreateTokenPiiData
-    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
+    ): Promise<
+      | {token: Token; error?: undefined}
+      | {token?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createToken` to convert bank account information into a single-use token that you safely pass to your server to use in an API call.
@@ -493,7 +574,10 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'bank_account',
       data: CreateTokenBankAccountData
-    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
+    ): Promise<
+      | {token: Token; error?: undefined}
+      | {token?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createToken` to tokenize the recollected CVC for a saved card.
@@ -506,7 +590,10 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'cvc_update',
       element: StripeCardCvcElement
-    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
+    ): Promise<
+      | {token: Token; error?: undefined}
+      | {token?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createToken` to create a single-use token that wraps a user’s legal entity information.
@@ -516,7 +603,10 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'account',
       data: TokenCreateParams.Account
-    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
+    ): Promise<
+      | {token: Token; error?: undefined}
+      | {token?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createToken` to create a single-use token that represents the details for a person.
@@ -526,7 +616,10 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'person',
       data: TokenCreateParams.Person
-    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
+    ): Promise<
+      | {token: Token; error?: undefined}
+      | {token?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createSource` to convert payment information collected by elements into a `Source` object that you safely pass to your server to use in an API call.
@@ -535,7 +628,10 @@ declare module '@stripe/stripe-js' {
     createSource(
       element: StripeElement,
       sourceData: CreateSourceData
-    ): Promise<{source: Source; error?: undefined} | {source?: undefined; error: StripeError}>;
+    ): Promise<
+      | {source: Source; error?: undefined}
+      | {source?: undefined; error: StripeError}
+    >;
 
     /**
      * Use `stripe.createSource` to convert raw payment information into a `Source` object that you safely pass to your server to use in an API call.
@@ -543,7 +639,10 @@ declare module '@stripe/stripe-js' {
      */
     createSource(
       sourceData: CreateSourceData
-    ): Promise<{source: Source; error?: undefined} | {source?: undefined; error: StripeError}>;
+    ): Promise<
+      | {source: Source; error?: undefined}
+      | {source?: undefined; error: StripeError}
+    >;
 
     /**
      * Retrieve a [Source](https://stripe.com/docs/api#sources) using its unique ID and client secret.
@@ -552,7 +651,10 @@ declare module '@stripe/stripe-js' {
      */
     retrieveSource(
       source: RetrieveSourceParam
-    ): Promise<{source: Source; error?: undefined} | {source?: undefined; error: StripeError}>;
+    ): Promise<
+      | {source: Source; error?: undefined}
+      | {source?: undefined; error: StripeError}
+    >;
   }
 
   /**

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -55,7 +55,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmAlipayPaymentData,
       options?: ConfirmAlipayPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Requires beta access:
@@ -75,7 +75,7 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitPayment(
       clientSecret: string,
       data?: ConfirmAuBecsDebitPaymentData
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmBancontactPayment` in the [Bancontact Payments with Payment Methods](https://stripe.com/docs/payments/bancontact#web) flow when the customer submits your payment form.
@@ -92,7 +92,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmBancontactPaymentData,
       options?: ConfirmBancontactPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmCardPayment` when the customer submits your payment form.
@@ -110,7 +110,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardPaymentData,
       options?: ConfirmCardPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmEpsPayment` in the [EPS Payments with Payment Methods](https://stripe.com/docs/payments/eps#web) flow when the customer submits your payment form.
@@ -127,7 +127,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmEpsPaymentData,
       options?: ConfirmEpsPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmFpxPayment` in the [FPX Payments with Payment Methods](https://stripe.com/docs/payments/fpx#web) flow when the customer submits your payment form.
@@ -144,7 +144,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmFpxPaymentData,
       options?: ConfirmFpxPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmGiropayPayment` in the [giropay Payments with Payment Methods](https://stripe.com/docs/payments/giropay#web) flow when the customer submits your payment form.
@@ -161,7 +161,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGiropayPaymentData,
       options?: ConfirmGiropayPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmGrabPayPayment` in the [GrabPay payments](https://stripe.com/docs/payments/grabpay) flow when the customer submits your payment form.
@@ -175,7 +175,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmGrabPayPaymentData,
       options?: ConfirmGrabPayPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmIdealPayment` in the [iDEAL Payments with Payment Methods](https://stripe.com/docs/payments/ideal) flow when the customer submits your payment form.
@@ -192,7 +192,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmIdealPaymentData,
       options?: ConfirmIdealPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmOxxoPayment` in the [OXXO Payment](https://stripe.com/docs/payments/oxxo) with Payment Methods flow when the customer submits your payment form.
@@ -210,7 +210,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmOxxoPaymentData,
       options?: ConfirmOxxoPaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmP24Payment` in the [Przelewy24 Payments with Payment Methods](https://stripe.com/docs/payments/p24#web) flow when the customer submits your payment form.
@@ -227,7 +227,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmP24PaymentData,
       options?: ConfirmP24PaymentOptions
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmSepaDebitPayment` in the [SEPA Direct Debit Payments](https://stripe.com/docs/payments/sepa-debit) with Payment Methods flow when the customer submits your payment form.
@@ -244,7 +244,7 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitPayment(
       clientSecret: string,
       data?: ConfirmSepaDebitPaymentData
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmSofortPayment` in the [Sofort Payments with Payment Methods](https://stripe.com/docs/payments/sofort) flow when the customer submits your payment form.
@@ -260,7 +260,7 @@ declare module '@stripe/stripe-js' {
     confirmSofortPayment(
       clientSecret: string,
       data?: ConfirmSofortPaymentData
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.handleCardAction` in the Payment Intents API [manual confirmation](https://stripe.com/docs/payments/payment-intents/web-manual) flow to handle a [PaymentIntent](https://stripe.com/docs/api/payment_intents) with the `requires_action` status.
@@ -278,7 +278,7 @@ declare module '@stripe/stripe-js' {
      */
     handleCardAction(
       clientSecret: string
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /**
      * Use stripe.createPaymentMethod to convert payment information collected by elements into a [PaymentMethod](https://stripe.com/docs/api/payment_methods) object that you safely pass to your server to use in an API call.
@@ -287,7 +287,7 @@ declare module '@stripe/stripe-js' {
      */
     createPaymentMethod(
       paymentMethodData: CreatePaymentMethodData
-    ): Promise<{paymentMethod?: PaymentMethod; error?: StripeError}>;
+    ): Promise<{paymentMethod: PaymentMethod; error?: undefined} | {paymentMethod?: undefined; error: StripeError}>;
 
     /**
      * Retrieve a [PaymentIntent](https://stripe.com/docs/api/payment_intents) using its [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret).
@@ -296,7 +296,7 @@ declare module '@stripe/stripe-js' {
      */
     retrievePaymentIntent(
       clientSecret: string
-    ): Promise<{paymentIntent?: PaymentIntent; error?: StripeError}>;
+    ): Promise<{paymentIntent: PaymentIntent; error?: undefined} | {paymentIntent?: undefined; error: StripeError}>;
 
     /////////////////////////////
     /// Setup Intents
@@ -322,7 +322,7 @@ declare module '@stripe/stripe-js' {
     confirmAuBecsDebitSetup(
       clientSecret: string,
       data?: ConfirmAuBecsDebitSetupData
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmBacsDebitSetup` in the [Bacs Direct Debit Payments](https://stripe.com/docs/payments/payment-methods/bacs-debit) flow when the customer submits your payment form.
@@ -339,7 +339,7 @@ declare module '@stripe/stripe-js' {
     confirmBacsDebitSetup(
       clientSecret: string,
       data?: ConfirmBacsDebitSetupData
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmBancontactSetup` in the [Set up future payments](https://stripe.com/docs/payments/bancontact/set-up-payment) flow to use Bancontact bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -357,7 +357,7 @@ declare module '@stripe/stripe-js' {
     confirmBancontactSetup(
       clientSecret: string,
       data?: ConfirmBancontactSetupData
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmCardSetup` in the [Setup Intents API flow](https://stripe.com/docs/payments/save-and-reuse) when the customer submits your payment form.
@@ -373,7 +373,7 @@ declare module '@stripe/stripe-js' {
       clientSecret: string,
       data?: ConfirmCardSetupData,
       options?: ConfirmCardSetupOptions
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmIdealSetup` in the [Set up future payments](https://stripe.com/docs/payments/ideal/set-up-payment) flow to use iDEAL bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -391,7 +391,7 @@ declare module '@stripe/stripe-js' {
     confirmIdealSetup(
       clientSecret: string,
       data?: ConfirmIdealSetupData
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.confirmSepaDebitSetup` in the [SEPA Direct Debit with Setup Intents](https://stripe.com/docs/payments/sepa-debit-setup-intents) flow when the customer submits your payment form.
@@ -408,7 +408,7 @@ declare module '@stripe/stripe-js' {
     confirmSepaDebitSetup(
       clientSecret: string,
       data?: ConfirmSepaDebitSetupData
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /*
      * Use `stripe.confirmSofortSetup` in the [Set up future payments](https://stripe.com/docs/payments/sofort/set-up-payment) flow to use SOFORT bank details to set up a SEPA Direct Debit payment method for future payments.
@@ -424,7 +424,7 @@ declare module '@stripe/stripe-js' {
     confirmSofortSetup(
       clientSecret: string,
       data?: ConfirmSofortSetupData
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /**
      * Retrieve a [SetupIntent](https://stripe.com/docs/api/setup_intents) using its client secret.
@@ -433,7 +433,7 @@ declare module '@stripe/stripe-js' {
      */
     retrieveSetupIntent(
       clientSecret: string
-    ): Promise<{setupIntent?: SetupIntent; error?: StripeError}>;
+    ): Promise<{setupIntent: SetupIntent; error?: undefined} | {setupIntent?: undefined; error: StripeError}>;
 
     /////////////////////////////
     /// Payment Request
@@ -463,7 +463,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeIbanElement,
       data: CreateTokenIbanData
-    ): Promise<{token?: Token; error?: StripeError}>;
+    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createToken` to convert information collected by card elements into a single-use [Token](https://stripe.com/docs/api#tokens) that you safely pass to your server to use in an API call.
@@ -473,7 +473,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: StripeCardElement | StripeCardNumberElement,
       data?: CreateTokenCardData
-    ): Promise<{token?: Token; error?: StripeError}>;
+    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createToken` to convert personally identifiable information (PII) into a single-use [Token](https://stripe.com/docs/api#tokens) for account identity verification.
@@ -483,7 +483,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'pii',
       data: CreateTokenPiiData
-    ): Promise<{token?: Token; error?: StripeError}>;
+    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createToken` to convert bank account information into a single-use token that you safely pass to your server to use in an API call.
@@ -493,7 +493,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'bank_account',
       data: CreateTokenBankAccountData
-    ): Promise<{token?: Token; error?: StripeError}>;
+    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createToken` to tokenize the recollected CVC for a saved card.
@@ -506,7 +506,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'cvc_update',
       element: StripeCardCvcElement
-    ): Promise<{token?: Token; error?: StripeError}>;
+    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createToken` to create a single-use token that wraps a user’s legal entity information.
@@ -516,7 +516,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'account',
       data: TokenCreateParams.Account
-    ): Promise<{token?: Token; error?: StripeError}>;
+    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createToken` to create a single-use token that represents the details for a person.
@@ -526,7 +526,7 @@ declare module '@stripe/stripe-js' {
     createToken(
       tokenType: 'person',
       data: TokenCreateParams.Person
-    ): Promise<{token?: Token; error?: StripeError}>;
+    ): Promise<{token: Token; error?: undefined} | {token?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createSource` to convert payment information collected by elements into a `Source` object that you safely pass to your server to use in an API call.
@@ -535,7 +535,7 @@ declare module '@stripe/stripe-js' {
     createSource(
       element: StripeElement,
       sourceData: CreateSourceData
-    ): Promise<{source?: Source; error?: StripeError}>;
+    ): Promise<{source: Source; error?: undefined} | {source?: undefined; error: StripeError}>;
 
     /**
      * Use `stripe.createSource` to convert raw payment information into a `Source` object that you safely pass to your server to use in an API call.
@@ -543,7 +543,7 @@ declare module '@stripe/stripe-js' {
      */
     createSource(
       sourceData: CreateSourceData
-    ): Promise<{source?: Source; error?: StripeError}>;
+    ): Promise<{source: Source; error?: undefined} | {source?: undefined; error: StripeError}>;
 
     /**
      * Retrieve a [Source](https://stripe.com/docs/api#sources) using its unique ID and client secret.
@@ -552,7 +552,7 @@ declare module '@stripe/stripe-js' {
      */
     retrieveSource(
       source: RetrieveSourceParam
-    ): Promise<{source?: Source; error?: StripeError}>;
+    ): Promise<{source: Source; error?: undefined} | {source?: undefined; error: StripeError}>;
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation
This PR improves the return type of our API methods to allow [type narrowing](https://www.typescriptlang.org/docs/handbook/2/narrowing.html).

```ts
const res = await stripe.confirmCardPayment(clientSecret, data);

if (res.error) {
  console.log(res.error.code);
} else {
  // No need to make a redundant check for res.paymentIntent
  console.log(res.paymentIntent.id);
}
```

This PR does not break destructuring, which used to work and still does.
```ts
const {paymentIntent, error} = await stripe.confirmCardPayment(clientSecret, data);

if (error) {
  console.log(error.code);
} else if (paymentIntent) {
  // Still need to check for paymentIntent if you destructure the response
  console.log(paymentIntent.id);
}
```

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
I wrote type level tests.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
