### PR TITLE
Add registerAppInfo method

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1395,10 +1395,10 @@ stripe
   .then((result: {setupIntent?: SetupIntent}) => null);
 
 stripe.registerAppInfo({
-  name: '',
+  name: 'Demo_Wrapper',
   partner_id: 'pp_partner_1234',
   version: '1.2.34',
-  url: '',
+  url: 'https://example.com',
 });
 
 const paymentRequest: PaymentRequest = stripe.paymentRequest({

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1394,6 +1394,13 @@ stripe
   .retrieveSetupIntent('')
   .then((result: {setupIntent?: SetupIntent}) => null);
 
+stripe.registerAppInfo({
+  name: '',
+  partner_id: 'pp_partner_1234',
+  version: '1.2.34',
+  url: '',
+});
+
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',
   currency: 'usd',

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -633,6 +633,16 @@ declare module '@stripe/stripe-js' {
      * @docs https://stripe.com/docs/js/tokens_sources/retrieve_source
      */
     retrieveSource(source: RetrieveSourceParam): Promise<SourceResult>;
+
+    /////////////////////////////
+    /// Analytics
+    ///
+    /////////////////////////////
+
+    /**
+     * Use `stripe.registerAppInfo` to register a frontend open source library.
+     */
+    registerAppInfo(wrapperLibrary: WrapperLibrary): void;
   }
 
   type PaymentIntentResult =
@@ -654,6 +664,29 @@ declare module '@stripe/stripe-js' {
   type TokenResult =
     | {token: Token; error?: undefined}
     | {token?: undefined; error: StripeError};
+
+  interface WrapperLibrary {
+    /**
+     * Your library’s name
+     */
+    name: string;
+
+    /**
+     * Required for Stripe Verified Partners, optional otherwise
+     * Your Partner ID from the Partners section of the Dashboard
+     */
+    partner_id?: string;
+
+    /**
+     * Your library's version
+     */
+    version?: string;
+
+    /**
+     * The URL for your library's website with your contact details
+     */
+    url?: string;
+  }
 
   /**
    * Use `Stripe(publishableKey, options?)` to create an instance of the `Stripe` object.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -667,7 +667,7 @@ declare module '@stripe/stripe-js' {
 
   interface WrapperLibrary {
     /**
-     * Your library’s name
+     * Your library’s name, maximum length is 30
      */
     name: string;
 
@@ -678,7 +678,7 @@ declare module '@stripe/stripe-js' {
     partner_id?: string;
 
     /**
-     * Your library's version
+     * Your library's version, in the format of x.x.x
      */
     version?: string;
 


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
This PR adds the new `stripe.registerAppInfo` method that is used for frontend open source libraries to identify themselves and a new type `WrapperLibrary`.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Added unit test.
