### PR TITLE
Add types for stripe.confirmSofort* options

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -1396,6 +1396,10 @@ stripe
   .then(({paymentIntent}: {paymentIntent?: PaymentIntent}) => {});
 
 stripe
+  .confirmSofortPayment('', {}, {handleActions: false})
+  .then(({paymentIntent}: {paymentIntent?: PaymentIntent}) => {});
+
+stripe
   .confirmWechatPayPayment('', {}, {handleActions: false})
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
@@ -1864,6 +1868,10 @@ stripe
 
 stripe
   .confirmSofortSetup('')
+  .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmSofortSetup('', {}, {handleActions: false})
   .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
 
 stripe

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -995,6 +995,17 @@ export interface ConfirmSofortPaymentData extends PaymentIntentConfirmParams {
 }
 
 /**
+ * An options object to control the behavior of `stripe.confirmSofortPayment`.
+ */
+export interface ConfirmSofortPaymentOptions {
+  /**
+   * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/sofort/accept-a-payment?platform=web#handle-redirect).
+   * Default is `true`.
+   */
+  handleActions?: boolean;
+}
+
+/**
  * Data to be sent with a `stripe.confirmWechatPayPayment` request.
  * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
  */

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -101,6 +101,17 @@ export interface ConfirmSofortSetupData extends SetupIntentConfirmParams {
 }
 
 /**
+ * An options object to control the behavior of `stripe.confirmSofortSetup`.
+ */
+export interface ConfirmSofortSetupOptions {
+  /**
+   * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/sofort/accept-a-payment?platform=web#handle-redirect).
+   * Default is `true`.
+   */
+  handleActions?: boolean;
+}
+
+/**
  * Data to be sent with a `stripe.confirmAuBecsDebitSetup` request.
  * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
  */

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -424,7 +424,8 @@ export interface Stripe {
    */
   confirmSofortPayment(
     clientSecret: string,
-    data?: paymentIntents.ConfirmSofortPaymentData
+    data?: paymentIntents.ConfirmSofortPaymentData,
+    options?: paymentIntents.ConfirmSofortPaymentOptions
   ): Promise<PaymentIntentResult>;
 
   /**
@@ -680,7 +681,8 @@ export interface Stripe {
    */
   confirmSofortSetup(
     clientSecret: string,
-    data?: setupIntents.ConfirmSofortSetupData
+    data?: setupIntents.ConfirmSofortSetupData,
+    options?: setupIntents.ConfirmSofortSetupOptions
   ): Promise<SetupIntentResult>;
 
   /**


### PR DESCRIPTION
Adds missing types for the third `options` parameter for [stripe.confirmSofortPayment](https://stripe.com/docs/js/payment_intents/confirm_sofort_payment) and [stripe.confirmSofortSetup](https://stripe.com/docs/js/setup_intents/confirm_sofort_setup).

Fixes #279 