### PR TITLE
type PaymentRequest.abort()

### DIFF
--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -15,6 +15,11 @@ export interface PaymentRequest {
   show(): void;
 
   /**
+   * Closes the browser’s payment interface.
+   */
+  abort?: () => void;
+
+  /**
    * `true` if the browser’s payment interface is showing.
    * When using the `PaymentRequestButtonElement`, this is called for you automatically.
    */

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -16,6 +16,8 @@ export interface PaymentRequest {
 
   /**
    * Closes the browser’s payment interface.
+   *
+   * WARNING: NOT OFFICIALLY SUPPORTED BY STRIPE
    */
   abort?: () => void;
 


### PR DESCRIPTION
### Summary & motivation

Adding `PaymentRequest.abort` type to mirror the [mdn's abort method](https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/abort). As it's not officially supported by stripe, leaving it optional as a use-at-your-own-risk.

### Testing & documentation

Using this type in our own codebase and it works perfectly.