### PR TITLE
Add address element types

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -41,6 +41,9 @@ paymentElement.on('change', (e) => {
   }
 });
 
+// @ts-expect-error: AddressElement requires a mode
+elements.create('address');
+
 stripe
   .confirmPayment({elements, confirmParams: {return_url: ''}})
   .then((res) => {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -40,6 +40,8 @@ import {
   StripeLinkAuthenticationElement,
   StripeShippingAddressElementChangeEvent,
   StripeShippingAddressElement,
+  StripeAddressElementChangeEvent,
+  StripeAddressElement,
   StripeElementType,
   CanMakePaymentResult,
   VerificationSession,
@@ -489,6 +491,77 @@ linkAuthenticationElement
 
 const retrievedLinkAuthenticationElement: StripeLinkAuthenticationElement | null = elements.getElement(
   'linkAuthentication'
+);
+
+let addressElementDefaults: StripeAddressElement = elements.create('address', {
+  mode: 'shipping',
+});
+
+addressElementDefaults = elements.create('address', {mode: 'billing'});
+
+const addressElement = elements.create('address', {
+  mode: 'shipping',
+  allowedCountries: ['US'],
+  autocomplete: {mode: 'disabled'},
+  contacts: [
+    {
+      name: 'Jane Doe',
+      address: {
+        line1: '513 Townsend St',
+        city: 'San Francisco',
+        state: 'CA',
+        postal_code: '92122',
+        country: 'US',
+      },
+    },
+  ],
+  blockPoBox: true,
+  defaultValues: {
+    name: 'Jane Doe',
+    address: {
+      line1: '513 Townsend St',
+      city: 'San Francisco',
+      state: 'CA',
+      postal_code: '92122',
+      country: 'US',
+    },
+  },
+  fields: {
+    phone: 'always',
+  },
+  validation: {
+    phone: {
+      required: 'never',
+    },
+  },
+});
+
+addressElement
+  .on('ready', (e: {elementType: 'address'}) => {})
+  .on('focus', (e: {elementType: 'address'}) => {})
+  .on('blur', (e: {elementType: 'address'}) => {})
+  .on('change', (e: StripeAddressElementChangeEvent) => {})
+  .on('loaderstart', (e: {elementType: 'address'}) => {})
+  .on(
+    'loaderror',
+    (e: {
+      elementType: 'address';
+      error: {
+        type: string;
+      };
+    }) => {}
+  );
+
+addressElement.update({
+  validation: {
+    phone: {
+      required: 'always',
+    },
+  },
+});
+
+const retrievedAddressElement: StripeAddressElement | null = elements.getElement(
+  'address'
 );
 
 let shippingAddressElementDefaults: StripeShippingAddressElement = elements.create(

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -1,4 +1,6 @@
 import {
+  StripeAddressElement,
+  StripeAddressElementOptions,
   StripeShippingAddressElement,
   StripeShippingAddressElementOptions,
   StripePaymentRequestButtonElement,
@@ -45,6 +47,29 @@ export interface StripeElements {
    * instance of Elements, and reflects these updates in the Payment Element.
    */
   fetchUpdates(): Promise<{error?: {message: string; status?: string}}>;
+
+  /////////////////////////////
+  /// address
+  /////////////////////////////
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Creates a `AddressElement`.
+   */
+  create(
+    elementType: 'address',
+    options: StripeAddressElementOptions
+  ): StripeAddressElement;
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Looks up a previously created `Element` by its type.
+   */
+  getElement(elementType: 'address'): StripeAddressElement | null;
 
   /////////////////////////////
   /// affirmMessage
@@ -329,9 +354,13 @@ export interface StripeElements {
     elementType: 'paymentRequestButton'
   ): StripePaymentRequestButtonElement | null;
 
+  /////////////////////////////
+  /// shippingAddress
+  /////////////////////////////
+
   /**
-   * Requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   * @deprecated
+   * Use `Address` element instead.
    *
    * Creates a `ShippingAddressElement`.
    */
@@ -341,8 +370,8 @@ export interface StripeElements {
   ): StripeShippingAddressElement;
 
   /**
-   * Requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   * @deprecated
+   * Use `Address` element instead.
    *
    * Looks up a previously created `Element` by its type.
    */
@@ -352,6 +381,7 @@ export interface StripeElements {
 }
 
 export type StripeElementType =
+  | 'address'
   | 'affirmMessage'
   | 'afterpayClearpayMessage'
   | 'auBankAccount'

--- a/types/stripe-js/elements/address.d.ts
+++ b/types/stripe-js/elements/address.d.ts
@@ -143,7 +143,7 @@ export interface StripeAddressElementOptions {
   mode: AddressMode;
 
   /**
-   * An array of two-letter ISO country codes representing which countries 
+   * An array of two-letter ISO country codes representing which countries
    * are displayed in the Address Element.
    */
   allowedCountries?: string[] | null;

--- a/types/stripe-js/elements/address.d.ts
+++ b/types/stripe-js/elements/address.d.ts
@@ -1,0 +1,243 @@
+import {StripeElementBase, StripeElementChangeEvent} from './base';
+import {StripeError} from '../stripe';
+
+export type StripeAddressElement = StripeElementBase & {
+  /**
+   * The change event is triggered when the `Element`'s value changes.
+   */
+  on(
+    eventType: 'change',
+    handler: (event: StripeAddressElementChangeEvent) => any
+  ): StripeAddressElement;
+  once(
+    eventType: 'change',
+    handler: (event: StripeAddressElementChangeEvent) => any
+  ): StripeAddressElement;
+  off(
+    eventType: 'change',
+    handler?: (event: StripeAddressElementChangeEvent) => any
+  ): StripeAddressElement;
+
+  /**
+   * Triggered when the element is fully rendered and can accept `element.focus` calls.
+   */
+  on(
+    eventType: 'ready',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  once(
+    eventType: 'ready',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  off(
+    eventType: 'ready',
+    handler?: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+
+  /**
+   * Triggered when the element gains focus.
+   */
+  on(
+    eventType: 'focus',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  once(
+    eventType: 'focus',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  off(
+    eventType: 'focus',
+    handler?: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+
+  /**
+   * Triggered when the element loses focus.
+   */
+  on(
+    eventType: 'blur',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  once(
+    eventType: 'blur',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  off(
+    eventType: 'blur',
+    handler?: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+
+  /**
+   * Triggered when the escape key is pressed within the element.
+   */
+  on(
+    eventType: 'escape',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  once(
+    eventType: 'escape',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  off(
+    eventType: 'escape',
+    handler?: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+
+  /**
+   * Triggered when the element fails to load.
+   */
+  on(
+    eventType: 'loaderror',
+    handler: (event: {elementType: 'address'; error: StripeError}) => any
+  ): StripeAddressElement;
+  once(
+    eventType: 'loaderror',
+    handler: (event: {elementType: 'address'; error: StripeError}) => any
+  ): StripeAddressElement;
+  off(
+    eventType: 'loaderror',
+    handler?: (event: {elementType: 'address'; error: StripeError}) => any
+  ): StripeAddressElement;
+
+  /**
+   * Triggered when the loader UI is mounted to the DOM and ready to be displayed.
+   */
+  on(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  once(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+  off(
+    eventType: 'loaderstart',
+    handler?: (event: {elementType: 'address'}) => any
+  ): StripeAddressElement;
+
+  /**
+   * Updates the options the `AddressElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   */
+  update(options: Partial<StripeAddressElementOptions>): StripeAddressElement;
+};
+
+export interface ContactOption {
+  name: string;
+  phone?: string;
+  address: {
+    line1: string;
+    line2?: string;
+    city: string;
+    state: string;
+    postal_code: string;
+    country: string;
+  };
+}
+
+export type AddressMode = 'shipping' | 'billing';
+
+export interface StripeAddressElementOptions {
+  /**
+   * Control which mode the AddressElement will be used for.
+   */
+  mode: AddressMode;
+
+  /**
+   * Control which countries are displayed in the address Element.
+   */
+  allowedCountries?: string[] | null;
+
+  /**
+   * Control autocomplete settings in the AddressElement.
+   */
+  autocomplete?:
+    | {mode: 'automatic'}
+    | {mode: 'disabled'}
+    | {mode: 'google_maps_api'; apiKey: string};
+
+  /**
+   * Whether or not AddressElement accepts PO boxes
+   */
+  blockPoBox?: boolean;
+
+  /**
+   * An array of saved addresses.
+   */
+  contacts?: ContactOption[];
+
+  /**
+   * Default value for AddressElement fields
+   */
+  defaultValues?: {
+    name?: string | null;
+    address?: {
+      line1?: string | null;
+      line2?: string | null;
+      city?: string | null;
+      state?: string | null;
+      postal_code?: string | null;
+      country: string;
+    };
+    phone?: string | null;
+  };
+
+  /**
+   * Control which additional fields to display in the address Element.
+   */
+  fields?: {
+    phone?: 'always' | 'never' | 'auto';
+  };
+
+  /**
+   * Specify validation rules for the above additional fields.
+   */
+  validation?: {
+    phone?: {
+      required: 'always' | 'never' | 'auto';
+    };
+  };
+}
+
+export interface StripeAddressElementChangeEvent
+  extends StripeElementChangeEvent {
+  /**
+   * The type of element that emitted this event.
+   */
+  elementType: 'address';
+
+  /**
+   * The mode of the address Element that emitted this event.
+   */
+  elementMode: AddressMode;
+
+  /**
+   * Whether or not the address Element is currently empty.
+   */
+  empty: boolean;
+
+  /**
+   * Whether or not the address Element is complete.
+   */
+  complete: boolean;
+
+  /**
+   * Whether or not the address is new.
+   */
+  isNewAddress: boolean;
+
+  /**
+   * An object containing the current address.
+   */
+  value: {
+    name: string;
+    address: {
+      line1: string;
+      line2: string | null;
+      city: string;
+      state: string;
+      postal_code: string;
+      country: string;
+    };
+    phone?: string;
+  };
+}

--- a/types/stripe-js/elements/address.d.ts
+++ b/types/stripe-js/elements/address.d.ts
@@ -144,7 +144,7 @@ export interface StripeAddressElementOptions {
 
   /**
    * An array of two-letter ISO country codes representing which countries
-   * are displayed in the Address Element.
+   * are displayed in the AddressElement.
    */
   allowedCountries?: string[] | null;
 
@@ -183,7 +183,7 @@ export interface StripeAddressElementOptions {
   };
 
   /**
-   * Control which additional fields to display in the Address Element.
+   * Control which additional fields to display in the AddressElement.
    */
   fields?: {
     phone?: 'always' | 'never' | 'auto';
@@ -207,17 +207,17 @@ export interface StripeAddressElementChangeEvent
   elementType: 'address';
 
   /**
-   * The mode of the Address Element that emitted this event.
+   * The mode of the AddressElement that emitted this event.
    */
   elementMode: AddressMode;
 
   /**
-   * Whether or not the Address Element is currently empty.
+   * Whether or not the AddressElement is currently empty.
    */
   empty: boolean;
 
   /**
-   * Whether or not the Address Element is complete.
+   * Whether or not the AddressElement is complete.
    */
   complete: boolean;
 

--- a/types/stripe-js/elements/address.d.ts
+++ b/types/stripe-js/elements/address.d.ts
@@ -143,7 +143,8 @@ export interface StripeAddressElementOptions {
   mode: AddressMode;
 
   /**
-   * Control which countries are displayed in the address Element.
+   * An array of two-letter ISO country codes representing which countries 
+   * are displayed in the Address Element.
    */
   allowedCountries?: string[] | null;
 
@@ -182,7 +183,7 @@ export interface StripeAddressElementOptions {
   };
 
   /**
-   * Control which additional fields to display in the address Element.
+   * Control which additional fields to display in the Address Element.
    */
   fields?: {
     phone?: 'always' | 'never' | 'auto';
@@ -206,17 +207,17 @@ export interface StripeAddressElementChangeEvent
   elementType: 'address';
 
   /**
-   * The mode of the address Element that emitted this event.
+   * The mode of the Address Element that emitted this event.
    */
   elementMode: AddressMode;
 
   /**
-   * Whether or not the address Element is currently empty.
+   * Whether or not the Address Element is currently empty.
    */
   empty: boolean;
 
   /**
-   * Whether or not the address Element is complete.
+   * Whether or not the Address Element is complete.
    */
   complete: boolean;
 

--- a/types/stripe-js/elements/index.d.ts
+++ b/types/stripe-js/elements/index.d.ts
@@ -1,3 +1,4 @@
+export * from './address';
 export * from './affirm-message';
 export * from './afterpay-clearpay-message';
 export * from './au-bank-account';

--- a/types/stripe-js/elements/shipping-address.d.ts
+++ b/types/stripe-js/elements/shipping-address.d.ts
@@ -194,7 +194,7 @@ export interface StripeShippingAddressElementChangeEvent
   complete: boolean;
 
   /**
-   * Whether or not the the shipping address is new.
+   * Whether or not the shipping address is new.
    */
   isNewAddress: boolean;
 


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Added types for `address` element and marked `shippingAddress` as deprecated.

### Testing & documentation
Added invalid and valid tests
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
