### PR TITLE
Re-enable the test to run against the BETA tagged version of TypeScript

### DIFF
--- a/tests/types/scripts/test.mjs
+++ b/tests/types/scripts/test.mjs
@@ -5,7 +5,7 @@ import 'zx/globals';
 
 const VERSIONS = [
   'next',
-  // 'beta', TypeScript beta version is broken right now: https://github.com/microsoft/TypeScript/pull/50915
+  'beta',
   'latest',
   '3.9.7',
   '3.8.3',


### PR DESCRIPTION
### Summary & motivation

This reverts the change introduced here: https://github.com/stripe/stripe-js/pull/356

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
