### PR TITLE
Document new options and update method in shipping address element

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -44,7 +44,6 @@ paymentElement.on('change', (e) => {
 });
 
 shippingAddressElement.update({
-  // @ts-expect-error: Argument of type '{ defaultValues: { allowedCountries: string[]; }; }' is not assignable to parameter of type 'StripeShippingAddressElementUpdateOptions'.
   defaultValues: {
     name: 'foo bar',
   },

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -4,6 +4,7 @@ import {
   StripeCardElement,
   StripeIbanElement,
   StripePaymentElement,
+  StripeShippingAddressElement,
 } from '../../../types';
 
 declare const stripe: Stripe;
@@ -11,6 +12,7 @@ declare const elements: StripeElements;
 declare const cardElement: StripeCardElement;
 declare const ibanElement: StripeIbanElement;
 declare const paymentElement: StripePaymentElement;
+declare const shippingAddressElement: StripeShippingAddressElement;
 
 elements.update({
   // @ts-expect-error: `clientSecret` is not updatable
@@ -39,6 +41,13 @@ paymentElement.on('change', (e) => {
   // @ts-expect-error: `error` is not present on PaymentElement "change" event.
   if (e.error) {
   }
+});
+
+shippingAddressElement.update({
+  // @ts-expect-error: Argument of type '{ defaultValues: { allowedCountries: string[]; }; }' is not assignable to parameter of type 'StripeShippingAddressElementUpdateOptions'.
+  defaultValues: {
+    name: 'foo bar',
+  },
 });
 
 stripe

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -4,7 +4,6 @@ import {
   StripeCardElement,
   StripeIbanElement,
   StripePaymentElement,
-  StripeShippingAddressElement,
 } from '../../../types';
 
 declare const stripe: Stripe;
@@ -12,7 +11,6 @@ declare const elements: StripeElements;
 declare const cardElement: StripeCardElement;
 declare const ibanElement: StripeIbanElement;
 declare const paymentElement: StripePaymentElement;
-declare const shippingAddressElement: StripeShippingAddressElement;
 
 elements.update({
   // @ts-expect-error: `clientSecret` is not updatable

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -43,12 +43,6 @@ paymentElement.on('change', (e) => {
   }
 });
 
-shippingAddressElement.update({
-  defaultValues: {
-    name: 'foo bar',
-  },
-});
-
 stripe
   .confirmPayment({elements, confirmParams: {return_url: ''}})
   .then((res) => {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -507,6 +507,14 @@ const shippingAddressElement = elements.create('shippingAddress', {
     },
   },
   disableAutocomplete: true,
+  fields: {
+    phone: 'always',
+  },
+  validation: {
+    phone: {
+      required: 'always',
+    },
+  },
 });
 
 shippingAddressElement
@@ -524,6 +532,15 @@ shippingAddressElement
       };
     }) => {}
   );
+
+shippingAddressElement.update({
+  fields: {
+    phone: 'never',
+  },
+  validation: {
+    phone: undefined,
+  },
+});
 
 const retrievedShippingAddressElement: StripeShippingAddressElement | null = elements.getElement(
   'shippingAddress'

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -512,7 +512,7 @@ const shippingAddressElement = elements.create('shippingAddress', {
   },
   validation: {
     phone: {
-      required: 'always',
+      required: 'never',
     },
   },
 });
@@ -534,11 +534,10 @@ shippingAddressElement
   );
 
 shippingAddressElement.update({
-  fields: {
-    phone: 'never',
-  },
   validation: {
-    phone: undefined,
+    phone: {
+      required: 'always',
+    },
   },
 });
 

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -148,7 +148,7 @@ export type StripeShippingAddressElementUpdateOptions = {
       required: 'always' | 'never' | 'auto';
     };
   };
-}
+};
 
 export interface StripeShippingAddressElementOptions {
   /**

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -148,12 +148,29 @@ export interface StripeShippingAddressElementOptions {
       postal_code?: string | null;
       country: string;
     };
+    phone?: string | null;
   };
 
   /**
    * Whether or not ShippingAddressElement provides autocomplete suggestions
    */
   disableAutocomplete?: boolean;
+
+  /**
+   * Control which additional fields to display in the shippingAddress Element.
+   */
+  fields?: {
+    phone?: 'always' | 'never' | 'auto';
+  };
+
+  /**
+   * Specify validation rules for the above additional fields.
+   */
+  validation?: {
+    phone?: {
+      required: 'always' | 'never' | 'auto';
+    };
+  };
 }
 
 export interface StripeShippingAddressElementChangeEvent
@@ -191,5 +208,6 @@ export interface StripeShippingAddressElementChangeEvent
       postal_code: string;
       country: string;
     };
+    phone?: string;
   };
 }

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -128,26 +128,8 @@ export type StripeShippingAddressElement = StripeElementBase & {
    * Updates are merged into the existing configuration.
    */
   update(
-    options: StripeShippingAddressElementUpdateOptions
+    options: Partial<StripeShippingAddressElementOptions>
   ): StripeShippingAddressElement;
-};
-
-export type StripeShippingAddressElementUpdateOptions = {
-  /**
-   * Control which additional fields to display in the shippingAddress Element.
-   */
-  fields?: {
-    phone?: 'always' | 'never' | 'auto';
-  };
-
-  /**
-   * Specify validation rules for the above additional fields.
-   */
-  validation?: {
-    phone?: {
-      required: 'always' | 'never' | 'auto';
-    };
-  };
 };
 
 export interface StripeShippingAddressElementOptions {

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -122,7 +122,33 @@ export type StripeShippingAddressElement = StripeElementBase & {
     eventType: 'loaderstart',
     handler?: (event: {elementType: 'shippingAddress'}) => any
   ): StripeShippingAddressElement;
+
+  /**
+   * Updates the options the `ShippingAddressElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   */
+  update(
+    options: StripeShippingAddressElementUpdateOptions
+  ): StripeShippingAddressElement;
 };
+
+export type StripeShippingAddressElementUpdateOptions = {
+  /**
+   * Control which additional fields to display in the shippingAddress Element.
+   */
+  fields?: {
+    phone?: 'always' | 'never' | 'auto';
+  };
+
+  /**
+   * Specify validation rules for the above additional fields.
+   */
+  validation?: {
+    phone?: {
+      required: 'always' | 'never' | 'auto';
+    };
+  };
+}
 
 export interface StripeShippingAddressElementOptions {
   /**


### PR DESCRIPTION
### Summary & motivation

- Add `fields` and `validation` options to StripeShippingAddressElementOptions
- Add update method to StripeShippingAddressElement
- Create StripeShippingAddressElementUpdateOptions type

### Testing & documentation

Added valid/invalid type tests

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
