### PR TITLE
Remove shipping address element `.update()` types

### DIFF
--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -80,14 +80,6 @@ export type StripeShippingAddressElement = StripeElementBase & {
     eventType: 'escape',
     handler?: (event: {elementType: 'shippingAddress'}) => any
   ): StripeShippingAddressElement;
-
-  /**
-   * Updates the options the `ShippingAddressElement` was initialized with.
-   * Updates are merged into the existing configuration.
-   */
-  update(
-    options: Partial<StripeShippingAddressElementOptions>
-  ): StripeShippingAddressElement;
 };
 
 export interface StripeShippingAddressElementOptions {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
- Removes `.update()` for shipping address element as we currently does not support it.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
- Existing tests should pass.
