### PR TITLE
Adding `loaderror` types to other applicable Elements

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -496,7 +496,16 @@ shippingAddressElement
   .on('ready', (e: {elementType: 'shippingAddress'}) => {})
   .on('focus', (e: {elementType: 'shippingAddress'}) => {})
   .on('blur', (e: {elementType: 'shippingAddress'}) => {})
-  .on('change', (e: StripeShippingAddressElementChangeEvent) => {});
+  .on('change', (e: StripeShippingAddressElementChangeEvent) => {})
+  .on(
+    'loaderror',
+    (e: {
+      elementType: 'shippingAddress';
+      error: {
+        type: string;
+      };
+    }) => {}
+  );
 
 const retrievedShippingAddressElement: StripeShippingAddressElement | null = elements.getElement(
   'shippingAddress'

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -456,7 +456,16 @@ linkAuthenticationElement
   .on('ready', (e: {elementType: 'linkAuthentication'}) => {})
   .on('focus', (e: {elementType: 'linkAuthentication'}) => {})
   .on('blur', (e: {elementType: 'linkAuthentication'}) => {})
-  .on('change', (e: StripeLinkAuthenticationElementChangeEvent) => {});
+  .on('change', (e: StripeLinkAuthenticationElementChangeEvent) => {})
+  .on(
+    'loaderror',
+    (e: {
+      elementType: 'linkAuthentication';
+      error: {
+        type: string;
+      };
+    }) => {}
+  );
 
 const retrievedLinkAuthenticationElement: StripeLinkAuthenticationElement | null = elements.getElement(
   'linkAuthentication'

--- a/types/stripe-js/elements/link-authentication.d.ts
+++ b/types/stripe-js/elements/link-authentication.d.ts
@@ -1,4 +1,5 @@
 import {StripeElementBase, StripeElementChangeEvent} from './base';
+import {StripeError} from '../stripe';
 
 export type StripeLinkAuthenticationElement = StripeElementBase & {
   /**
@@ -79,6 +80,31 @@ export type StripeLinkAuthenticationElement = StripeElementBase & {
   off(
     eventType: 'escape',
     handler?: (event: {elementType: 'linkAuthentication'}) => any
+  ): StripeLinkAuthenticationElement;
+
+  /**
+   * Triggered when the element fails to load.
+   */
+  on(
+    eventType: 'loaderror',
+    handler: (event: {
+      elementType: 'linkAuthentication';
+      error: StripeError;
+    }) => any
+  ): StripeLinkAuthenticationElement;
+  once(
+    eventType: 'loaderror',
+    handler: (event: {
+      elementType: 'linkAuthentication';
+      error: StripeError;
+    }) => any
+  ): StripeLinkAuthenticationElement;
+  off(
+    eventType: 'loaderror',
+    handler?: (event: {
+      elementType: 'linkAuthentication';
+      error: StripeError;
+    }) => any
   ): StripeLinkAuthenticationElement;
 };
 

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -1,4 +1,5 @@
 import {StripeElementBase, StripeElementChangeEvent} from './base';
+import {StripeError} from '../stripe';
 
 export type StripeShippingAddressElement = StripeElementBase & {
   /**
@@ -79,6 +80,31 @@ export type StripeShippingAddressElement = StripeElementBase & {
   off(
     eventType: 'escape',
     handler?: (event: {elementType: 'shippingAddress'}) => any
+  ): StripeShippingAddressElement;
+
+  /**
+   * Triggered when the element fails to load.
+   */
+  on(
+    eventType: 'loaderror',
+    handler: (event: {
+      elementType: 'shippingAddress';
+      error: StripeError;
+    }) => any
+  ): StripeShippingAddressElement;
+  once(
+    eventType: 'loaderror',
+    handler: (event: {
+      elementType: 'shippingAddress';
+      error: StripeError;
+    }) => any
+  ): StripeShippingAddressElement;
+  off(
+    eventType: 'loaderror',
+    handler?: (event: {
+      elementType: 'shippingAddress';
+      error: StripeError;
+    }) => any
   ): StripeShippingAddressElement;
 };
 


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

We added types for `loaderror` to the Payment Element recently, but other Elements emit that event as well.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

I added valid type tests.
