### PR TITLE
Deprecates `disableAutocomplete` from SAE

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -506,7 +506,6 @@ const shippingAddressElement = elements.create('shippingAddress', {
       country: 'US',
     },
   },
-  disableAutocomplete: true,
   fields: {
     phone: 'always',
   },

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -160,11 +160,6 @@ export interface StripeShippingAddressElementOptions {
   };
 
   /**
-   * Whether or not ShippingAddressElement provides autocomplete suggestions
-   */
-  disableAutocomplete?: boolean;
-
-  /**
    * Control which additional fields to display in the shippingAddress Element.
    */
   fields?: {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
This PR deprecates the `disableAutocomplete` option from Shipping Address Element as we'll have a new set of autocomplete configurations.

### Testing & documentation
Update the test

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
