### PR TITLE
Add `networkschange` event

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -423,12 +423,15 @@ cardElement
     if (e.error) {
       console.error(e.error.message);
     }
-  });
+  })
+  .on('networkschange', (e: {elementType: 'card'}) => {});
 
 const onceHandler = () => {};
 cardElement.once('ready', onceHandler);
 cardElement.off('ready', onceHandler);
 cardElement.off('change');
+
+cardNumberElement.on('networkschange', (e: {elementType: 'cardNumber'}) => {});
 
 auBankAccountElement.on(
   'change',

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -89,7 +89,7 @@ export type StripeCardNumberElement = StripeElementBase & {
   /**
    * Triggered when there is a change to the available networks the provided card can run on.
    */
-   on(
+  on(
     eventType: 'networkschange',
     handler: (event: {elementType: 'cardNumber'}) => any
   ): StripeCardNumberElement;

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -87,6 +87,22 @@ export type StripeCardNumberElement = StripeElementBase & {
   ): StripeCardNumberElement;
 
   /**
+   * Triggered when there is a change to the available networks the provided card can run on.
+   */
+   on(
+    eventType: 'networkschange',
+    handler: (event: {elementType: 'cardNumber'}) => any
+  ): StripeCardNumberElement;
+  once(
+    eventType: 'networkschange',
+    handler: (event: {elementType: 'cardNumber'}) => any
+  ): StripeCardNumberElement;
+  off(
+    eventType: 'networkschange',
+    handler?: (event: {elementType: 'cardNumber'}) => any
+  ): StripeCardNumberElement;
+
+  /**
    * Updates the options the `CardNumberElement` was initialized with.
    * Updates are merged into the existing configuration.
    *

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -87,6 +87,22 @@ export type StripeCardElement = StripeElementBase & {
   ): StripeCardElement;
 
   /**
+   * Triggered when there is a change to the available networks the provided card can run on.
+   */
+   on(
+    eventType: 'networkschange',
+    handler: (event: {elementType: 'card'}) => any
+  ): StripeCardElement;
+  once(
+    eventType: 'networkschange',
+    handler: (event: {elementType: 'card'}) => any
+  ): StripeCardElement;
+  off(
+    eventType: 'networkschange',
+    handler?: (event: {elementType: 'card'}) => any
+  ): StripeCardElement;
+
+  /**
    * Updates the options the `CardElement` was initialized with.
    * Updates are merged into the existing configuration.
    *

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -89,7 +89,7 @@ export type StripeCardElement = StripeElementBase & {
   /**
    * Triggered when there is a change to the available networks the provided card can run on.
    */
-   on(
+  on(
     eventType: 'networkschange',
     handler: (event: {elementType: 'card'}) => any
   ): StripeCardElement;


### PR DESCRIPTION
### Summary & motivation

Add `networkschange` event to all applicable Elements. This event will trigger when there is a change to the available networks the provided card can run on.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Added valid type tests.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
