### PR TITLE
Add expand types for collectBankAccount and confirmPayment

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -1615,6 +1615,7 @@ stripe
         billing_details: {name: 'Jenny Rosen', email: 'jenny@example.com'},
       },
     },
+    expand: ['payment_method'],
   })
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
@@ -2023,6 +2024,7 @@ stripe
         billing_details: {name: 'Jenny Rosen', email: 'jenny@example.com'},
       },
     },
+    expand: ['payment_method'],
   })
   .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
 

--- a/types/api/payment-intents.d.ts
+++ b/types/api/payment-intents.d.ts
@@ -77,9 +77,9 @@ export interface PaymentIntent {
   next_action: PaymentIntent.NextAction | null;
 
   /**
-   * ID of the payment method used in this PaymentIntent.
+   * ID of the payment method used in this PaymentIntent, or the PaymentMethod itself if this field is expanded.
    */
-  payment_method: string | null;
+  payment_method: string | null | PaymentMethod;
 
   /**
    * The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.

--- a/types/api/setup-intents.d.ts
+++ b/types/api/setup-intents.d.ts
@@ -52,9 +52,9 @@ export interface SetupIntent {
   next_action: SetupIntent.NextAction | null;
 
   /**
-   * ID of the payment method used with this SetupIntent.
+   * ID of the payment method used with this SetupIntent, or the PaymentMethod itself if this field is expanded.
    */
-  payment_method: string | null;
+  payment_method: string | null | PaymentMethod;
 
   /**
    * The list of payment method types (e.g. card) that this SetupIntent is allowed to set up.

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -1303,6 +1303,11 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
      */
     billing_details?: PaymentMethodCreateParams.BillingDetails;
   };
+
+  /**
+   * Specifies which fields in the response should be expanded.
+   */
+  expand?: Array<string>;
 }
 
 /**
@@ -1325,4 +1330,9 @@ export interface CollectBankAccountForPaymentOptions {
   clientSecret: string;
 
   params: CollectBankAccountParams;
+
+  /**
+   * Specifies which fields in the response should be expanded.
+   */
+  expand?: Array<string>;
 }

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -210,4 +210,9 @@ export interface CollectBankAccountForSetupOptions {
   clientSecret: string;
 
   params: CollectBankAccountParams;
+
+  /**
+   * Specifies which fields in the response should be expanded.
+   */
+  expand?: Array<string>;
 }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Adds the `expand` parameter to `collectBankAccountForPayment/Setup`, and `confirmPayment/Setup`. Also includes `PaymentMethod` as a possible type for `payment_method` in a PaymentIntent or SetupIntent. Resolves #309 

### Testing & documentation
Added onto existing unit tests.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
