### PR TITLE
Add customerOptions type

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -27,6 +27,14 @@ elements.update({
   loader: 'auto',
 });
 
+elements.update({
+  // @ts-expect-error: `loader` is not updatable
+  customerOptions: {
+    customer: 'cus_foo',
+    ephemeralKey: 'ek_test_foo',
+  },
+});
+
 paymentElement.on('change', (e) => {
   // @ts-expect-error: `error` is not present on PaymentElement "change" event.
   if (e.error) {

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -28,7 +28,7 @@ elements.update({
 });
 
 elements.update({
-  // @ts-expect-error: `loader` is not updatable
+  // @ts-expect-error: `customerOptions` is not updatable
   customerOptions: {
     customer: 'cus_foo',
     ephemeralKey: 'ek_test_foo',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -86,6 +86,10 @@ const elements: StripeElements = stripe.elements({
     labels: 'above',
   },
   loader: 'auto',
+  customerOptions: {
+    customer: 'cus_foo',
+    ephemeralKey: 'ek_test_foo',
+  },
 });
 
 const elementsNoOptions: StripeElements = stripe.elements();

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -471,6 +471,15 @@ export interface StripeElementsOptions {
    * Default is `'auto'` (Stripe determines if a loader UI should be shown).
    */
   loader?: 'auto' | 'always' | 'never';
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Display saved PaymentMethods and Customer information.
+   * Supported for the `payment`, `shippingAddress`, and `linkAuthentication` Elements.
+   */
+  customerOptions?: CustomerOptions;
 }
 
 /*
@@ -485,9 +494,6 @@ export interface StripeElementsUpdateOptions {
   locale?: StripeElementLocale;
 
   /**
-   * Used with the Payment Element, requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
-   *
    * Match the design of your site with the appearance option.
    * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
    *
@@ -637,4 +643,16 @@ export interface Appearance {
   };
 
   labels?: 'above' | 'floating';
+}
+
+export interface CustomerOptions {
+  /**
+   * The Customer id.
+   */
+  customer: string;
+
+  /**
+   * The ephemeral key for a Customer that grants temporary access to Customer data.
+   */
+  ephemeralKey: string;
 }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Adds types for `customerOptions` in `stripe.elements()`.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Updated unit tests.
