### PR TITLE
switch to using prettier --check instead of --list-different

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "test:unit": "jest",
     "test:versions": "./tests/versions/scripts/test.sh",
     "test:types": "tsc -p ./tests/types",
-    "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-list-different",
+    "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-check",
     "typecheck": "tsc",
     "build": "yarn clean && yarn rollup -c",
     "clean": "rimraf dist",
     "prepublishOnly": "echo \"\nPlease use ./scripts/publish instead\n\" && exit 1",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
-    "prettier-list-different": "prettier './**/*.{js,ts,md,html,css}' --list-different"
+    "prettier-check": "prettier './**/*.{js,ts,md,html,css}' --check"
   },
   "keywords": [
     "Stripe",


### PR DESCRIPTION
As per https://prettier.io/docs/en/cli.html#--check this returns a
better formatted error message.

### Summary & motivation

Prints a better human readable error when prettier formatting is not applied.

### Testing & documentation

No change to API or documentation.
