### PR TITLE
Add `readOnly` type to PaymentElementOptions

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -272,6 +272,7 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
   business: {
     name: '',
   },
+  readOnly: true,
   paymentMethodOrder: ['card', 'sepa_debit'],
   wallets: {
     applePay: 'never',

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -153,6 +153,12 @@ export interface StripePaymentElementOptions {
   fields?: FieldsOption;
 
   /**
+   * Apply a read-only state to the Payment Element so that payment details can’t be changed.
+   * Default is false.
+   */
+  readOnly?: boolean;
+
+  /**
    * Control terms display in the Payment Element.
    */
   terms?: TermsOption;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Add `readOnly` to `StripePaymentElementOptions` type

### Testing & documentation
Just a type change

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
