### PR TITLE
Fix CollectBankAccountTokenResult type

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2265,6 +2265,8 @@ stripe
     }
 
     if (result.token) {
+      if (result.token.id) {
+      }
     }
   });
 

--- a/types/api/tokens.d.ts
+++ b/types/api/tokens.d.ts
@@ -1,3 +1,4 @@
+import {Omit} from '../utils';
 import {Card} from './cards';
 import {BankAccount} from './bank-accounts';
 import {JapanAddressParam, MetadataParam} from './shared';
@@ -45,6 +46,10 @@ export interface Token {
    */
   used: boolean;
 }
+
+export type BankAccountToken = Omit<Token, 'card'> & {
+  bank_account: BankAccount;
+};
 
 export namespace TokenCreateParams {
   export interface Account {

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -1044,7 +1044,7 @@ export type FinancialConnectionsSessionResult =
 export type CollectBankAccountTokenResult =
   | {
       financialConnectionsSession: api.FinancialConnectionsSession;
-      token: string;
+      token: api.BankAccountToken;
       error?: undefined;
     }
   | {


### PR DESCRIPTION
### Summary & motivation

- Fixes #342 
- #338 incorrectly specified that `CollectBankAccountTokenResult`'s
  `token` property could be a `string`.
- Exports a new API type to represent Bank Account Tokens, based on the
  existing Token type. `collectBankAccountToken` will never return a
  Card Token.

### Testing & documentation

The addition to `tests/types/src/valid.ts` causes the suite to fail without the
accompanying code change.