### PR TITLE
expand PaymentMethod type to include au_becs_debit

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -1639,11 +1639,21 @@ stripe.createPaymentMethod({
   billing_details: {name: 'Jenny Rosen', email: 'jenny@example.com'},
 });
 
-stripe.createPaymentMethod({
-  type: 'au_becs_debit',
-  au_becs_debit: {bsb_number: '', account_number: ''},
-  billing_details: {name: 'Jenny Rosen', email: 'jenny@example.com'},
-});
+stripe
+  .createPaymentMethod({
+    type: 'au_becs_debit',
+    au_becs_debit: {bsb_number: '', account_number: ''},
+    billing_details: {name: 'Jenny Rosen', email: 'jenny@example.com'},
+  })
+  .then(({paymentMethod}) => {
+    if (
+      paymentMethod &&
+      paymentMethod.au_becs_debit &&
+      paymentMethod.au_becs_debit.fingerprint
+    ) {
+      console.log(paymentMethod.au_becs_debit.fingerprint);
+    }
+  });
 
 stripe
   .createPaymentMethod({

--- a/types/api/payment-methods.d.ts
+++ b/types/api/payment-methods.d.ts
@@ -63,6 +63,8 @@ export interface PaymentMethod {
 
   acss_debit?: PaymentMethod.AcssDebit;
 
+  au_becs_debit?: PaymentMethod.AuBecsDebit;
+
   us_bank_account?: PaymentMethod.UsBankAccount;
 }
 


### PR DESCRIPTION
Expands [PaymentMethod type](https://github.com/stripe/stripe-js/blob/master/types/api/payment-methods.d.ts#L6) to include `au_becs_debit`

Fixes https://github.com/stripe/stripe-js/issues/195