### PR TITLE
Add CreateTokenBankAccountData.account_type

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -410,6 +410,7 @@ stripe.createToken('bank_account', {
   account_number: '',
   account_holder_name: '',
   account_holder_type: '',
+  account_type: '',
 });
 
 stripe.createToken('account', {

--- a/types/stripe-js/token-and-sources.d.ts
+++ b/types/stripe-js/token-and-sources.d.ts
@@ -80,6 +80,8 @@ declare module '@stripe/stripe-js' {
     account_holder_name?: string;
 
     account_holder_type: string;
+
+    account_type?: string;
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

I've added the new `account_type` field to `CreateTokenBankAccountData`, which allows callers to pass in the _type_ of bank account being used (e.g. `checking` or `savings`) for those corridors that require it.

More information can be found in the API docs: https://stripe.com/docs/api/customer_bank_accounts/object#customer_bank_account_object-account_type

### Testing & documentation

Updated existing tests.
