### PR TITLE
add types for confirm paynow and promptpay

### DIFF
--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1167,6 +1167,17 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
+  .confirmPayNowPayment('', {
+    payment_method: {
+      billing_details: {
+        name: '',
+        email: '',
+      },
+    },
+  }, {handleActions: false})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
   .confirmPayPalPayment('', {
     return_url: 'https://example.com',
   })
@@ -1463,6 +1474,16 @@ stripe.createPaymentMethod({
 stripe.createPaymentMethod({
   type: 'afterpay_clearpay',
   afterpay_clearpay: {},
+});
+
+stripe.createPaymentMethod({
+  type: 'paynow',
+  billing_details: {name: '', email: ''},
+});
+
+stripe.createPaymentMethod({
+  type: 'promptpay',
+  billing_details: {name: '', email: ''},
 });
 
 stripe.retrievePaymentIntent('{PAYMENT_INTENT_CLIENT_SECRET}');

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1150,31 +1150,43 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmPayNowPayment('', {
-    payment_method: '',
-  }, {handleActions: false})
+  .confirmPayNowPayment(
+    '',
+    {
+      payment_method: '',
+    },
+    {handleActions: false}
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmPayNowPayment('', {
-    payment_method: {
-      billing_details: {
-        name: '',
-        email: '',
+  .confirmPayNowPayment(
+    '',
+    {
+      payment_method: {
+        billing_details: {
+          name: '',
+          email: '',
+        },
       },
     },
-  }, {handleActions: false})
+    {handleActions: false}
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmPayNowPayment('', {
-    payment_method: {
-      billing_details: {
-        name: '',
-        email: '',
+  .confirmPayNowPayment(
+    '',
+    {
+      payment_method: {
+        billing_details: {
+          name: '',
+          email: '',
+        },
       },
     },
-  }, {handleActions: false})
+    {handleActions: false}
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
@@ -1195,20 +1207,28 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmPromptPayPayment('', {
-    payment_method: '',
-  }, {handleActions: false})
+  .confirmPromptPayPayment(
+    '',
+    {
+      payment_method: '',
+    },
+    {handleActions: false}
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmPromptPayPayment('', {
-    payment_method: {
-      billing_details: {
-        name: '',
-        email: '',
+  .confirmPromptPayPayment(
+    '',
+    {
+      payment_method: {
+        billing_details: {
+          name: '',
+          email: '',
+        },
       },
     },
-  }, {handleActions: false})
+    {handleActions: false}
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe

--- a/tests/types/index.ts
+++ b/tests/types/index.ts
@@ -1146,6 +1146,27 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
+  .confirmPayNowPayment('', {})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmPayNowPayment('', {
+    payment_method: '',
+  }, {handleActions: false})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmPayNowPayment('', {
+    payment_method: {
+      billing_details: {
+        name: '',
+        email: '',
+      },
+    },
+  }, {handleActions: false})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
   .confirmPayPalPayment('', {
     return_url: 'https://example.com',
   })
@@ -1156,6 +1177,27 @@ stripe
     payment_method: '',
     return_url: 'https://example.com',
   })
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmPromptPayPayment('', {})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmPromptPayPayment('', {
+    payment_method: '',
+  }, {handleActions: false})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmPromptPayPayment('', {
+    payment_method: {
+      billing_details: {
+        name: '',
+        email: '',
+      },
+    },
+  }, {handleActions: false})
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -312,6 +312,24 @@ declare module '@stripe/stripe-js' {
      * Requires beta access:
      * Contact [Stripe support](https://support.stripe.com/) for more information.
      *
+     * Use `stripe.confirmPayNowPayment` in the [PayNow Payments](https://stripe.com/docs/payments/paynow) with Payment Methods flow when the customer submits your payment form.
+     * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide.
+     * Refer to our [integration guide](https://stripe.com/docs/payments/paynow) for more details.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new PaymentMethod for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     */
+    confirmPayNowPayment(
+      clientSecret: string,
+      data?: ConfirmPayNowPaymentData,
+      options?: ConfirmPayNowPaymentOptions
+    ): Promise<PaymentIntentResult>;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
      * Use `stripe.confirmPayPalPayment` in the [PayPal Payments](https://stripe.com/docs/payments/paypal) with Payment Methods flow when the customer submits your payment form.
      * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide, and it will automatically redirect the customer to authorize the transaction.
      * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
@@ -325,6 +343,24 @@ declare module '@stripe/stripe-js' {
     confirmPayPalPayment(
       clientSecret: string,
       data?: ConfirmPayPalPaymentData
+    ): Promise<PaymentIntentResult>;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Use `stripe.confirmPromptPayPayment` in the [PromptPay Payments](https://stripe.com/docs/payments/promptpay) with Payment Methods flow when the customer submits your payment form.
+     * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide.
+     * Refer to our [integration guide](https://stripe.com/docs/payments/promptpay) for more details.
+     *
+     * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new PaymentMethod for you.
+     * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+     */
+    confirmPromptPayPayment(
+      clientSecret: string,
+      data?: ConfirmPromptPayPaymentData,
+      options?: ConfirmPromptPayPaymentOptions
     ): Promise<PaymentIntentResult>;
 
     /**

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -772,6 +772,31 @@ declare module '@stripe/stripe-js' {
   }
 
   /**
+   * Data to be sent with a `stripe.confirmPayNowPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmPayNowPaymentData extends PaymentIntentConfirmParams {
+    /**
+     * The `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent` or a new `PaymentMethod` will be created.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<ConfirmPayNowPaymentData, 'type'>;
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmPayNowPayment`.
+   */
+  interface ConfirmPayNowPaymentOptions {
+    /**
+     * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/p24#handle-redirect).
+     * Default is `true`.
+     */
+    handleActions?: boolean;
+  }
+
+  /**
    * Data to be sent with a `stripe.confirmPayPalPayment` request.
    * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
    */
@@ -794,6 +819,31 @@ declare module '@stripe/stripe-js' {
    * An options object to control the behavior of `stripe.confirmP24Payment`.
    */
   interface ConfirmP24PaymentOptions {
+    /**
+     * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/p24#handle-redirect).
+     * Default is `true`.
+     */
+    handleActions?: boolean;
+  }
+
+  /**
+   * Data to be sent with a `stripe.confirmPayNowPayment` request.
+   * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+   */
+  interface ConfirmPromptPayPaymentData extends PaymentIntentConfirmParams {
+    /**
+     * The `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+     * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent` or a new `PaymentMethod` will be created.
+     *
+     * @recommended
+     */
+    payment_method?: string | Omit<ConfirmPromptPayPaymentData, 'type'>;
+  }
+
+  /**
+   * An options object to control the behavior of `stripe.confirmPayNowPayment`.
+   */
+  interface ConfirmPromptPayPaymentOptions {
     /**
      * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/p24#handle-redirect).
      * Default is `true`.

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -16,6 +16,8 @@ declare module '@stripe/stripe-js' {
     | CreatePaymentMethodIdealData
     | CreatePaymentMethodKlarnaData
     | CreatePaymentMethodP24Data
+    | CreatePaymentMethodPayNowData
+    | CreatePaymentMethodPromptPayData
     | CreatePaymentMethodFpxData
     | CreatePaymentMethodSepaDebitData
     | CreatePaymentMethodSofortData

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -219,8 +219,16 @@ declare module '@stripe/stripe-js' {
         };
   }
 
+  interface CreatePaymentMethodPayNowData extends PaymentMethodCreateParams {
+    type: 'paynow';
+  }
+
   interface CreatePaymentMethodPayPalData extends PaymentMethodCreateParams {
     type: 'paypal';
+  }
+
+  interface CreatePaymentMethodPromptPayData extends PaymentMethodCreateParams {
+    type: 'promptpay';
   }
 
   interface CreatePaymentMethodSepaDebitData extends PaymentMethodCreateParams {
@@ -782,7 +790,7 @@ declare module '@stripe/stripe-js' {
      *
      * @recommended
      */
-    payment_method?: string | Omit<ConfirmPayNowPaymentData, 'type'>;
+    payment_method?: string | Omit<CreatePaymentMethodPayNowData, 'type'>;
   }
 
   /**
@@ -837,7 +845,7 @@ declare module '@stripe/stripe-js' {
      *
      * @recommended
      */
-    payment_method?: string | Omit<ConfirmPromptPayPaymentData, 'type'>;
+    payment_method?: string | Omit<CreatePaymentMethodPromptPayData, 'type'>;
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
add type hint for `confirmPayNowPayment` and `confirmPromptPayPayment`

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->
no tests. would rework on test if I know how to test this

<!-- If this is an API change, have you updated the documentation? -->
the integration documentation for paynow and promptpay is live. wip with js documentation

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
