### PR TITLE
FIX: TS def XX_bank_account -> XX_bank_transfer

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -1082,7 +1082,7 @@ stripe
         customer_balance: {
           funding_type: 'bank_transfer',
           bank_transfer: {
-            type: 'us_bank_account',
+            type: 'us_bank_transfer',
             requested_address_types: ['aba', 'swift'],
           },
         },
@@ -1105,8 +1105,8 @@ stripe
         customer_balance: {
           funding_type: 'bank_transfer',
           bank_transfer: {
-            type: 'eu_bank_account',
-            eu_bank_account: {
+            type: 'eu_bank_transfer',
+            eu_bank_transfer: {
               country: 'NL',
             },
           },
@@ -1130,8 +1130,8 @@ stripe
         customer_balance: {
           funding_type: 'bank_transfer',
           bank_transfer: {
-            type: 'id_bank_account',
-            id_bank_account: {
+            type: 'id_bank_transfer',
+            id_bank_transfer: {
               bank: 'bni',
             },
           },

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -653,14 +653,14 @@ export interface ConfirmCustomerBalancePaymentData
       funding_type?: 'bank_transfer';
       bank_transfer?: {
         type:
-          | 'us_bank_transfer'
           | 'eu_bank_transfer'
-          | 'id_bank_transfer'
           | 'gb_bank_transfer'
+          | 'id_bank_transfer'
           | 'jp_bank_transfer'
-          | 'mx_bank_transfer';
+          | 'mx_bank_transfer'
+          | 'us_bank_transfer';
         eu_bank_transfer?: {
-          country: 'ES' | 'FR' | 'IE' | 'NL';
+          country: 'DE' | 'ES' | 'FR' | 'IE' | 'NL';
         };
         id_bank_transfer?: {
           bank: 'bni' | 'bca';

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -653,16 +653,16 @@ export interface ConfirmCustomerBalancePaymentData
       funding_type?: 'bank_transfer';
       bank_transfer?: {
         type:
-          | 'us_bank_account'
-          | 'eu_bank_account'
-          | 'id_bank_account'
-          | 'gb_bank_account'
-          | 'jp_bank_account'
-          | 'mx_bank_account';
-        eu_bank_account?: {
+          | 'us_bank_transfer'
+          | 'eu_bank_transfer'
+          | 'id_bank_transfer'
+          | 'gb_bank_transfer'
+          | 'jp_bank_transfer'
+          | 'mx_bank_transfer';
+        eu_bank_transfer?: {
           country: 'ES' | 'FR' | 'IE' | 'NL';
         };
-        id_bank_account?: {
+        id_bank_transfer?: {
           bank: 'bni' | 'bca';
         };
         requested_address_types?: Array<


### PR DESCRIPTION
The API and document tell us using `xx_bank_transfer` string to the `confirmCustomerBalancePayment` method.
But this SDK shows the error when we using these values.

I think we need to  these definition

### Summary & motivation

When we want to use `confirmCustomerBalancePayment` method with TypeScript.
We got these errors:

### TypeScript Error: 

When we copy and paste this example code from the documents:
https://stripe.com/docs/payments/bank-transfers/accept-a-payment?platform=api#collect-payment-method-options

```js
stripe.confirmCustomerBalancePayment(
  '{PAYMENT_INTENT_CLIENT_SECRET}',
  {
    payment_method: {
      customer_balance: {
      },
    },
    payment_method_options: {
      customer_balance: {
        funding_type: 'bank_transfer',
        bank_transfer: {
          type: 'eu_bank_transfer',
          eu_bank_transfer: {
            country: 'FR',
          }
        },
      },
    },
  },
  {
    handleActions: false,
  }
)
```

We got the TypeScript error:

```
./pages/payment_intents/index.tsx:55:23
Type error: Type '"eu_bank_transfer"' is not assignable to type '"us_bank_account" | "eu_bank_account" | "id_bank_account" | "gb_bank_account" | "jp_bank_account" | "mx_bank_account"'.

  53 |                     funding_type: 'bank_transfer',
  54 |                     bank_transfer: {
> 55 |                       type: 'eu_bank_transfer',
     |                       ^
  56 |                       eu_bank_transfer: {
  57 |                         country: 'FR',
  58 |                       }

> Build error occurred
```

### API error:

I tried to update the code to allow the TypeScript error:

```diff_js
stripe.confirmCustomerBalancePayment(
  '{PAYMENT_INTENT_CLIENT_SECRET}',
  {
    payment_method: {
      customer_balance: {
      },
    },
    payment_method_options: {
      customer_balance: {
        funding_type: 'bank_transfer',
        bank_transfer: {
-          type: 'eu_bank_transfer',
+          type: 'eu_bank_account',
-          eu_bank_transfer: {
+          eu_bank_account: {
            country: 'FR',
          }
        },
      },
    },
  },
  {
    handleActions: false,
  }
)
```

Then, the Stripe API returned this error:

```

code: "parameter_unknown"
doc_url: "https://stripe.com/docs/error-codes/parameter-unknown"
message: "Received unknown parameter: payment_method_options[customer_balance][bank_transfer][eu_bank_account]. Did you mean eu_bank_transfer?"
param: "payment_method_options[customer_balance][bank_transfer][eu_bank_account]"
```

So, we may need to update the TypeScript definition to resolve the conflicts.

Thanks!
