### PR TITLE
Add `defaultValues` to `StripePaymentElementOptions` interface

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -277,7 +277,7 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
         city: 'South San Francisco',
         state: 'CA',
         country: 'US',
-        postalCode: '94080',
+        postal_code: '94080',
       },
     },
   },

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -266,6 +266,21 @@ const afterpayClearpayMessageElement = elements.create(
 );
 
 const paymentElement: StripePaymentElement = elements.create('payment', {
+  defaultValues: {
+    billingDetails: {
+      name: 'Jane Doe',
+      email: 'jane.doe@example.com',
+      phone: '8004444444',
+      address: {
+        line1: '354 Oyster Point Blvd',
+        line2: '',
+        city: 'South San Francisco',
+        state: 'CA',
+        country: 'US',
+        postalCode: '94080'
+      }
+    }
+  },
   fields: {
     billingDetails: {
       email: 'never',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -277,9 +277,9 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
         city: 'South San Francisco',
         state: 'CA',
         country: 'US',
-        postalCode: '94080'
-      }
-    }
+        postalCode: '94080',
+      },
+    },
   },
   fields: {
     billingDetails: {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -117,7 +117,7 @@ export interface DefaultValuesOption {
     phone?: string;
     address?: {
       country?: string;
-      postalCode?: string;
+      postal_code?: string;
       state?: string;
       city?: string;
       line1?: string;

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -110,6 +110,24 @@ export type StripePaymentElement = StripeElementBase & {
   collapse(): StripePaymentElement;
 };
 
+export interface DefaultValuesOption {
+  billingDetails?:
+    {
+      name?: string;
+      email?: string;
+      phone?: string;
+      address?:
+        {
+          country?: string;
+          postalCode?: string;
+          state?: string;
+          city?: string;
+          line1?: string;
+          line2?: string;
+        };
+    };
+}
+
 export type FieldOption = 'auto' | 'never';
 
 export interface FieldsOption {
@@ -152,6 +170,11 @@ export interface WalletsOption {
 }
 
 export interface StripePaymentElementOptions {
+  /**
+   * Provide initial customer information that will be displayed in the Payment Element.
+   */
+  defaultValues?: DefaultValuesOption;
+
   /**
    * Override the business name displayed in the Payment Element.
    * By default the PaymentElement will use your Stripe account or business name.

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -111,21 +111,19 @@ export type StripePaymentElement = StripeElementBase & {
 };
 
 export interface DefaultValuesOption {
-  billingDetails?:
-    {
-      name?: string;
-      email?: string;
-      phone?: string;
-      address?:
-        {
-          country?: string;
-          postalCode?: string;
-          state?: string;
-          city?: string;
-          line1?: string;
-          line2?: string;
-        };
+  billingDetails?: {
+    name?: string;
+    email?: string;
+    phone?: string;
+    address?: {
+      country?: string;
+      postalCode?: string;
+      state?: string;
+      city?: string;
+      line1?: string;
+      line2?: string;
     };
+  };
 }
 
 export type FieldOption = 'auto' | 'never';


### PR DESCRIPTION
### Summary & motivation

We ran into typescript error when using the [`defaultValues`](https://stripe.com/docs/js/elements_object/create_payment_element#payment_element_create-options-defaultValues) option in Payment Element. This adds it to `StripePaymentElementOptions` interface.

### Testing & documentation

I wrote unit tests.
