### PR TITLE
Fix missing Checkout types

### DIFF
--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -1,3 +1,4 @@
+export * from './checkout';
 export * from './elements';
 export * from './elements-group';
 export * from './payment-intents';


### PR DESCRIPTION
### Summary & motivation

Version `1.21.0` introduce a small issue and Checkout types are not being exported. 

This simple fix seems to do the trick. Feel free to close this if you already have it or I'm missing something, just trying to help :)

### Testing & documentation

I think no tests are required in this case, really simple fix. 

This is the issue I'm trying to fix: https://github.com/stripe/stripe-js/issues/259