### PR TITLE
PaymentElement + confirmPayment + confirmSetup types

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1632,6 +1632,111 @@ stripe
     }) => null
   );
 
+stripe
+  .confirmPayment({
+    elements,
+    confirmParams: {
+      return_url: '',
+    },
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    // @ts-expect-error redirect only, no paymentIntent expected
+    if (res.paymentIntent) {
+    }
+  });
+
+stripe
+  .confirmPayment({
+    elements,
+    confirmParams: {
+      return_url: '',
+    },
+    redirect: 'always',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    // @ts-expect-error redirect only, no paymentIntent expected
+    if (res.paymentIntent) {
+    }
+  });
+
+stripe
+  .confirmPayment({
+    elements,
+    confirmParams: {
+      return_url: '',
+    },
+    redirect: 'if_required',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.paymentIntent) {
+    }
+  });
+
+stripe
+  .confirmSetup({
+    elements,
+    confirmParams: {
+      return_url: '',
+    },
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    // @ts-expect-error redirect only, no paymentIntent expected
+    if (res.paymentIntent) {
+    }
+  });
+
+stripe
+  .confirmSetup({
+    elements,
+    confirmParams: {
+      return_url: '',
+    },
+    redirect: 'always',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    // @ts-expect-error redirect only, no paymentIntent expected
+    if (res.paymentIntent) {
+    }
+  });
+
+stripe
+  .confirmSetup({
+    elements,
+    confirmParams: {
+      return_url: '',
+    },
+    redirect: 'if_required',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.setupIntent) {
+    }
+  });
+
+// @ts-expect-error confirmParams.return_url is required
+stripe
+  .confirmSetup({
+    elements,
+    redirect: 'if_required',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.setupIntent) {
+    }
+  });
+
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',
   currency: 'usd',

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1666,9 +1666,18 @@ stripe
 stripe
   .confirmPayment({
     elements,
-    confirmParams: {
-      return_url: '',
-    },
+    redirect: 'if_required',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.paymentIntent) {
+    }
+  });
+stripe
+  .confirmPayment({
+    elements,
+    confirmParams: {},
     redirect: 'if_required',
   })
   .then((res) => {
@@ -1724,7 +1733,6 @@ stripe
     }
   });
 
-// @ts-expect-error confirmParams.return_url is required
 stripe
   .confirmSetup({
     elements,
@@ -1736,6 +1744,20 @@ stripe
     if (res.setupIntent) {
     }
   });
+
+stripe
+  .confirmSetup({
+    elements,
+    confirmParams: {},
+    redirect: 'if_required',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.setupIntent) {
+    }
+  });
+
 
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -96,6 +96,20 @@ const MY_STYLE: StripeElementStyle = {
   },
 };
 
+elements.update({});
+elements.update({
+  locale: 'es',
+  appearance: {},
+});
+elements.update({
+  // @ts-expect-error: `clientSecret` is not updatable
+  clientSecret: 'pk_foo_secret_bar',
+});
+elements.update({
+  // @ts-expect-error: `fonts` is not updatable
+  fonts: [],
+});
+
 const auBankAccountElement = elements.create('auBankAccount', {});
 
 const retrievedAuBankAccountElement: StripeAuBankAccountElement | null = elements.getElement(

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1758,7 +1758,6 @@ stripe
     }
   });
 
-
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',
   currency: 'usd',

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -35,6 +35,7 @@ import {
   StripeAuBankAccountElement,
   StripeAuBankAccountElementChangeEvent,
   StripePaymentRequestButtonElement,
+  StripePaymentElement,
   StripeAfterpayClearpayMessageElement,
   StripeElementType,
   CanMakePaymentResult,
@@ -246,6 +247,55 @@ const afterpayClearpayMessageElement = elements.create(
     currency: 'USD',
   }
 );
+
+const paymentElement: StripePaymentElement = elements.create('payment', {
+  fields: {
+    billingDetails: {
+      email: 'never',
+      phone: 'auto',
+      address: 'never',
+    },
+  },
+  terms: {
+    card: 'auto',
+    sepaDebit: 'always',
+    ideal: 'never',
+  },
+  business: {
+    name: '',
+  },
+  paymentMethodOrder: ['card', 'sepa_debit'],
+});
+
+let paymentElementDefaults: StripePaymentElement = elements.create('payment');
+paymentElementDefaults = elements.create('payment', {});
+
+const retrievedPaymentElement: StripePaymentElement | null = elements.getElement(
+  'payment'
+);
+
+paymentElement
+  .on('ready', (e: {elementType: 'payment'}) => {})
+  .on('focus', (e: {elementType: 'payment'}) => {})
+  .on('blur', (e: {elementType: 'payment'}) => {})
+  .on(
+    'change',
+    (e: {
+      elementType: 'payment';
+      value: {type: string};
+      collapsed: boolean;
+      complete: boolean;
+      empty: boolean;
+    }) => {}
+  );
+
+paymentElement.on('change', (e) => {
+  // @ts-expect-error: `error` is not present on PaymentElement "change" event.
+  if (e.error) {
+  }
+});
+
+paymentElement.collapse();
 
 afterpayClearpayMessageElement.on(
   'ready',

--- a/types/stripe-js/elements.d.ts
+++ b/types/stripe-js/elements.d.ts
@@ -15,6 +15,31 @@ import {StripeAuBankAccountElement} from '@stripe/stripe-js';
 
 declare module '@stripe/stripe-js' {
   interface StripeElements {
+    /**
+     * Updates the options that `Elements` was initialized with.
+     * Updates are shallowly merged into the existing configuration.
+     */
+    update(options: StripeElementsUpdateOptions): void;
+
+    /////////////////////////////
+    /// afterpayClearpayMessage
+    /////////////////////////////
+
+    /**
+     * Creates an `AfterpayClearpayMessageElement`.
+     */
+    create(
+      elementType: 'afterpayClearpayMessage',
+      options: StripeAfterpayClearpayMessageElementOptions
+    ): StripeAfterpayClearpayMessageElement;
+
+    /**
+     * Looks up a previously created `Element` by its type.
+     */
+    getElement(
+      elementType: 'afterpayClearpayMessage'
+    ): StripeAfterpayClearpayMessageElement | null;
+
     /////////////////////////////
     /// auBankAccount
     /////////////////////////////
@@ -217,24 +242,10 @@ declare module '@stripe/stripe-js' {
     getElement(
       elementType: 'paymentRequestButton'
     ): StripePaymentRequestButtonElement | null;
-
-    /**
-     * Creates an `AfterpayClearpayMessageElement`.
-     */
-    create(
-      elementType: 'afterpayClearpayMessage',
-      options: StripeAfterpayClearpayMessageElementOptions
-    ): StripeAfterpayClearpayMessageElement;
-
-    /**
-     * Looks up a previously created `Element` by its type.
-     */
-    getElement(
-      elementType: 'afterpayClearpayMessage'
-    ): StripeAfterpayClearpayMessageElement | null;
   }
 
   type StripeElementType =
+    | 'afterpayClearpayMessage'
     | 'auBankAccount'
     | 'card'
     | 'cardNumber'
@@ -245,10 +256,10 @@ declare module '@stripe/stripe-js' {
     | 'iban'
     | 'idealBank'
     | 'p24Bank'
-    | 'paymentRequestButton'
-    | 'afterpayClearpayMessage';
+    | 'paymentRequestButton';
 
   type StripeElement =
+    | StripeAfterpayClearpayMessageElement
     | StripeAuBankAccountElement
     | StripeCardElement
     | StripeCardNumberElement
@@ -259,8 +270,7 @@ declare module '@stripe/stripe-js' {
     | StripeIbanElement
     | StripeIdealBankElement
     | StripeP24BankElement
-    | StripePaymentRequestButtonElement
-    | StripeAfterpayClearpayMessageElement;
+    | StripePaymentRequestButtonElement;
 
   type StripeElementLocale =
     | 'auto'
@@ -324,6 +334,50 @@ declare module '@stripe/stripe-js' {
      * Setting the locale does not affect the behavior of postal code validation—a valid postal code for the billing country of the card is still required.
      */
     locale?: StripeElementLocale;
+
+    /**
+     * Used with the Payment Element, requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Match the design of your site with the appearance option.
+     * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
+     *
+     * @docs https://stripe.com/docs/stripe-js/appearance-api
+     */
+    appearance?: Record<string, unknown>;
+
+    /**
+     * Used with the Payment Element, requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * The client secret for a PaymentIntent or SetupIntent
+     *
+     * @docs https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret
+     */
+    clientSecret?: string;
+  }
+
+  /*
+   * Updatable options for an `Elements` instance
+   */
+  interface StripeElementsUpdateOptions {
+    /**
+     * The [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) of the locale to display placeholders and error strings in.
+     * Default is `auto` (Stripe detects the locale of the browser).
+     * Setting the locale does not affect the behavior of postal code validation—a valid postal code for the billing country of the card is still required.
+     */
+    locale?: StripeElementLocale;
+
+    /**
+     * Used with the Payment Element, requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Match the design of your site with the appearance option.
+     * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
+     *
+     * @docs https://stripe.com/docs/stripe-js/appearance-api
+     */
+    appearance?: Record<string, unknown>;
   }
 
   /*

--- a/types/stripe-js/elements.d.ts
+++ b/types/stripe-js/elements.d.ts
@@ -10,6 +10,7 @@
 ///<reference path='./elements/eps-bank.d.ts' />
 ///<reference path='./elements/p24-bank.d.ts' />
 ///<reference path='./elements/afterpay-clearpay-message.d.ts' />
+///<reference path='./elements/payment.d.ts' />
 
 import {StripeAuBankAccountElement} from '@stripe/stripe-js';
 
@@ -223,6 +224,29 @@ declare module '@stripe/stripe-js' {
     getElement(elementType: 'idealBank'): StripeIdealBankElement | null;
 
     /////////////////////////////
+    /// payment
+    /////////////////////////////
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Creates a `PaymentElement`.
+     */
+    create(
+      elementType: 'payment',
+      options?: StripePaymentElementOptions
+    ): StripePaymentElement;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Looks up a previously created `Element` by its type.
+     */
+    getElement(elementType: 'payment'): StripePaymentElement | null;
+
+    /////////////////////////////
     /// paymentRequestButton
     /////////////////////////////
 
@@ -256,6 +280,7 @@ declare module '@stripe/stripe-js' {
     | 'iban'
     | 'idealBank'
     | 'p24Bank'
+    | 'payment'
     | 'paymentRequestButton';
 
   type StripeElement =
@@ -270,6 +295,7 @@ declare module '@stripe/stripe-js' {
     | StripeIbanElement
     | StripeIdealBankElement
     | StripeP24BankElement
+    | StripePaymentElement
     | StripePaymentRequestButtonElement;
 
   type StripeElementLocale =

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -1,0 +1,170 @@
+///<reference path='./base.d.ts' />
+
+declare module '@stripe/stripe-js' {
+  type StripePaymentElement = StripeElementBase & {
+    /**
+     * The change event is triggered when the `Element`'s value changes.
+     */
+    on(
+      eventType: 'change',
+      handler: (event: StripePaymentElementChangeEvent) => any
+    ): StripePaymentElement;
+    once(
+      eventType: 'change',
+      handler: (event: StripePaymentElementChangeEvent) => any
+    ): StripePaymentElement;
+    off(
+      eventType: 'change',
+      handler?: (event: StripePaymentElementChangeEvent) => any
+    ): StripePaymentElement;
+
+    /**
+     * Triggered when the element is fully rendered and can accept `element.focus` calls.
+     */
+    on(
+      eventType: 'ready',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    once(
+      eventType: 'ready',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    off(
+      eventType: 'ready',
+      handler?: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+
+    /**
+     * Triggered when the element gains focus.
+     */
+    on(
+      eventType: 'focus',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    once(
+      eventType: 'focus',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    off(
+      eventType: 'focus',
+      handler?: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+
+    /**
+     * Triggered when the element loses focus.
+     */
+    on(
+      eventType: 'blur',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    once(
+      eventType: 'blur',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    off(
+      eventType: 'blur',
+      handler?: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+
+    /**
+     * Triggered when the escape key is pressed within the element.
+     */
+    on(
+      eventType: 'escape',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    once(
+      eventType: 'escape',
+      handler: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+    off(
+      eventType: 'escape',
+      handler?: (event: {elementType: 'payment'}) => any
+    ): StripePaymentElement;
+
+    /**
+     * Updates the options the `PaymentElement` was initialized with.
+     * Updates are merged into the existing configuration.
+     */
+    update(options: Partial<StripePaymentElementOptions>): StripePaymentElement;
+
+    /**
+     * Collapses the Payment Element into a row of payment method tabs.
+     */
+    collapse(): StripePaymentElement;
+  };
+
+  type FieldOption = 'auto' | 'never';
+
+  interface FieldsOption {
+    billingDetails?:
+      | FieldOption
+      | {
+          name?: FieldOption;
+          email?: FieldOption;
+          phone?: FieldOption;
+          address?:
+            | FieldOption
+            | {
+                country?: FieldOption;
+                postalCode?: FieldOption;
+                state?: FieldOption;
+                city?: FieldOption;
+                line1?: FieldOption;
+                line2?: FieldOption;
+              };
+        };
+  }
+
+  type TermOption = 'auto' | 'always' | 'never';
+
+  interface TermsOption {
+    bancontact?: TermOption;
+    card?: TermOption;
+    ideal?: TermOption;
+    sepaDebit?: TermOption;
+    sofort?: TermOption;
+  }
+
+  interface StripePaymentElementOptions {
+    /**
+     * Override the business name displayed in the Payment Element.
+     * By default the PaymentElement will use your Stripe account or business name.
+     */
+    business?: {name: string};
+
+    /**
+     * Override the order in which payment methods are displayed in the Payment Element.
+     * By default, the Payment Element will use a dynamic ordering that optimizes payment method display for each user.
+     */
+    paymentMethodOrder?: string[];
+
+    /**
+     * Control which fields are displayed in the Payment Element.
+     */
+    fields?: FieldsOption;
+
+    /**
+     * Control terms display in the Payment Element.
+     */
+    terms?: TermsOption;
+  }
+
+  interface StripePaymentElementChangeEvent
+    extends Omit<StripeElementChangeEvent, 'error'> {
+    /**
+     * The type of element that emitted this event.
+     */
+    elementType: 'payment';
+
+    /**
+     * Whether or not the Payment Element is currently collapsed.
+     */
+    collapsed: boolean;
+
+    /**
+     * An object containing the currently selected PaymentMethod type.
+     */
+    value: {type: string};
+  }
+}

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -41,6 +41,30 @@ declare module '@stripe/stripe-js' {
     /////////////////////////////
 
     /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * @docs https://stripe.com/docs/stripe-js/payment-element/accept-a-payment-manual
+     */
+    confirmPayment(options: {
+      elements: StripeElements;
+      confirmParams: ConfirmPaymentData;
+      redirect: 'if_required';
+    }): Promise<PaymentIntentResult>;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * @docs https://stripe.com/docs/stripe-js/payment-element/accept-a-payment-manual
+     */
+    confirmPayment(options: {
+      elements: StripeElements;
+      confirmParams: ConfirmPaymentData;
+      redirect?: 'always';
+    }): Promise<never | {error: StripeError}>;
+
+    /**
      * Use `stripe.confirmAcssDebitPayment` in the [Accept a Canadian pre-authorized debit payment](https://stripe.com/docs/payments/acss-debit/accept-a-payment) flow when the customer submits your payment form.
      * When called, it will automatically pop up a modal to collect bank account details and verification, accept the mandate, and confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) when the user submits the form.
      *
@@ -404,6 +428,30 @@ declare module '@stripe/stripe-js' {
     ///
     /// https://stripe.com/docs/js/setup_intents
     /////////////////////////////
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * @docs https://stripe.com/docs/stripe-js/payment-element/set-up-payment-manual
+     */
+    confirmSetup(options: {
+      elements: StripeElements;
+      confirmParams: ConfirmPaymentData;
+      redirect: 'if_required';
+    }): Promise<SetupIntentResult>;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * @docs https://stripe.com/docs/stripe-js/payment-element/set-up-payment-manual
+     */
+    confirmSetup(options: {
+      elements: StripeElements;
+      confirmParams: ConfirmPaymentData;
+      redirect?: 'always';
+    }): Promise<never | {error: StripeError}>;
 
     /**
      * Use `stripe.confirmAcssDebitSetup` to [save details for future payments with pre-authorized debit in Canada](https://stripe.com/docs/payments/acss-debit/set-up-payment).

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -48,7 +48,7 @@ declare module '@stripe/stripe-js' {
      */
     confirmPayment(options: {
       elements: StripeElements;
-      confirmParams: ConfirmPaymentData;
+      confirmParams?: Partial<ConfirmPaymentData>;
       redirect: 'if_required';
     }): Promise<PaymentIntentResult>;
 
@@ -437,7 +437,7 @@ declare module '@stripe/stripe-js' {
      */
     confirmSetup(options: {
       elements: StripeElements;
-      confirmParams: ConfirmPaymentData;
+      confirmParams?: Partial<ConfirmPaymentData>;
       redirect: 'if_required';
     }): Promise<SetupIntentResult>;
 

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -943,6 +943,32 @@ declare module '@stripe/stripe-js' {
   }
 
   /**
+   * Data to be sent with a `stripe.confirmPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmPaymentData extends PaymentIntentConfirmParams {
+    /**
+     * The url your customer will be directed to after they complete payment.
+     */
+    return_url: string;
+
+    /**
+     * An object to attach additional billing_details to the PaymentMethod created via Elements.
+     *
+     * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_data
+     */
+    payment_method_data?: {
+      /**
+       * The customer's billing details. Details collected by Elements will override values passed here.
+       * Billing fields that are omitted in the Payment Element via the `fields` option required.
+       *
+       * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_data-billing_details
+       */
+      billing_details?: PaymentMethodCreateParams.BillingDetails;
+    };
+  }
+
+  /**
    * Data to be sent with a `stripe.verifyMicrodepositsForPayment` request.
    */
   interface VerifyMicrodepositsForPaymentData {


### PR DESCRIPTION
### Summary & motivation

Add types to support the upcoming [Payment Element](https://stripe.com/docs/payments/payment-element).

#### New Methods
* `stripe.confirmPayment` 
* `stripe.confirmSetup` 
* `elements.update` 

#### Updated Methods
* `stripe.elements` updated to support `appearance` and `clientSecret` options
* `elements.create` and `elements.getElement` updated to support the Payment Element.

#### Usage

```ts
const elements = stripe.elements({
  clientSecret: '{{client_secret}}',
  locale: 'fr',
});

elements.update({ locale: 'es' })

elements.create('payment', {
  fields: {
    billing_details: {
      name: 'never',
    },
  }
});

const payment = elements.getElement('payment')

const {error} = await stripe.confirmPayment({
  elements,
  confirmParams: { 
    return_url: 'https://exampe.com',
    payment_method_data: {
      billing_details: {
        name: 'Jenny Rosen',
      }
    }
  },
});
```

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
I wrote unit tests.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
