### PR TITLE
Deprecate wallets and add disableWallets

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -211,7 +211,7 @@ const paymentRequestButtonElement = elements.create('paymentRequestButton', {
     total: {label: 'Demo total', amount: 1000},
     requestPayerName: true,
     requestPayerEmail: true,
-    wallets: ['applePay', 'browserCard'],
+    disableWallets: ['googlePay'],
   }),
 });
 

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -216,10 +216,6 @@ declare module '@stripe/stripe-js' {
     /**
      * An array of wallet strings.
      * Use this option to disable Google Pay and/or Apple Pay.
-     *
-     * Notes:
-     * You cannot create two `paymentRequest` objects with different `disableWallets` configurations.
-     * This option must have the same value for all pages on your site.
      */
     disableWallets?: PaymentRequestWallet[];
 

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -214,11 +214,18 @@ declare module '@stripe/stripe-js' {
     shippingOptions?: PaymentRequestShippingOption[];
 
     /**
-     * An array of `PaymentRequestWallet` strings.
+     * An array of wallet strings.
+     * Use this option to disable Google Pay and/or Apple Pay.
      *
-     * By default, if no `wallets` option is passed in, all wallets will be enabled.
-     * If you use this property, only wallets passed in will be enabled.
-     * If an empty array is specified, all wallets will be disabled.
+     * Notes:
+     * You cannot create two `paymentRequest` objects with different `disableWallets` configurations.
+     * This option must have the same value for all pages on your site.
+     */
+    disableWallets?: PaymentRequestWallet[];
+
+    /**
+     * @deprecated
+     * Use disableWallets instead.
      */
     wallets?: PaymentRequestWallet[];
   }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
- Deprecated `wallets` from `paymentRequestOptions`.
- Added `disableWallets` in `paymentRequestOptions` to replace `wallets`.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Added test for `disableWallets`.
