### PR TITLE
Finish specifying the Financial Connections Account type

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2328,7 +2328,61 @@ stripe
     if (result.financialConnectionsSession) {
       const numAccounts = result.financialConnectionsSession.accounts.length;
       const accountNames = result.financialConnectionsSession.accounts.map(
-        (account) => account.display_name
+        (account) => {
+          if (account.balance) {
+            console.log(account.balance.as_of);
+            console.log(
+              account.balance.current.usd && account.balance.current.usd > 0
+            );
+
+            if (
+              account.balance.type === 'cash' &&
+              account.balance.cash.available.usd
+            ) {
+              console.log(account.balance.cash.available.usd > 0);
+            }
+
+            if (
+              account.balance.type === 'credit' &&
+              account.balance.credit.used.usd
+            ) {
+              console.log(account.balance.credit.used.usd > 0);
+            }
+          }
+
+          if (
+            account.balance_refresh &&
+            account.balance_refresh.status === 'pending'
+          ) {
+          }
+
+          if (
+            account.ownership_refresh &&
+            account.ownership_refresh.status === 'failed'
+          ) {
+          }
+
+          console.log(
+            account.supported_payment_method_types.includes('us_bank_account')
+          );
+
+          if (account.livemode) {
+          }
+
+          if (account.permissions.includes('balances')) {
+          }
+
+          if (account.status === 'inactive') {
+          }
+
+          if (
+            account.category === 'cash' &&
+            account.subcategory === 'checking'
+          ) {
+          }
+
+          return account.display_name;
+        }
       );
 
       console.log(numAccounts);

--- a/types/api/financial-connections.d.ts
+++ b/types/api/financial-connections.d.ts
@@ -1,3 +1,93 @@
+type SupportedPaymentMethodType = 'us_bank_account' | 'link';
+
+interface CommonBalance {
+  /**
+   * The time that the external institution calculated this balance. Measured
+   * in seconds since the Unix epoch.
+   */
+  as_of: number;
+
+  /**
+   * The balances owed to (or by) the account holder.
+   *
+   * Each key is a three-letter ISO currency code, in lowercase.
+   *
+   * Each value is a integer amount. A positive amount indicates money owed to
+   * the account holder. A negative amount indicates money owed by the account
+   * holder.
+   */
+  current: {
+    [key: string]: number | undefined;
+  };
+}
+
+interface CashBalance {
+  /**
+   * Information on a `cash` balance. Only set if `balance.type` is `cash`.
+   */
+  cash: {
+    /**
+     * The funds available to the account holder. Typically this is the
+     * current balance less any holds.
+     *
+     * Each key is a three-letter ISO currency code, in lowercase.
+     *
+     * Each value is a integer amount. A positive amount indicates money owed
+     * to the account holder. A negative amount indicates money owed by the
+     * account holder.
+     */
+    available: {[key: string]: number | undefined};
+  };
+
+  type: 'cash';
+}
+
+interface CreditBalance {
+  /**
+   * Information on a `credit` balance. Only set if `balance.type` is `credit`.
+   */
+  credit: {
+    /**
+     * The credit that has been used by the account holder.
+     *
+     * Each key is a three-letter ISO currency code, in lowercase
+     *
+     * Each value is a integer amount. A positive amount indicates money owed
+     * to the account holder. A negative amount indicates money owed by the
+     * account holder.
+     */
+    used: {[key: string]: number | undefined};
+  };
+
+  type: 'credit';
+}
+
+type Balance = (CommonBalance & CashBalance) | (CommonBalance & CreditBalance);
+
+interface BalanceRefresh {
+  /**
+   * The status of the Balance Refresh
+   */
+  status: 'pending' | 'succeeded' | 'failed';
+
+  /**
+   * Time at which the Balance Refresh was attempted. Measured in seconds since the Unix epoch.
+   */
+  last_attempted_at: number;
+}
+
+interface OwnershipRefresh {
+  /**
+   * The status of the Ownership Refresh
+   */
+  status: 'pending' | 'succeeded' | 'failed';
+
+  /**
+   * Time at which the Ownersip Refresh was attempted. Measured in seconds since the Unix epoch.
+   */
+  last_attempted_at: number;
+}
+
 /**
  * The Financial Connections Session object
  */
@@ -44,9 +134,24 @@ export namespace FinancialConnectionsSession {
     object: 'linked_account' | 'financial_connections.account';
 
     /**
+     * The balance for this Account
+     */
+    balance: null | Balance;
+
+    /**
+     * The most recent Balance Refresh for this Account
+     */
+    balance_refresh: null | BalanceRefresh;
+
+    /**
      * The type of the account.
      */
-    category: string;
+    category: 'cash' | 'credit' | 'investment' | 'other';
+
+    /**
+     * Time at which the object was created. Measured in seconds since the Unix epoch.
+     */
+    created: number;
 
     /**
      * A human-readable name that has been assigned to this account, either by the account holder or by the institution.
@@ -62,6 +167,47 @@ export namespace FinancialConnectionsSession {
      * The last 4 digits of the account number. If present, this will be 4 numeric characters.
      */
     last4: string | null;
+
+    /**
+     * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+     */
+    livemode: boolean;
+
+    /**
+     * The ID of this account's Ownership resource.
+     */
+    ownership: string | null;
+
+    /**
+     * The most recent Ownership Refresh for this Account
+     */
+    ownership_refresh: null | OwnershipRefresh;
+
+    /**
+     * Permissions granted on this Account
+     */
+    permissions: Permission[];
+
+    /**
+     * The status of the Account
+     */
+    status: 'active' | 'inactive' | 'disconnected';
+
+    /**
+     * The sub-category of the Account
+     */
+    subcategory:
+      | 'checking'
+      | 'savings'
+      | 'mortgage'
+      | 'line_of_credit'
+      | 'credit_card'
+      | 'other';
+
+    /**
+     * The types of Payment Methods which can be set up by this Account
+     */
+    supported_payment_method_types: SupportedPaymentMethodType[];
   }
 
   /**


### PR DESCRIPTION
### Summary & motivation

- For reasons I do not remember (possibly for no good reason), #338 didn't
  contain type definitions for the entire Financial Connections Account
  resource. This PR adds them.
- Additionally, converts the `category` type from a `string` to an enum of
  `string`s

### Testing & documentation

- Extends the `valid.ts` test to test various attributes, and to demonstrate
  the behavior of `cash` vs `credit` balance types.