### PR TITLE
Add confirmWechatPayPayment types and tests

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1027,6 +1027,67 @@ stripe
   .then(({paymentIntent}: {paymentIntent?: PaymentIntent}) => {});
 
 stripe
+  .confirmWechatPayPayment('', {}, {handleActions: false})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmWechatPayPayment(
+    '',
+    {
+      payment_method: '',
+    },
+    {handleActions: false}
+  )
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmWechatPayPayment(
+    '',
+    {
+      payment_method: {
+        billing_details: {
+          name: '',
+          email: '',
+        },
+      },
+    },
+    {handleActions: false}
+  )
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmWechatPayPayment(
+    '',
+    {
+      payment_method_options: {
+        wechat_pay: {
+          client: 'web',
+        },
+      },
+    },
+    {handleActions: false}
+  )
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmWechatPayPayment(
+    '',
+    {
+      payment_method: {
+        billing_details: {
+          name: '',
+          email: '',
+        },
+      },
+      payment_method_options: {
+        wechat_pay: {},
+      },
+    },
+    {handleActions: false}
+  )
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
   .confirmAfterpayClearpayPayment('', {return_url: window.location.href})
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 

--- a/types/api/PaymentIntents.d.ts
+++ b/types/api/PaymentIntents.d.ts
@@ -179,9 +179,14 @@ declare module '@stripe/stripe-js' {
       redirect_to_url?: NextAction.RedirectToUrl;
 
       /**
-       * Type of the next action to perform, one of `redirect_to_url` or `use_stripe_sdk`.
+       * Type of the next action to perform, one of `redirect_to_url`, `use_stripe_sdk` or `wechat_pay_display_qr_code`.
        */
       type: string;
+
+      /**
+       * Wechat Pay display qrcode
+       */
+      wechat_pay_display_qr_code?: NextAction.WechatPayDisplayQrCode;
     }
 
     namespace NextAction {
@@ -195,6 +200,17 @@ declare module '@stripe/stripe-js' {
          * The URL you must redirect your customer to in order to authenticate the payment.
          */
         url: string | null;
+      }
+      interface WechatPayDisplayQrCode {
+        /**
+         * Render and display `paymentIntent.next_action.wechat_pay_display_qr_code.data` as a QR code on your checkout page.
+         */
+        data: string;
+
+        /**
+         * Use `paymentIntent.next_action.wechat_pay_display_qr_code.image_data_url` as an image source.
+         */
+        image_data_url: string;
       }
     }
 

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -300,6 +300,26 @@ declare module '@stripe/stripe-js' {
     ): Promise<PaymentIntentResult>;
 
     /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Use `stripe.confirmWechatPayPayment` in the [Wechat Pay Payments](https://stripe.com/docs/payments/wechat-pay) with Payment Methods flow when the customer submits your payment form.
+     * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide.
+     * Refer to our [integration guide](https://stripe.com/docs/payments/wechat-pay/accept-a-payment) for more details.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new PaymentMethod for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_wechat_pay_payment
+     */
+    confirmWechatPayPayment(
+      clientSecret: string,
+      data?: ConfirmWechatPayPaymentData,
+      options?: ConfirmWechatPayPaymentOptions
+    ): Promise<PaymentIntentResult>;
+
+    /**
      * Use `stripe.handleCardAction` in the Payment Intents API [manual confirmation](https://stripe.com/docs/payments/payment-intents/web-manual) flow to handle a [PaymentIntent](https://stripe.com/docs/api/payment_intents) with the `requires_action` status.
      * It will throw an error if the `PaymentIntent` has a different status.
      *

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -17,10 +17,19 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodP24Data
     | CreatePaymentMethodFpxData
     | CreatePaymentMethodSepaDebitData
-    | CreatePaymentMethodSofortData;
+    | CreatePaymentMethodSofortData
+    | CreatePaymentMethodWechatPayData;
 
   interface CreatePaymentMethodAlipayData extends PaymentMethodCreateParams {
     type: 'alipay';
+  }
+
+  interface CreatePaymentMethodWechatPayData extends PaymentMethodCreateParams {
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     */
+    type: 'wechat_pay';
   }
 
   interface CreatePaymentMethodAfterpayClearpayData
@@ -739,6 +748,42 @@ declare module '@stripe/stripe-js' {
      * The newly created SEPA Direct Debit [PaymentMethod](https://stripe.com/docs/api/payment_methods) will be attached to this customer.
      */
     setup_future_usage?: 'off_session';
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmWechatPayPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmWechatPayPaymentData extends PaymentIntentConfirmParams {
+    /**
+     * The `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent` or a new `PaymentMethod` will be created.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodWechatPayData, 'type'>;
+
+    /**
+     * An object containing payment-method-specific configuration to confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with.
+     */
+    payment_method_options?: {
+      /**
+       * Configuration for this wechat payment.
+       */
+      wechat_pay: {
+        client?: 'web';
+      };
+    };
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmWechatPayPayment`.
+   */
+  interface ConfirmWechatPayPaymentOptions {
+    /**
+     * This must be set to false, and you are responsible for handling the next_action after confirming the PaymentIntent.
+     */
+    handleActions: boolean;
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

* Adds `confirmWechatPayPayment` types. `confirmWechatPayPayment` is currently in beta.
* Adds `wechat_pay_display_qr_code` interface.

### Testing & documentation
Wrote unit tests that pass.
