### PR TITLE
add type for paymentMethodMessaging Element

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -36,6 +36,7 @@ import {
   StripePaymentElement,
   StripeAffirmMessageElement,
   StripeAfterpayClearpayMessageElement,
+  StripePaymentMethodMessagingElement,
   StripeLinkAuthenticationElementChangeEvent,
   StripeLinkAuthenticationElement,
   StripeShippingAddressElementChangeEvent,
@@ -267,6 +268,16 @@ const afterpayClearpayMessageElement = elements.create(
   }
 );
 
+const paymentMethodMessagingElement = elements.create(
+  'paymentMethodMessaging',
+  {
+    amount: 2000,
+    paymentMethods: ['afterpay_clearpay', 'klarna'],
+    countryCode: 'US',
+    currency: 'USD'
+  }
+)
+
 const paymentElement: StripePaymentElement = elements.create('payment', {
   defaultValues: {
     billingDetails: {
@@ -344,6 +355,7 @@ paymentElement
 
 paymentElement.collapse();
 
+// Test Affirm Messaging Element
 affirmMessageElement.on('ready', (e: {elementType: 'affirmMessage'}) => {});
 
 const retrievedAffirmMessageElement: StripeAffirmMessageElement | null = elements.getElement(
@@ -352,6 +364,7 @@ const retrievedAffirmMessageElement: StripeAffirmMessageElement | null = element
 
 retrievedAffirmMessageElement!.update({amount: 10000});
 
+// Test Afterpay Messaging Element
 afterpayClearpayMessageElement.on(
   'ready',
   (e: {elementType: 'afterpayClearpayMessage'}) => {}
@@ -362,6 +375,15 @@ const retrievedAfterpayClearpayMessageElement: StripeAfterpayClearpayMessageElem
 );
 
 retrievedAfterpayClearpayMessageElement!.update({currency: 'GBP'});
+
+// Test Payment Method Messaging Element
+paymentMethodMessagingElement.on('ready', (e: {elementType: 'paymentMethodMessaging'}) => {});
+
+const retrievedPaymentMethodMessagingElement: StripePaymentMethodMessagingElement | null = elements.getElement(
+  'paymentMethodMessaging'
+);
+
+retrievedPaymentMethodMessagingElement!.update({amount: 10000});
 
 const epsBankElement = elements.create('epsBank', {
   style: MY_STYLE,

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -274,9 +274,9 @@ const paymentMethodMessagingElement = elements.create(
     amount: 2000,
     paymentMethods: ['afterpay_clearpay', 'klarna'],
     countryCode: 'US',
-    currency: 'USD'
+    currency: 'USD',
   }
-)
+);
 
 const paymentElement: StripePaymentElement = elements.create('payment', {
   defaultValues: {
@@ -377,7 +377,10 @@ const retrievedAfterpayClearpayMessageElement: StripeAfterpayClearpayMessageElem
 retrievedAfterpayClearpayMessageElement!.update({currency: 'GBP'});
 
 // Test Payment Method Messaging Element
-paymentMethodMessagingElement.on('ready', (e: {elementType: 'paymentMethodMessaging'}) => {});
+paymentMethodMessagingElement.on(
+  'ready',
+  (e: {elementType: 'paymentMethodMessaging'}) => {}
+);
 
 const retrievedPaymentMethodMessagingElement: StripePaymentMethodMessagingElement | null = elements.getElement(
   'paymentMethodMessaging'

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -31,6 +31,8 @@ import {
   StripeAfterpayClearpayMessageElementOptions,
   StripeAffirmMessageElement,
   StripeAffirmMessageElementOptions,
+  StripePaymentMethodMessagingElementOptions,
+  StripePaymentMethodMessagingElement,
   StripeAfterpayClearpayMessageElement,
   StripeAuBankAccountElementOptions,
 } from './elements';
@@ -70,6 +72,23 @@ export interface StripeElements {
    * Looks up a previously created `Element` by its type.
    */
   getElement(elementType: 'address'): StripeAddressElement | null;
+
+  /////////////////////////////
+  /// paymentMethodMessaging
+  /////////////////////////////
+
+  /**
+   * Creates an `paymentMethodMessaging`.
+   */
+   create(
+    elementType: 'paymentMethodMessaging',
+    options: StripePaymentMethodMessagingElementOptions
+  ): StripePaymentMethodMessagingElement;
+
+  /**
+   * Looks up a previously created `Element` by its type.
+   */
+  getElement(elementType: 'paymentMethodMessaging'): StripePaymentMethodMessagingElement | null;
 
   /////////////////////////////
   /// affirmMessage

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -80,7 +80,7 @@ export interface StripeElements {
   /**
    * Creates an `paymentMethodMessaging`.
    */
-   create(
+  create(
     elementType: 'paymentMethodMessaging',
     options: StripePaymentMethodMessagingElementOptions
   ): StripePaymentMethodMessagingElement;
@@ -88,7 +88,9 @@ export interface StripeElements {
   /**
    * Looks up a previously created `Element` by its type.
    */
-  getElement(elementType: 'paymentMethodMessaging'): StripePaymentMethodMessagingElement | null;
+  getElement(
+    elementType: 'paymentMethodMessaging'
+  ): StripePaymentMethodMessagingElement | null;
 
   /////////////////////////////
   /// affirmMessage

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -78,7 +78,7 @@ export interface StripeElements {
   /////////////////////////////
 
   /**
-   * Creates an `paymentMethodMessaging`.
+   * Creates an `paymentMethodMessagingElement`.
    */
   create(
     elementType: 'paymentMethodMessaging',

--- a/types/stripe-js/elements/index.d.ts
+++ b/types/stripe-js/elements/index.d.ts
@@ -1,4 +1,5 @@
 export * from './address';
+export * from './payment-method-messaging';
 export * from './affirm-message';
 export * from './afterpay-clearpay-message';
 export * from './au-bank-account';

--- a/types/stripe-js/elements/payment-method-messaging.d.ts
+++ b/types/stripe-js/elements/payment-method-messaging.d.ts
@@ -41,17 +41,43 @@ export interface StripePaymentMethodMessagingElementOptions {
   /**
    * The currency to display.
    */
-  currency: 'USD' | 'GBP' | 'EUR' | 'DKK' | 'NOK' | 'SEK' | 'AUD' | 'CAD' | 'NZD';
+  currency:
+    | 'USD'
+    | 'GBP'
+    | 'EUR'
+    | 'DKK'
+    | 'NOK'
+    | 'SEK'
+    | 'AUD'
+    | 'CAD'
+    | 'NZD';
 
   /**
    * Payment methods to show messaging for.
    */
-  paymentMethods: Array<'afterpay_clearpay' | 'klarna'>
+  paymentMethods: Array<'afterpay_clearpay' | 'klarna'>;
 
   /**
    * The country the end-buyer is in.
    */
-  countryCode:  'US' | 'CA' | 'AU' | 'NZ' | 'GB' | 'IE' | 'FR' | 'ES' | 'DE' | 'AT' | 'BE' | 'DK' | 'FI' | 'IT' | 'NL' | 'NO' | 'SE';
+  countryCode:
+    | 'US'
+    | 'CA'
+    | 'AU'
+    | 'NZ'
+    | 'GB'
+    | 'IE'
+    | 'FR'
+    | 'ES'
+    | 'DE'
+    | 'AT'
+    | 'BE'
+    | 'DK'
+    | 'FI'
+    | 'IT'
+    | 'NL'
+    | 'NO'
+    | 'SE';
 
   /**
    * The font color of the promotional message.

--- a/types/stripe-js/elements/payment-method-messaging.d.ts
+++ b/types/stripe-js/elements/payment-method-messaging.d.ts
@@ -1,0 +1,67 @@
+export type StripePaymentMethodMessagingElement = {
+  /**
+   * The `element.mount` method attaches your [Element](https://stripe.com/docs/js/element) to the DOM.
+   * `element.mount` accepts either a CSS Selector (e.g., `'#payment-method-messaging'`) or a DOM element.
+   */
+  mount(domElement: string | HTMLElement): void;
+
+  /**
+   * Removes the element from the DOM and destroys it.
+   * A destroyed element can not be re-activated or re-mounted to the DOM.
+   */
+  destroy(): void;
+
+  /**
+   * Unmounts the element from the DOM.
+   * Call `element.mount` to re-attach it to the DOM.
+   */
+  unmount(): void;
+
+  /**
+   * Updates the options the `PaymentMethodMessagingElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   */
+  update(options: Partial<StripePaymentMethodMessagingElementOptions>): void;
+
+  /**
+   * Triggered when the element is fully loaded and ready to perform method calls.
+   */
+  on(
+    eventType: 'ready',
+    handler: (event: {elementType: 'paymentMethodMessaging'}) => any
+  ): StripePaymentMethodMessagingElement;
+};
+
+export interface StripePaymentMethodMessagingElementOptions {
+  /**
+   * The total amount in the smallest currency unit.
+   */
+  amount: number;
+
+  /**
+   * The currency to display.
+   */
+  currency: 'USD' | 'GBP' | 'EUR' | 'DKK' | 'NOK' | 'SEK' | 'AUD' | 'CAD' | 'NZD';
+
+  /**
+   * Payment methods to show messaging for.
+   */
+  paymentMethods: Array<'afterpay_clearpay' | 'klarna'>
+
+  /**
+   * The country the end-buyer is in.
+   */
+  countryCode:  'US' | 'CA' | 'AU' | 'NZ' | 'GB' | 'IE' | 'FR' | 'ES' | 'DE' | 'AT' | 'BE' | 'DK' | 'FI' | 'IT' | 'NL' | 'NO' | 'SE';
+
+  /**
+   * The font color of the promotional message.
+   */
+  darkMode?: boolean;
+
+  /**
+   * The font size of the promotional message.
+   */
+  metaData?: {
+    messagingClientReferenceId: string | null;
+  };
+}


### PR DESCRIPTION
### Summary & motivation

Add typings for the PaymentMethodMessaging Element

### Testing & documentation

Unit tests `tests/types/src/valid.ts`