### PR TITLE
Make address.line2 nullable in StripeShippingAddressElementChangeEvent

### DIFF
--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -143,7 +143,7 @@ export interface StripeShippingAddressElementChangeEvent
     name: string;
     address: {
       line1: string;
-      line2: string;
+      line2: string | null;
       city: string;
       state: string;
       postal_code: string;


### PR DESCRIPTION
### Summary & motivation

- Adds `null` as a possible type for `value.address.line2` in `StripeShippingAddressElementChangeEvent`

### Testing & documentation

Ran the existing tests
