### PR TITLE
Add `loaderstart` event

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -319,6 +319,7 @@ paymentElement
   .on('ready', (e: {elementType: 'payment'}) => {})
   .on('focus', (e: {elementType: 'payment'}) => {})
   .on('blur', (e: {elementType: 'payment'}) => {})
+  .on('loaderstart', (e: {elementType: 'payment'}) => {})
   .on(
     'change',
     (e: {
@@ -472,6 +473,7 @@ linkAuthenticationElement
   .on('focus', (e: {elementType: 'linkAuthentication'}) => {})
   .on('blur', (e: {elementType: 'linkAuthentication'}) => {})
   .on('change', (e: StripeLinkAuthenticationElementChangeEvent) => {})
+  .on('loaderstart', (e: {elementType: 'linkAuthentication'}) => {})
   .on(
     'loaderror',
     (e: {
@@ -512,6 +514,7 @@ shippingAddressElement
   .on('focus', (e: {elementType: 'shippingAddress'}) => {})
   .on('blur', (e: {elementType: 'shippingAddress'}) => {})
   .on('change', (e: StripeShippingAddressElementChangeEvent) => {})
+  .on('loaderstart', (e: {elementType: 'shippingAddress'}) => {})
   .on(
     'loaderror',
     (e: {

--- a/types/stripe-js/elements/link-authentication.d.ts
+++ b/types/stripe-js/elements/link-authentication.d.ts
@@ -106,6 +106,22 @@ export type StripeLinkAuthenticationElement = StripeElementBase & {
       error: StripeError;
     }) => any
   ): StripeLinkAuthenticationElement;
+
+  /**
+   * Triggered when the loader UI is mounted to the DOM and ready to be displayed.
+   */
+  on(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'linkAuthentication'}) => any
+  ): StripeLinkAuthenticationElement;
+  once(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'linkAuthentication'}) => any
+  ): StripeLinkAuthenticationElement;
+  off(
+    eventType: 'loaderstart',
+    handler?: (event: {elementType: 'linkAuthentication'}) => any
+  ): StripeLinkAuthenticationElement;
 };
 
 export interface StripeLinkAuthenticationElementOptions {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -99,6 +99,22 @@ export type StripePaymentElement = StripeElementBase & {
   ): StripePaymentElement;
 
   /**
+   * Triggered when the loader UI is mounted to the DOM and ready to be displayed.
+   */
+  on(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'payment'}) => any
+  ): StripePaymentElement;
+  once(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'payment'}) => any
+  ): StripePaymentElement;
+  off(
+    eventType: 'loaderstart',
+    handler?: (event: {elementType: 'payment'}) => any
+  ): StripePaymentElement;
+
+  /**
    * Updates the options the `PaymentElement` was initialized with.
    * Updates are merged into the existing configuration.
    */

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -106,6 +106,22 @@ export type StripeShippingAddressElement = StripeElementBase & {
       error: StripeError;
     }) => any
   ): StripeShippingAddressElement;
+
+  /**
+   * Triggered when the loader UI is mounted to the DOM and ready to be displayed.
+   */
+  on(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'shippingAddress'}) => any
+  ): StripeShippingAddressElement;
+  once(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'shippingAddress'}) => any
+  ): StripeShippingAddressElement;
+  off(
+    eventType: 'loaderstart',
+    handler?: (event: {elementType: 'shippingAddress'}) => any
+  ): StripeShippingAddressElement;
 };
 
 export interface StripeShippingAddressElementOptions {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Add `loaderstart` event to all applicable Elements. This event will trigger when the loader UI is enabled and mounted to the DOM ready to be displayed.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Added valid type tests.
