### PR TITLE
Add `th` as a supported locale

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -145,6 +145,7 @@ declare module '@stripe/stripe-js' {
     | 'sk'
     | 'sl'
     | 'sv'
+    | 'th'
     | 'tr'
     | 'zh'
     | 'zh-HK'


### PR DESCRIPTION
### Summary & motivation
Checkout now supports `th` as a locale
<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
