### PR TITLE
Add paymentMethodMessaging element to types

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -416,6 +416,7 @@ export type StripeElementType =
   | 'idealBank'
   | 'p24Bank'
   | 'payment'
+  | 'paymentMethodMessaging'
   | 'paymentRequestButton'
   | 'linkAuthentication'
   | 'shippingAddress';
@@ -434,6 +435,7 @@ export type StripeElement =
   | StripeIdealBankElement
   | StripeP24BankElement
   | StripePaymentElement
+  | StripePaymentMethodMessagingElement
   | StripePaymentRequestButtonElement;
 
 export type StripeElementLocale =


### PR DESCRIPTION
### Summary & motivation

Add paymentMethodMessaging Element to types used by the react-stripe-js repo. Think these are relatively knew because old reference PRs didn't include this change :(  

### Testing & documentation

Test Pass
