### PR TITLE
Add missing ConfirmSofortPaymentOptions options

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -1372,17 +1372,23 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
-  .confirmSofortPayment('', {
-    payment_method: {
-      sofort: {
-        country: '',
+  .confirmSofortPayment(
+    '',
+    {
+      payment_method: {
+        sofort: {
+          country: '',
+        },
+        billing_details: {
+          name: '',
+        },
       },
-      billing_details: {
-        name: '',
-      },
+      return_url: '',
     },
-    return_url: '',
-  })
+    {
+      handleActions: false,
+    }
+  )
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -995,6 +995,17 @@ export interface ConfirmSofortPaymentData extends PaymentIntentConfirmParams {
 }
 
 /**
+ * An options object to control the behavior of `stripe.confirmSofortPayment`.
+ */
+export interface ConfirmSofortPaymentOptions {
+  /**
+   * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/sofort#handle-redirect).
+   * Default is `true`.
+   */
+  handleActions?: boolean;
+}
+
+/**
  * Data to be sent with a `stripe.confirmWechatPayPayment` request.
  * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
  */

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -424,7 +424,8 @@ export interface Stripe {
    */
   confirmSofortPayment(
     clientSecret: string,
-    data?: paymentIntents.ConfirmSofortPaymentData
+    data?: paymentIntents.ConfirmSofortPaymentData,
+    options?: paymentIntents.ConfirmSofortPaymentOptions
   ): Promise<PaymentIntentResult>;
 
   /**


### PR DESCRIPTION
As all the other payment methods, stripe.confirmSofortPayment
also have a third parameter, which allows developer to control
the execution. In particular it allows handling the redirect manually.
This behavior is described in the official documentation. Thus we adding
a missing parameter type
Reference: https://stripe.com/docs/js/payment_intents/confirm_sofort_payment#stripe_confirm_sofort_payment-options

UPD: I verified it works currently if I disable TS type check with `@ts-expect-error` like that
```typescript
      return stripe
        .confirmSofortPayment(intent, {
          payment_method: {
            sofort: {
              country: country.toUpperCase(),
            },
          },
          return_url: returnUrl,
        },
        // @ts-expect-error   
          {
          handleActions: false,
        })
```