### PR TITLE
Improve TypeScript support for Exact Optional Property Types.

### DIFF
--- a/types/stripe-js/token-and-sources.d.ts
+++ b/types/stripe-js/token-and-sources.d.ts
@@ -27,30 +27,30 @@ declare module '@stripe/stripe-js' {
     /**
      * @recommended
      */
-    name?: string;
+    name?: string | undefined;
 
-    address_line1?: string;
+    address_line1?: string | undefined;
 
-    address_line2?: string;
+    address_line2?: string | undefined;
 
-    address_city?: string;
+    address_city?: string | undefined;
 
-    address_state?: string;
+    address_state?: string | undefined;
 
-    address_zip?: string;
+    address_zip?: string | undefined;
 
     /**
      * A two character country code (for example, `US`).
      *
      * @recommended
      */
-    address_country?: string;
+    address_country?: string | undefined;
 
     /**
      * Required in order to [add the card to a Connect account](https://stripe.com/docs/connect/payouts#bank-accounts) (in all other cases, this parameter is not used).
      * Currently, the only supported currency for debit card payouts is `usd`.
      */
-    currency?: string;
+    currency?: string | undefined;
   }
 
   interface CreateTokenIbanData {


### PR DESCRIPTION
### Summary & motivation

I'm opening this PR to start a discussion regarding [exact optional property types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-4/#exact-optional-property-types).

With this flag TypeScript treats the following types as different:

```ts
interface A1 {
    a?: string
}
interface A2 {
    a: string | undefined
}

const a: A1 = {}               // This is okay
const b: A1 = { a: 'test' }    // This is also okay
const c: A1 = { a: undefined } // Compile error!
const d: A2 = { a: undefined } // This is fine
const e: A2 = {}               // Compile error!
```

In order to allow all variant of the type you need:

```ts
interface A {
    a?: string | undefined
}
```

While this is not a required change for all properties, it is a useful one as it makes life of your users easier.
For instance, when collecting the address of a user:

```tsx
// Simplified for clarity
const PaymentInfo: FC<{}> = ({}) => {

    const [address_line1, setAddressLine1] = React.useState('');
    const [address_line2, setAddressLine2] = React.useState<string | undefined>(undefined);
    const [address_city, setAddressCity] = React.useState<string | undefined>(undefined);

    async function handleSubmit() {

        // This does not compile under the new flag
        const res = await stripe.createToken(card, {
            name,
            address_line1,
            address_line2,
            address_city,
            address_country,
        });
    }

    return <form onSubmit={handleSubmit}>
        <input value={address_line1} onChange={(ev) => setAddressLine1(ev.target.value)} />
        <input value={address_line2} onChange={(ev) => setAddressLine2(ev.target.value)} />
        <input value={address_city} onChange={(ev) => setAddressCity(ev.target.value)} />
        <CardElement />
    </form>
};
```
With this flag in mind, as a library author you now have more flexibility in your API to express how you intent your downstream users to use it.

With this PR, I want to start a discussion to know your thoughts and if you like the change proposed here, I'm offering some time to go over all types and see where it make sense to do a similar change.

(I don't expect the types under `types/api` to require any change for instance)
