### PR TITLE
Adding `'flat'` theme to `appearance.theme` union type

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -533,7 +533,7 @@ export interface CustomFontSource {
  * @docs https://stripe.com/docs/stripe-js/appearance-api
  */
 export interface Appearance {
-  theme?: 'stripe' | 'night' | 'none';
+  theme?: 'stripe' | 'night' | 'flat' | 'none';
 
   variables?: {
     // General font styles


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Add `'flat'` to the `apperance.theme` union type. Fixes https://github.com/stripe/stripe-js/issues/266.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Type-only change