### PR TITLE
Add Order types

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -87,6 +87,38 @@ stripe
     }
   });
 
+stripe.processOrder({elements, confirmParams: {return_url: ''}}).then((res) => {
+  if (res.error) {
+  }
+
+  // @ts-expect-error redirect only, no paymentIntent expected
+  if (res.paymentIntent) {
+  }
+
+  // @ts-expect-error redirect only, no order expected
+  if (res.order) {
+  }
+});
+
+stripe
+  .processOrder({
+    elements,
+    confirmParams: {return_url: ''},
+    redirect: 'always',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+
+    // @ts-expect-error redirect only, no paymentIntent expected
+    if (res.paymentIntent) {
+    }
+
+    // @ts-expect-error redirect only, no order expected
+    if (res.order) {
+    }
+  });
+
 stripe.createToken(cardElement, {
   currency: '',
   name: '',

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -119,6 +119,18 @@ stripe
     }
   });
 
+stripe.retrieveOrder('{ORDER_CLIENT_SECRET}').then((res) => {
+  if (res.error) {
+  }
+
+  if (res.order) {
+  }
+
+  // @ts-expect-error retrieve order, no paymentIntent expected
+  if (res.paymentIntent) {
+  }
+});
+
 stripe.createToken(cardElement, {
   currency: '',
   name: '',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2168,7 +2168,12 @@ stripe
     }
   });
 
-stripe.retrieveOrder('{ORDER_CLIENT_SECRET}');
+stripe.retrieveOrder('{ORDER_CLIENT_SECRET}').then((res) => {
+  if (res.error) {
+  }
+  if (res.order) {
+  }
+});
 
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2139,6 +2139,37 @@ stripe
     }
   });
 
+stripe
+  .processOrder({
+    elements,
+    redirect: 'if_required',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.paymentIntent) {
+    }
+    if (res.order) {
+    }
+  });
+
+stripe
+  .processOrder({
+    elements,
+    confirmParams: {},
+    redirect: 'if_required',
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.paymentIntent) {
+    }
+    if (res.order) {
+    }
+  });
+
+stripe.retrieveOrder('{ORDER_CLIENT_SECRET}');
+
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',
   currency: 'usd',

--- a/types/api/index.d.ts
+++ b/types/api/index.d.ts
@@ -1,6 +1,7 @@
 export * from './shared';
 export * from './payment-methods';
 export * from './payment-intents';
+export * from './orders';
 export * from './setup-intents';
 export * from './sources';
 export * from './tokens';

--- a/types/api/orders.d.ts
+++ b/types/api/orders.d.ts
@@ -1,0 +1,122 @@
+import {Address} from './shared';
+import {PaymentIntent} from './payment-intents';
+
+/**
+ * The Order object.
+ */
+export interface Order {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   */
+  object: 'order';
+
+  /**
+   * Total order cost after discounts and taxes are applied. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). To submit an order, the total must be either 0 or at least $0.50 USD or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts).
+   */
+  amount_total: number;
+
+  /**
+   * Order cost before any discounts or taxes are applied. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
+   */
+  amount_subtotal: number;
+
+  /**
+   * Customer billing details associated with the order.
+   */
+  billing_details: Order.Billing | null;
+
+  /**
+   * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+   */
+  currency: string;
+
+  /**
+   * Time at which the object was created. Measured in seconds since the Unix epoch.
+   */
+  created: number;
+
+  /**
+   * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+   */
+  livemode: boolean;
+
+  /**
+   * Customer shipping information associated with the order.
+   */
+  shipping_details: Order.Shipping | null;
+
+  /**
+   * Payment information associated with the order.
+   */
+  payment: Order.Payment;
+
+  /**
+   * The overall status of the order.
+   */
+  status: Order.Status;
+}
+
+export namespace Order {
+  export interface Billing {
+    /**
+     * Billing address for the order.
+     */
+    address?: Address;
+
+    /**
+     * Email address for the order.
+     */
+    email?: string | null;
+
+    /**
+     * Full name for the order.
+     */
+    name?: string | null;
+
+    /**
+     * Billing phone number for the order (including extension).
+     */
+    phone?: string | null;
+  }
+
+  export interface Shipping {
+    /**
+     * Recipient shipping address. Required if the order includes products that are shippable.
+     */
+    address?: Address;
+
+    /**
+     * Recipient name.
+     */
+    name?: string | null;
+
+    /**
+     * Recipient phone (including extension).
+     */
+    phone?: string | null;
+  }
+
+  export interface Payment {
+    /**
+     * Payment intent associated with this order. Null when the order is `open`.
+     */
+    payment_intent?: PaymentIntent | null;
+
+    /**
+     * The status of the underlying payment associated with this order, if any. Null when the order is `open`.
+     */
+    status?: PaymentIntent.Status | null;
+  }
+
+  export type Status =
+    | 'open'
+    | 'submitted'
+    | 'processing'
+    | 'complete'
+    | 'canceled';
+}

--- a/types/stripe-js/orders.d.ts
+++ b/types/stripe-js/orders.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Parameters that will be passed on to the Stripe API to confirm payment for an Order's PaymentIntent.
+ */
+export interface ProcessOrderParams {
+  /**
+   * The url your customer will be directed to after they complete payment.
+   */
+  return_url: string;
+}

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -987,6 +987,7 @@ export type SetupIntentResult =
 
 export type OrderResult =
   | {paymentIntent: api.PaymentIntent; order: api.Order; error?: undefined}
+  | {paymentIntent?: undefined; order: api.Order; error?: undefined}
   | {paymentIntent?: undefined; order?: undefined; error: StripeError};
 
 export type PaymentMethodResult =

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -1,6 +1,7 @@
 import * as api from '../api';
 import * as paymentIntents from './payment-intents';
 import * as setupIntents from './setup-intents';
+import * as orders from './orders';
 import * as tokens from './token-and-sources';
 import * as elements from './elements';
 
@@ -47,7 +48,7 @@ export interface Stripe {
    * When called, `stripe.confirmPayment` will attempt to complete any [required actions](https://stripe.com/docs/payments/intents), such as authenticating your user by displaying a 3DS dialog or redirecting them to a bank authorization page.
    * Your user will be redirected to the return_url you pass once the confirmation is complete.
    *
-   * By default, stripe.`confirmPayment` will always redirect to your return_url after a successful confirmation.
+   * By default, `stripe.confirmPayment` will always redirect to your return_url after a successful confirmation.
    * If you set `redirect: "if_required"`, then `stripe.confirmPayment` will only redirect if your user chooses a redirect-based payment method.
    * Setting `if_required` requires that you handle successful confirmations for redirect-based and non-redirect based payment methods separately.
    *
@@ -796,6 +797,49 @@ export interface Stripe {
   retrieveSetupIntent(clientSecret: string): Promise<SetupIntentResult>;
 
   /////////////////////////////
+  /// Orders
+  ///
+  /// https://stripe.com/docs/js/orders
+  /////////////////////////////
+
+  /**
+   * Use `stripe.processOrder` to submit and confirm payment for an [Order](https://stripe.com/docs/api/orders_v2) using data collected by the [Payment Element](https://stripe.com/docs/js/element/payment_element).
+   * When called, `stripe.processOrder` will attempt to complete any required actions, such as authenticating your user by displaying a 3DS dialog or redirecting them to a bank authorization page.
+   * Your user will be redirected to the return_url you pass once the confirmation is complete.
+   *
+   * By default, `stripe.processOrder` will always redirect to your return_url after a successful confirmation.
+   * If you set `redirect: "if_required"`, then `stripe.processOrder` will only redirect if your user chooses a redirect-based method.
+   * Setting `if_required` requires that you handle successful confirmations for redirect-based and non-redirect based payment methods separately.
+   *
+   * @docs https://stripe.com/docs/js/orders/process_order
+   */
+  processOrder(options: {
+    elements: StripeElements;
+    confirmParams?: Partial<orders.ProcessOrderParams>;
+    redirect: 'if_required';
+  }): Promise<OrderResult>;
+
+  /**
+   * Use `stripe.processOrder` to submit and confirm payment for an [Order](https://stripe.com/docs/api/orders_v2) using data collected by the [Payment Element](https://stripe.com/docs/js/element/payment_element).
+   * When called, `stripe.processOrder` will attempt to complete any required actions, such as authenticating your user by displaying a 3DS dialog or redirecting them to a bank authorization page.
+   * Your user will be redirected to the return_url you pass once the confirmation is complete.
+   *
+   * @docs https://stripe.com/docs/js/orders/process_order
+   */
+  processOrder(options: {
+    elements: StripeElements;
+    confirmParams: orders.ProcessOrderParams;
+    redirect?: 'always';
+  }): Promise<never | {error: StripeError}>;
+
+  /**
+   * Retrieve an [Order](https://stripe.com/docs/api/orders_v2) using its [client secret](https://stripe.com/docs/api/orders_v2/object#order_v2_object-client_secret).
+   *
+   * @docs https://stripe.com/docs/js/orders/retrieve_order
+   */
+  retrieveOrder(clientSecret: string): Promise<OrderResult>;
+
+  /////////////////////////////
   /// Payment Request
   ///
   /// https://stripe.com/docs/js/payment_request
@@ -940,6 +984,10 @@ export type PaymentIntentResult =
 export type SetupIntentResult =
   | {setupIntent: api.SetupIntent; error?: undefined}
   | {setupIntent?: undefined; error: StripeError};
+
+export type OrderResult =
+  | {paymentIntent: api.PaymentIntent; order: api.Order; error?: undefined}
+  | {paymentIntent?: undefined; order?: undefined; error: StripeError};
 
 export type PaymentMethodResult =
   | {paymentMethod: api.PaymentMethod; error?: undefined}

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -817,7 +817,7 @@ export interface Stripe {
     elements: StripeElements;
     confirmParams?: Partial<orders.ProcessOrderParams>;
     redirect: 'if_required';
-  }): Promise<OrderResult>;
+  }): Promise<ProcessOrderResult>;
 
   /**
    * Use `stripe.processOrder` to submit and confirm payment for an [Order](https://stripe.com/docs/api/orders_v2) using data collected by the [Payment Element](https://stripe.com/docs/js/element/payment_element).
@@ -837,7 +837,7 @@ export interface Stripe {
    *
    * @docs https://stripe.com/docs/js/orders/retrieve_order
    */
-  retrieveOrder(clientSecret: string): Promise<OrderResult>;
+  retrieveOrder(clientSecret: string): Promise<RetrieveOrderResult>;
 
   /////////////////////////////
   /// Payment Request
@@ -985,10 +985,14 @@ export type SetupIntentResult =
   | {setupIntent: api.SetupIntent; error?: undefined}
   | {setupIntent?: undefined; error: StripeError};
 
-export type OrderResult =
+export type ProcessOrderResult =
   | {paymentIntent: api.PaymentIntent; order: api.Order; error?: undefined}
   | {paymentIntent?: undefined; order: api.Order; error?: undefined}
   | {paymentIntent?: undefined; order?: undefined; error: StripeError};
+
+export type RetrieveOrderResult =
+  | {order: api.Order; error?: undefined}
+  | {order?: undefined; error: StripeError};
 
 export type PaymentMethodResult =
   | {paymentMethod: api.PaymentMethod; error?: undefined}


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
#322 
Add missing type declarations for Order:
- `stripe.processOrder`
- `stripe.retrieveOrder`

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Added type tests to `valid.ts` and `invalid.ts`
