### PR TITLE
Disables testing the `beta` tag until Typescript issue is fixed

### DIFF
--- a/tests/types/scripts/test.mjs
+++ b/tests/types/scripts/test.mjs
@@ -5,7 +5,7 @@ import 'zx/globals';
 
 const VERSIONS = [
   'next',
-  'beta',
+  // 'beta', TypeScript beta version is broken right now: https://github.com/microsoft/TypeScript/pull/50915
   'latest',
   '3.9.7',
   '3.8.3',


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Typescript's current beta tagged version has a bug that breaks our tests for that beta version. This PR disables testing against that beta version.

After publishing a new version, I will revert this change.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Verified the `yarn test:types` task.