### PR TITLE
Add missing `descriptor_code` type to `VerifyMicrodepositsForSetupData`

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2043,6 +2043,13 @@ stripe
   .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
 
 stripe
+  .verifyMicrodepositsForSetup('', {
+    amounts: [32, 45],
+    descriptor_code: '123456',
+  })
+  .then((result: {setupIntent?: SetupIntent; error?: StripeError}) => null);
+
+stripe
   .collectBankAccountForSetup({
     clientSecret: '',
     params: {

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -187,6 +187,11 @@ export interface VerifyMicrodepositsForSetupData {
    * An array of two positive integers, in cents, equal to the values of the microdeposits sent to the bank account.
    */
   amounts?: Array<number>;
+
+  /**
+   * A six-character code starting with SM present in the microdeposit sent to the bank account.
+   */
+  descriptor_code?: string;
 }
 
 export interface ConfirmUsBankAccountSetupData


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

This PR adds a missing type `descriptor_code` to the `stripe.verifyMicrodepositsForSetup` function ([API Ref](https://stripe.com/docs/js/setup_intents/verify_microdeposits_for_setup))

Fixes https://github.com/stripe/stripe-js/issues/328

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

I verified this property is expected as an optional parameter to that method, and added a valid types test.