### PR TITLE
Add confirmPixPayment

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -1580,6 +1580,26 @@ stripe
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 
 stripe
+  .confirmPixPayment('', {})
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmPixPayment('', {
+    payment_method: '',
+  })
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
+  .confirmPixPayment(
+    '',
+    {
+      payment_method: '',
+    },
+    {handleActions: false}
+  )
+  .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
+
+stripe
   .confirmPromptPayPayment('', {})
   .then((result: {paymentIntent?: PaymentIntent; error?: StripeError}) => null);
 

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -32,6 +32,7 @@ export type CreatePaymentMethodData =
   | CreatePaymentMethodP24Data
   | CreatePaymentMethodPayPalData
   | CreatePaymentMethodPayNowData
+  | CreatePaymentMethodPixData
   | CreatePaymentMethodPromptPayData
   | CreatePaymentMethodFpxData
   | CreatePaymentMethodUsBankAccountData
@@ -287,6 +288,10 @@ export interface CreatePaymentMethodPayNowData
 export interface CreatePaymentMethodPayPalData
   extends PaymentMethodCreateParams {
   type: 'paypal';
+}
+
+export interface CreatePaymentMethodPixData extends PaymentMethodCreateParams {
+  type: 'pix';
 }
 
 export interface CreatePaymentMethodPromptPayData
@@ -1050,6 +1055,31 @@ export interface ConfirmPayPalPaymentData extends PaymentIntentConfirmParams {
  * An options object to control the behavior of `stripe.confirmP24Payment`.
  */
 export interface ConfirmP24PaymentOptions {
+  /**
+   * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/p24#handle-redirect).
+   * Default is `true`.
+   */
+  handleActions?: boolean;
+}
+
+/**
+ * Data to be sent with a `stripe.confirmPixPayment` request.
+ * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+ */
+export interface ConfirmPixPaymentData extends PaymentIntentConfirmParams {
+  /**
+   * The `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+   * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent` or a new `PaymentMethod` will be created.
+   *
+   * @recommended
+   */
+  payment_method?: string | Omit<CreatePaymentMethodPixData, 'type'>;
+}
+
+/**
+ * An options object to control the behavior of `stripe.confirmPayNowPayment`.
+ */
+export interface ConfirmPixPaymentOptions {
   /**
    * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/p24#handle-redirect).
    * Default is `true`.

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -409,6 +409,24 @@ export interface Stripe {
   ): Promise<PaymentIntentResult>;
 
   /**
+
+   * Use `stripe.confirmPixPayment` in the [Pix Payments](https://stripe.com/docs/payments/pix) with Payment Methods flow when the customer submits your payment form.
+   * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide.
+   * Refer to our [integration guide](https://stripe.com/docs/payments/pix) for more details.
+   *
+   * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+   * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new PaymentMethod for you.
+   * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+   *
+   * @docs https://stripe.com/docs/js/payment_intents/confirm_pix_payment
+   */
+  confirmPixPayment(
+    clientSecret: string,
+    data?: paymentIntents.ConfirmPixPaymentData,
+    options?: paymentIntents.ConfirmPixPaymentOptions
+  ): Promise<PaymentIntentResult>;
+
+  /**
    * Requires beta access:
    * Contact [Stripe support](https://support.stripe.com/) for more information.
    *


### PR DESCRIPTION
### Summary & motivation

* Registers `confirmPixPayment` types.
* Related to https://github.com/stripe/stripe-js/issues/351

### Testing & documentation

* Added test calls to `tests/types/src/valid.ts`.
