### PR TITLE
Add Financial Connections types

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2218,6 +2218,25 @@ stripe.retrieveOrder('{ORDER_CLIENT_SECRET}').then((res) => {
   }
 });
 
+stripe
+  .collectFinancialConnectionsAccounts({
+    clientSecret: '{FINANCIAL_CONNECTIONS_CLIENT_SECRET}',
+  })
+  .then((result) => {
+    if (result.error) {
+    }
+
+    if (result.financialConnectionsSession) {
+      const numAccounts = result.financialConnectionsSession.accounts.length;
+      const accountNames = result.financialConnectionsSession.accounts.map(
+        (account) => account.display_name
+      );
+
+      console.log(numAccounts);
+      console.log(accountNames);
+    }
+  });
+
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',
   currency: 'usd',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2237,6 +2237,21 @@ stripe
     }
   });
 
+stripe
+  .collectBankAccountToken({
+    clientSecret: '{FINANCIAL_CONNECTIONS_CLIENT_SECRET}',
+  })
+  .then((result) => {
+    if (result.error) {
+    }
+
+    if (result.financialConnectionsSession) {
+    }
+
+    if (result.token) {
+    }
+  });
+
 const paymentRequest: PaymentRequest = stripe.paymentRequest({
   country: 'US',
   currency: 'usd',

--- a/types/api/financial-connections.d.ts
+++ b/types/api/financial-connections.d.ts
@@ -1,0 +1,86 @@
+/**
+ * The Financial Connections Session object
+ */
+export interface FinancialConnectionsSession {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
+
+  /**
+   * List of accounts collected by the Session
+   */
+  accounts: FinancialConnectionsSession.Account[];
+
+  /**
+   * Filters applied to the Session
+   */
+  filters?: FinancialConnectionsSession.Filters;
+
+  /**
+   * List of data permissions requested in the Session
+   */
+  permissions?: FinancialConnectionsSession.Permission[];
+
+  /**
+   * For webview integrations only. The user will be redirected to this URL to return to your app.
+   */
+  return_url?: string;
+}
+
+export namespace FinancialConnectionsSession {
+  /**
+   * The Financial Connections Account object
+   */
+  export interface Account {
+    /**
+     * Unique identifier for the object.
+     */
+    id: string;
+
+    /**
+     * String representing the object's type. `'linked_account'` is present for backwards-compatibility.
+     */
+    object: 'linked_account' | 'financial_connections.account';
+
+    /**
+     * The type of the account.
+     */
+    category: string;
+
+    /**
+     * A human-readable name that has been assigned to this account, either by the account holder or by the institution.
+     */
+    display_name: string;
+
+    /**
+     * The name of the institution that holds this account.
+     */
+    institution_name: string;
+
+    /**
+     * The last 4 digits of the account number. If present, this will be 4 numeric characters.
+     */
+    last4: string | null;
+  }
+
+  /**
+   * Filters to restrict the kinds of accounts to collect.
+   */
+  export interface Filters {
+    /**
+     * List of countries from which to collect accounts.
+     */
+    countries?: string[];
+  }
+
+  /**
+   * Data features to which access can be requested
+   */
+  export type Permission =
+    | 'payment_method'
+    | 'balances'
+    | 'transactions'
+    | 'ownership'
+    | 'account_numbers';
+}

--- a/types/api/index.d.ts
+++ b/types/api/index.d.ts
@@ -8,3 +8,4 @@ export * from './tokens';
 export * from './bank-accounts';
 export * from './cards';
 export * from './verification-sessions';
+export * from './financial-connections';

--- a/types/stripe-js/financial-connections.d.ts
+++ b/types/stripe-js/financial-connections.d.ts
@@ -7,3 +7,13 @@ export interface CollectFinancialConnectionsAccountsOptions {
    */
   clientSecret: string;
 }
+
+/**
+ * Data to be sent with a `stripe.collectBankAccountToken` request.
+ */
+export interface CollectBankAccountTokenOptions {
+  /**
+   * The client secret of the [Financial Connections Session](https://stripe.com/docs/api/financial_connections/session).
+   */
+  clientSecret: string;
+}

--- a/types/stripe-js/financial-connections.d.ts
+++ b/types/stripe-js/financial-connections.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Data to be sent with a `stripe.collectFinancialConnectionsAccounts` request.
+ */
+export interface CollectFinancialConnectionsAccountsOptions {
+  /**
+   * The client secret of the [Financial Connections Session](https://stripe.com/docs/api/financial_connections/session).
+   */
+  clientSecret: string;
+}

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -4,6 +4,7 @@ import * as setupIntents from './setup-intents';
 import * as orders from './orders';
 import * as tokens from './token-and-sources';
 import * as elements from './elements';
+import * as financialConnections from './financial-connections';
 
 import {StripeElements, StripeElementsOptions} from './elements-group';
 import {RedirectToCheckoutOptions} from './checkout';
@@ -975,6 +976,20 @@ export interface Stripe {
    * * @docs https://stripe.com/docs/js/identity/modal
    */
   verifyIdentity(clientSecret: string): Promise<VerificationSessionResult>;
+
+  /////////////////////////////
+  /// Financial Connections
+  ///
+  /////////////////////////////
+
+  /**
+   * Use `stripe.collectFinancialConnectionsAccounts` to display a [Financial Connections](https://stripe.com/docs/financial-connections) modal that lets you securely collect financial accounts.
+   *
+   * * @docs https://stripe.com/docs/js/financial_connections/collect_financial_connections_accounts
+   */
+  collectFinancialConnectionsAccounts(
+    options: financialConnections.CollectFinancialConnectionsAccountsOptions
+  ): Promise<FinancialConnectionsSessionResult>;
 }
 
 export type PaymentIntentResult =
@@ -1009,6 +1024,13 @@ export type TokenResult =
 export type VerificationSessionResult =
   | {verificationSession: api.VerificationSession; error?: undefined}
   | {verificationSession?: undefined; error: StripeError};
+
+export type FinancialConnectionsSessionResult =
+  | {
+      financialConnectionsSession: api.FinancialConnectionsSession;
+      error?: undefined;
+    }
+  | {financialConnectionsSession: undefined; error: StripeError};
 
 export interface WrapperLibrary {
   /**

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -990,6 +990,15 @@ export interface Stripe {
   collectFinancialConnectionsAccounts(
     options: financialConnections.CollectFinancialConnectionsAccountsOptions
   ): Promise<FinancialConnectionsSessionResult>;
+
+  /**
+   * Use `stripe.collectBankAccountToken` to display a [Financial Connections](https://stripe.com/docs/financial-connections) modal that lets you securely collect a [Bank Account Token](https://stripe.com/docs/api/tokens/object).
+   *
+   * * @docs https://stripe.com/docs/js/financial_connections/collect_bank_account_token
+   */
+  collectBankAccountToken(
+    options: financialConnections.CollectBankAccountTokenOptions
+  ): Promise<CollectBankAccountTokenResult>;
 }
 
 export type PaymentIntentResult =
@@ -1031,6 +1040,18 @@ export type FinancialConnectionsSessionResult =
       error?: undefined;
     }
   | {financialConnectionsSession: undefined; error: StripeError};
+
+export type CollectBankAccountTokenResult =
+  | {
+      financialConnectionsSession: api.FinancialConnectionsSession;
+      token: string;
+      error?: undefined;
+    }
+  | {
+      financialConnectionsSession: undefined;
+      token: undefined;
+      error: StripeError;
+    };
 
 export interface WrapperLibrary {
   /**


### PR DESCRIPTION
### Summary & motivation

Adds missing type definitions for the two entry points related to Financial Connections:

- `collectFinancialConnectionsAccounts`
- `collectBankAccountToken`

### Testing & documentation

- Added cases to `valid.ts`
- For field-level documentation, mostly hewed to match https://stripe.com/docs/api descriptions
