### PR TITLE
Add confirmCustomerBalancePayment

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -886,74 +886,90 @@ stripe.confirmCardPayment('').then((res) => {
 });
 
 stripe
-  .confirmCustomerBalancePayment('', {
-    payment_method: {
-      customer_balance: {},
+  .confirmCustomerBalancePayment(
+    '',
+    {
+      payment_method: {
+        customer_balance: {},
+      },
+    },
+    {
+      handleActions: false,
     }
-  }, {
-    handleActions: false,
-  })
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmCustomerBalancePayment('', {
-    payment_method: {
-      customer_balance: {},
-    },
-    payment_method_options: {
-      customer_balance: {
-        funding_type: 'bank_transfer',
-        bank_transfer: {
-          type:  'us_bank_account',
-          requested_address_types: ['aba', 'swift'],
-        },
+  .confirmCustomerBalancePayment(
+    '',
+    {
+      payment_method: {
+        customer_balance: {},
       },
-    },
-  }, {
-    handleActions: false,
-  })
-  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
-
-stripe
-  .confirmCustomerBalancePayment('', {
-    payment_method: {
-      customer_balance: {},
-    },
-    payment_method_options: {
-      customer_balance: {
-        funding_type: 'bank_transfer',
-        bank_transfer: {
-          type:  'eu_bank_account',
-          eu_bank_account: {
-            country: 'NL',
+      payment_method_options: {
+        customer_balance: {
+          funding_type: 'bank_transfer',
+          bank_transfer: {
+            type: 'us_bank_account',
+            requested_address_types: ['aba', 'swift'],
           },
         },
       },
     },
-  }, {
-    handleActions: false,
-  })
+    {
+      handleActions: false,
+    }
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmCustomerBalancePayment('', {
-    payment_method: {
-      customer_balance: {},
-    },
-    payment_method_options: {
-      customer_balance: {
-        funding_type: 'bank_transfer',
-        bank_transfer: {
-          type: 'id_bank_account',
-          id_bank_account: {
-            bank: 'bni',
+  .confirmCustomerBalancePayment(
+    '',
+    {
+      payment_method: {
+        customer_balance: {},
+      },
+      payment_method_options: {
+        customer_balance: {
+          funding_type: 'bank_transfer',
+          bank_transfer: {
+            type: 'eu_bank_account',
+            eu_bank_account: {
+              country: 'NL',
+            },
           },
         },
       },
     },
-  }, {
-    handleActions: false,
-  })
+    {
+      handleActions: false,
+    }
+  )
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmCustomerBalancePayment(
+    '',
+    {
+      payment_method: {
+        customer_balance: {},
+      },
+      payment_method_options: {
+        customer_balance: {
+          funding_type: 'bank_transfer',
+          bank_transfer: {
+            type: 'id_bank_account',
+            id_bank_account: {
+              bank: 'bni',
+            },
+          },
+        },
+      },
+    },
+    {
+      handleActions: false,
+    }
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -886,6 +886,77 @@ stripe.confirmCardPayment('').then((res) => {
 });
 
 stripe
+  .confirmCustomerBalancePayment('', {
+    payment_method: {
+      customer_balance: {},
+    }
+  }, {
+    handleActions: false,
+  })
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmCustomerBalancePayment('', {
+    payment_method: {
+      customer_balance: {},
+    },
+    payment_method_options: {
+      customer_balance: {
+        funding_type: 'bank_transfer',
+        bank_transfer: {
+          type:  'us_bank_account',
+          requested_address_types: ['aba', 'swift'],
+        },
+      },
+    },
+  }, {
+    handleActions: false,
+  })
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmCustomerBalancePayment('', {
+    payment_method: {
+      customer_balance: {},
+    },
+    payment_method_options: {
+      customer_balance: {
+        funding_type: 'bank_transfer',
+        bank_transfer: {
+          type:  'eu_bank_account',
+          eu_bank_account: {
+            country: 'NL',
+          },
+        },
+      },
+    },
+  }, {
+    handleActions: false,
+  })
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmCustomerBalancePayment('', {
+    payment_method: {
+      customer_balance: {},
+    },
+    payment_method_options: {
+      customer_balance: {
+        funding_type: 'bank_transfer',
+        bank_transfer: {
+          type: 'id_bank_account',
+          id_bank_account: {
+            bank: 'bni',
+          },
+        },
+      },
+    },
+  }, {
+    handleActions: false,
+  })
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
   .confirmEpsPayment('', {
     payment_method: {
       eps: {bank: 'bank_austria'},

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -174,12 +174,12 @@ declare module '@stripe/stripe-js' {
     /**
      * Requires beta access:
      * Contact [Stripe support](https://support.stripe.com/) for more information.
-     * 
+     *
      * Use `stripe.confirmCustomerBalancePayment` when the customer submits your payment form.
-     * 
-     * When called, it will confirm the PaymentIntent with data you provide. 
+     *
+     * When called, it will confirm the PaymentIntent with data you provide.
      * Refer to our [integration guide](https://stripe.com/docs/payments/bank-transfers) for more details.
-     * 
+     *
      * Since the Customer Balance payment method draws from a balance, the attempt will succeed or fail depending on the current balance amount. To collect more funds from the customer when the cash balance is insufficient, use the customer balance with bank transfer funding parameters.
      * The confirmation attempt will finish in one of the following result states:
      * 1. If the customer balance was enough to pay the amount, the status is succeeded. The funding_type data is effectively ignored.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -172,6 +172,26 @@ declare module '@stripe/stripe-js' {
     ): Promise<PaymentIntentResult>;
 
     /**
+     * Use `stripe.confirmCustomerBalancePayment` when the customer submits your payment form.
+     * 
+     * When called, it will confirm the PaymentIntent with data you provide. 
+     * Refer to our [integration guide](https://stripe.com/docs/payments/bank-transfers) for more details.
+     * 
+     * Since the Customer Balance payment method draws from a balance, the attempt will succeed or fail depending on the current balance amount. To collect more funds from the customer when the cash balance is insufficient, use the customer balance with bank transfer funding parameters.
+     * The confirmation attempt will finish in one of the following result states:
+     * 1. If the customer balance was enough to pay the amount, the status is succeeded. The funding_type data is effectively ignored.
+     * 2. If the balance was not enough to pay the amount, and you didn't send the funding_type, the status is requires_payment_method.
+     * 3. If the balance was not enough to pay the amount, and you did send the funding_type, the status is requires_action. The paymentIntent.next_action.display_bank_transfer_instructions hash contains bank transfer details for funding the Customer Balance.
+     *
+     * @docs https://stripe.com/docs/js/payment_intents/confirm_customer_balance_payment
+     */
+    confirmCustomerBalancePayment(
+      clientSecret: string,
+      data: ConfirmCustomerBalancePaymentData,
+      options: ConfirmCustomerBalancePaymentOptions
+    ): Promise<PaymentIntentResult>;
+
+    /**
      * Use `stripe.confirmEpsPayment` in the [EPS Payments with Payment Methods](https://stripe.com/docs/payments/eps#web) flow when the customer submits your payment form.
      * When called, it will confirm the `PaymentIntent` with `data` you provide, and it will automatically redirect the customer to authorize the transaction.
      * Once authorization is complete, the customer will be redirected back to your specified `return_url`.

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -172,6 +172,9 @@ declare module '@stripe/stripe-js' {
     ): Promise<PaymentIntentResult>;
 
     /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     * 
      * Use `stripe.confirmCustomerBalancePayment` when the customer submits your payment form.
      * 
      * When called, it will confirm the PaymentIntent with data you provide. 

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -96,13 +96,7 @@ declare module '@stripe/stripe-js' {
      * Requires beta access:
      * Contact [Stripe support](https://support.stripe.com/) for more information.
      */
-    type: 'customer_balance';
-
-    /**
-     * Requires beta access:
-     * Contact [Stripe support](https://support.stripe.com/) for more information.
-     */
-    customer_balance: {};
+    customer_balance: {},
   }
 
   interface CreatePaymentMethodEpsData extends PaymentMethodCreateParams {

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -10,6 +10,7 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodBancontactData
     | CreatePaymentMethodBoletoData
     | CreatePaymentMethodCardData
+    | CreatePaymentMethodCustomerBalanceData
     | CreatePaymentMethodEpsData
     | CreatePaymentMethodGiropayData
     | CreatePaymentMethodGrabPayData
@@ -88,6 +89,11 @@ declare module '@stripe/stripe-js' {
     type: 'card';
 
     card: StripeCardElement | StripeCardNumberElement | {token: string};
+  }
+
+  interface CreatePaymentMethodCustomerBalanceData extends PaymentMethodCreateParams {
+    type: 'customer_balance';
+    customer_balance: {};
   }
 
   interface CreatePaymentMethodEpsData extends PaymentMethodCreateParams {
@@ -501,6 +507,32 @@ declare module '@stripe/stripe-js' {
      */
     handleActions?: boolean;
   }
+
+
+  /**
+   * Data to be sent with a `stripe.confirmCustomerBalancePayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+   interface ConfirmCustomerBalancePaymentData extends PaymentIntentConfirmParams {
+    /**
+     * An object specifying the `customer_balance` type.
+     */
+    payment_method: CreatePaymentMethodCustomerBalanceData
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmCustomerBalancePayment`.
+   */
+  interface ConfirmCustomerBalancePaymentOptions {
+    /**
+     * This must be set to `false`.
+     * The Customer Balance does not handle the next actions for you automatically (e.g. displaying bank transfer details). 
+     * To make future upgrades easier, this option is required to always be sent. 
+     * Please refer to our [Stripe Customer Balance integration guide](https://stripe.com/docs/payments/bank-transfers) for more info.
+     */
+    handleActions: false;
+  }
+
 
   /**
    * Data to be sent with a `stripe.confirmEpsPayment` request.

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -529,8 +529,8 @@ declare module '@stripe/stripe-js' {
     payment_method: CreatePaymentMethodCustomerBalanceData
     payment_method_options?: {
       customer_balance?: {
-        funding_type: 'bank_transfer';
-        bank_transfer: {
+        funding_type?: 'bank_transfer';
+        bank_transfer?: {
           type:  'us_bank_account' | 'eu_bank_account' | 'id_bank_account' | 'gb_bank_account' | 'jp_bank_account' | 'mx_bank_account';
           eu_bank_account?: {
             country: 'ES' | 'FR' | 'IE' | 'NL';

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -91,12 +91,13 @@ declare module '@stripe/stripe-js' {
     card: StripeCardElement | StripeCardNumberElement | {token: string};
   }
 
-  interface CreatePaymentMethodCustomerBalanceData extends PaymentMethodCreateParams {
+  interface CreatePaymentMethodCustomerBalanceData
+    extends PaymentMethodCreateParams {
     /**
      * Requires beta access:
      * Contact [Stripe support](https://support.stripe.com/) for more information.
      */
-    customer_balance: Record<string, never>,
+    customer_balance: Record<string, never>;
   }
 
   interface CreatePaymentMethodEpsData extends PaymentMethodCreateParams {
@@ -511,21 +512,27 @@ declare module '@stripe/stripe-js' {
     handleActions?: boolean;
   }
 
-
   /**
    * Data to be sent with a `stripe.confirmCustomerBalancePayment` request.
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
-   interface ConfirmCustomerBalancePaymentData extends PaymentIntentConfirmParams {
+  interface ConfirmCustomerBalancePaymentData
+    extends PaymentIntentConfirmParams {
     /**
      * An object specifying the `customer_balance` type.
      */
-    payment_method: CreatePaymentMethodCustomerBalanceData
+    payment_method: CreatePaymentMethodCustomerBalanceData;
     payment_method_options?: {
       customer_balance?: {
         funding_type?: 'bank_transfer';
         bank_transfer?: {
-          type:  'us_bank_account' | 'eu_bank_account' | 'id_bank_account' | 'gb_bank_account' | 'jp_bank_account' | 'mx_bank_account';
+          type:
+            | 'us_bank_account'
+            | 'eu_bank_account'
+            | 'id_bank_account'
+            | 'gb_bank_account'
+            | 'jp_bank_account'
+            | 'mx_bank_account';
           eu_bank_account?: {
             country: 'ES' | 'FR' | 'IE' | 'NL';
           };
@@ -533,11 +540,18 @@ declare module '@stripe/stripe-js' {
             bank: 'bni' | 'bca';
           };
           requested_address_types?: Array<
-            'aba' | 'swift' | 'sort_code' | 'zengin' | 'iban' | 'spei' | 'id_bban' | 'sepa'
+            | 'aba'
+            | 'swift'
+            | 'sort_code'
+            | 'zengin'
+            | 'iban'
+            | 'spei'
+            | 'id_bban'
+            | 'sepa'
           >;
         };
-      },
-    },
+      };
+    };
   }
 
   /**
@@ -546,13 +560,12 @@ declare module '@stripe/stripe-js' {
   interface ConfirmCustomerBalancePaymentOptions {
     /**
      * This must be set to `false`.
-     * The Customer Balance does not handle the next actions for you automatically (e.g. displaying bank transfer details). 
-     * To make future upgrades easier, this option is required to always be sent. 
+     * The Customer Balance does not handle the next actions for you automatically (e.g. displaying bank transfer details).
+     * To make future upgrades easier, this option is required to always be sent.
      * Please refer to our [Stripe Customer Balance integration guide](https://stripe.com/docs/payments/bank-transfers) for more info.
      */
     handleActions: false;
   }
-
 
   /**
    * Data to be sent with a `stripe.confirmEpsPayment` request.

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -96,7 +96,7 @@ declare module '@stripe/stripe-js' {
      * Requires beta access:
      * Contact [Stripe support](https://support.stripe.com/) for more information.
      */
-    customer_balance: {},
+    customer_balance: Record<string, never>,
   }
 
   interface CreatePaymentMethodEpsData extends PaymentMethodCreateParams {

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -92,7 +92,16 @@ declare module '@stripe/stripe-js' {
   }
 
   interface CreatePaymentMethodCustomerBalanceData extends PaymentMethodCreateParams {
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     */
     type: 'customer_balance';
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     */
     customer_balance: {};
   }
 

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -527,6 +527,23 @@ declare module '@stripe/stripe-js' {
      * An object specifying the `customer_balance` type.
      */
     payment_method: CreatePaymentMethodCustomerBalanceData
+    payment_method_options?: {
+      customer_balance?: {
+        funding_type: 'bank_transfer';
+        bank_transfer: {
+          type:  'us_bank_account' | 'eu_bank_account' | 'id_bank_account' | 'gb_bank_account' | 'jp_bank_account' | 'mx_bank_account';
+          eu_bank_account?: {
+            country: 'ES' | 'FR' | 'IE' | 'NL';
+          };
+          id_bank_account?: {
+            bank: 'bni' | 'bca';
+          };
+          requested_address_types?: Array<
+            'aba' | 'swift' | 'sort_code' | 'zengin' | 'iban' | 'spei' | 'id_bban' | 'sepa'
+          >;
+        };
+      },
+    },
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

* Following on from adding the Stripe.js ref docs, this registers the `confirmCustomerBalancePayment` types.
* Feature is in beta, and noted as such in comments.

### Testing & documentation

* Added test calls to `tests/types/index.ts`

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
