### PR TITLE
Update shipping address element options and change event

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -451,6 +451,18 @@ shippingAddressElementDefaults = elements.create('shippingAddress', {});
 
 const shippingAddressElement = elements.create('shippingAddress', {
   allowedCountries: ['US'],
+  blockPoBox: true,
+  defaultValues: {
+    name: 'Jane Doe',
+    address: {
+      line1: '513 Townsend St',
+      city: 'San Francisco',
+      state: 'CA',
+      postal_code: '92122',
+      country: 'US',
+    },
+  },
+  disableAutocomplete: true,
 });
 
 shippingAddressElement

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -95,6 +95,31 @@ export interface StripeShippingAddressElementOptions {
    * Control which countries are displayed in the shippingAddress Element.
    */
   allowedCountries?: string[] | null;
+
+  /**
+   * Whether or not ShippingAddressElement accepts PO boxes
+   */
+  blockPoBox?: boolean;
+
+  /**
+   * Default value for ShippingAddressElement fields
+   */
+  defaultValues?: {
+    name?: string | null;
+    address?: {
+      line1?: string | null;
+      line2?: string | null;
+      city?: string | null;
+      state?: string | null;
+      postal_code?: string | null;
+      country: string;
+    };
+  };
+
+  /**
+   * Whether or not ShippingAddressElement provides autocomplete suggestions
+   */
+  disableAutocomplete?: boolean;
 }
 
 export interface StripeShippingAddressElementChangeEvent
@@ -124,13 +149,13 @@ export interface StripeShippingAddressElementChangeEvent
    */
   value: {
     name: string;
-    addressLine1: string;
-    addressLine2: string;
-    locality: string;
-    administrativeArea: string;
-    postalCode: string;
-    country: string;
-    dependentLocality: string;
-    sortingCode: string;
+    address: {
+      line1: string;
+      line2: string;
+      city: string;
+      state: string;
+      postal_code: string;
+      country: string;
+    };
   };
 }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

- Extends shipping address element options
- Updates shipping address element change event

**This should not be merged until private beta of Shipping Address Element and the next beta for Link Authentication Element is announced.**

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

- Updated test to include new options
