### PR TITLE
Add Identity API types

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -38,6 +38,7 @@ import {
   StripeAfterpayClearpayMessageElement,
   StripeElementType,
   CanMakePaymentResult,
+  VerificationSession,
 } from '@stripe/stripe-js';
 
 const stripePromise: Promise<Stripe | null> = loadStripe('');
@@ -1491,6 +1492,15 @@ stripe.registerAppInfo({
   version: '1.2.34',
   url: 'https://example.com',
 });
+
+stripe
+  .verifyIdentity('')
+  .then(
+    (result: {
+      verificationSession?: VerificationSession;
+      error?: StripeError;
+    }) => null
+  );
 
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',

--- a/types/api/VerificationSessions.d.ts
+++ b/types/api/VerificationSessions.d.ts
@@ -1,0 +1,11 @@
+declare module '@stripe/stripe-js' {
+  /**
+   * The VerificationSession object.
+   */
+  interface VerificationSession {
+    /**
+     * Unique identifier for the object.
+     */
+    id: string;
+  }
+}

--- a/types/api/index.d.ts
+++ b/types/api/index.d.ts
@@ -6,3 +6,4 @@
 ///<reference path='./Tokens.d.ts' />
 ///<reference path='./BankAccounts.d.ts' />
 ///<reference path='./Cards.d.ts' />
+///<reference path='./VerificationSessions.d.ts' />

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -663,6 +663,18 @@ declare module '@stripe/stripe-js' {
      * Use `stripe.registerAppInfo` to register a frontend open source library.
      */
     registerAppInfo(wrapperLibrary: WrapperLibrary): void;
+
+    /////////////////////////////
+    /// Identity
+    ///
+    /////////////////////////////
+
+    /**
+     * Use `stripe.verifyIdentity` to display an [Identity](https://stripe.com/docs/identity) modal that securely collects verification information.
+     *
+     * * @docs https://stripe.com/docs/js/identity/modal
+     */
+    verifyIdentity(clientSecret: string): Promise<VerificationSessionResult>;
   }
 
   type PaymentIntentResult =
@@ -684,6 +696,10 @@ declare module '@stripe/stripe-js' {
   type TokenResult =
     | {token: Token; error?: undefined}
     | {token?: undefined; error: StripeError};
+
+  type VerificationSessionResult =
+    | {verificationSession: VerificationSession; error?: undefined}
+    | {verificationSession?: undefined; error: StripeError};
 
   interface WrapperLibrary {
     /**


### PR DESCRIPTION
### Summary & motivation

• add `verifyIdentity` types

### Testing & documentation

• docs: https://stripe.com/docs/js/identity/modal
• added unit test
