### PR TITLE
fix webkitAutofill casing

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -161,7 +161,7 @@ const fpxBankElement = elements.create('fpxBank', {
   style: MY_STYLE,
   value: '',
   accountHolderType: 'individual',
-  classes: {webkitAutoFill: ''},
+  classes: {webkitAutofill: ''},
 });
 
 elements.create('fpxBank', {
@@ -190,7 +190,7 @@ const idealBankElement = elements.create('idealBank', {
   style: MY_STYLE,
   value: '',
   hideIcon: false,
-  classes: {webkitAutoFill: ''},
+  classes: {webkitAutofill: ''},
 });
 
 elements.create('idealBank', {style: {base: {fontWeight: 500}}});
@@ -239,7 +239,7 @@ retrievedAfterpayClearpayMessageElement!.update({currency: 'GBP'});
 const epsBankElement = elements.create('epsBank', {
   style: MY_STYLE,
   value: '',
-  classes: {webkitAutoFill: ''},
+  classes: {webkitAutofill: ''},
 });
 
 elements.create('epsBank', {style: {base: {fontWeight: 500}}});
@@ -251,7 +251,7 @@ const retrievedEpsBankElement: StripeEpsBankElement | null = elements.getElement
 const p24BankElement = elements.create('p24Bank', {
   style: MY_STYLE,
   value: '',
-  classes: {webkitAutoFill: ''},
+  classes: {webkitAutofill: ''},
 });
 
 elements.create('p24Bank', {style: {base: {fontWeight: 500}}});

--- a/types/stripe-js/elements/base.d.ts
+++ b/types/stripe-js/elements/base.d.ts
@@ -225,7 +225,7 @@ declare module '@stripe/stripe-js' {
      * The class name to apply when the `Element` has its value autofilled by the browser (only on Chrome and Safari).
      * Defaults to `StripeElement--webkit-autofill`.
      */
-    webkitAutoFill?: string;
+    webkitAutofill?: string;
   }
 
   interface StripeElementChangeEvent {


### PR DESCRIPTION
### Summary & motivation

Fix the casing of `webkitAutofill` (currently `webkitAutoFill`) property in our types. 

Fixes #163

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

I updated our types level tests.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
