### PR TITLE
Add types for stripe.confirmBoletoPayment

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -737,6 +737,45 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
+  .confirmBoletoPayment(
+    '',
+    {
+      payment_method: {
+        billing_details: {
+          name: 'Jenny Rosen',
+          email: 'jennyrosen@stripe.com',
+          address: {
+            line1: 'Av. Paulista 1374',
+            country: 'BR',
+            state: 'SP',
+            postal_code: '01310100',
+            city: 'São Paulo',
+          },
+        },
+        boleto: {
+          tax_id: '000.000.000-00',
+        },
+      },
+    },
+    {
+      handleActions: false,
+    }
+  )
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmBoletoPayment('', {payment_method: ''})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmBoletoPayment('', {payment_method: ''}, {handleActions: false})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmBoletoPayment('')
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
   .confirmCardPayment('', {
     payment_method: {card: cardElement, billing_details: {name: ''}},
   })

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -112,6 +112,24 @@ declare module '@stripe/stripe-js' {
     ): Promise<PaymentIntentResult>;
 
     /**
+     * Use `stripe.confirmBoletoPayment` in the [Boleto Payment](https://stripe.com/docs/payments/boleto) with Payment Methods flow when the customer submits your payment form.
+     * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide.
+     * Note that there are some additional requirements to this flow that are not covered in this reference.
+     * Refer to our [integration guide](https://stripe.com/docs/payments/boleto) for more details.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new PaymentMethod for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_boleto_payment
+     */
+    confirmBoletoPayment(
+      clientSecret: string,
+      data?: ConfirmBoletoPaymentData,
+      options?: ConfirmBoletoPaymentOptions
+    ): Promise<PaymentIntentResult>;
+
+    /**
      * Use `stripe.confirmCardPayment` when the customer submits your payment form.
      * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide and carry out 3DS or other next actions if they are required.
      *

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -8,6 +8,7 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodAlipayData
     | CreatePaymentMethodAuBecsDebitData
     | CreatePaymentMethodBancontactData
+    | CreatePaymentMethodBoletoData
     | CreatePaymentMethodCardData
     | CreatePaymentMethodEpsData
     | CreatePaymentMethodGiropayData
@@ -54,6 +55,32 @@ declare module '@stripe/stripe-js' {
      */
     billing_details: PaymentMethodCreateParams.BillingDetails & {
       name: string;
+    };
+  }
+
+  interface CreatePaymentMethodBoletoData extends PaymentMethodCreateParams {
+    type: 'boleto';
+
+    /**
+     * The customer's billing details.
+     * `name`, `email`, and full `address` is required.
+     *
+     * @docs https://stripe.com/docs/api/payment_methods/create#create_payment_method-billing_details
+     */
+    billing_details: PaymentMethodCreateParams.BillingDetails & {
+      email: string;
+      name: string;
+      address: PaymentMethodCreateParams.BillingDetails.Address & {
+        line1: string;
+        city: string;
+        postal_code: string;
+        state: string;
+        country: string;
+      };
+    };
+
+    boleto: {
+      tax_id: string;
     };
   }
 
@@ -361,6 +388,30 @@ declare module '@stripe/stripe-js' {
      * @recommended
      */
     return_url?: string;
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmBoletoPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmBoletoPaymentData extends PaymentIntentConfirmParams {
+    /**
+     * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<CreatePaymentMethodBoletoData, 'type'>;
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmBoletoPayment`.
+   */
+  interface ConfirmBoletoPaymentOptions {
+    /**
+     * Set this to `false` if you want to handle next actions yourself. Please refer to our [Stripe Boleto integration guide](https://stripe.com/docs/payments/boleto) for more info. Default is `true`.
+     */
+    handleActions?: boolean;
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

Adding types to `stripe.confirmBoletoPayments` now that Boleto is in GA.

### Testing & documentation

Wrote unit tests, ran via `npm test`.
