### PR TITLE
Add type definitions for Issuing Elements

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -44,6 +44,23 @@ paymentElement.on('change', (e) => {
 // @ts-expect-error: AddressElement requires a mode
 elements.create('address');
 
+// @ts-expect-error: No overload matches this call
+elements.create('issuingCardNumberDisplay');
+
+// @ts-expect-error: No overload matches this call
+elements.create('issuingCardCvcDisplay');
+
+// @ts-expect-error: No overload matches this call
+elements.create('issuingCardExpiryDisplay');
+
+// @ts-expect-error: No overload matches this call
+elements.create('issuingCardPinDisplay');
+
+elements.create('issuingCardCopyButton', {
+  // @ts-expect-error: Type '"non_existent"' is not assignable to type '"number" | "expiry" | "cvc" | "pin"'
+  toCopy: 'non_existent',
+});
+
 stripe
   .confirmPayment({elements, confirmParams: {return_url: ''}})
   .then((res) => {

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -164,3 +164,9 @@ stripe.createToken(ibanElement, {
   account_holder_name: '',
   extra_property: '',
 });
+
+// @ts-expect-error: Argument of type '{}' is not assignable to parameter of type 'EphemeralKeyNonceOptions'
+stripe.createEphemeralKeyNonce({});
+
+// @ts-expect-error: Expected 1 arguments, but got 0
+stripe.createEphemeralKeyNonce();

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2668,3 +2668,7 @@ issuingCopyButtonElement.update({
     },
   },
 });
+
+stripe.createEphemeralKeyNonce({
+  issuingCard: '',
+});

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2564,3 +2564,107 @@ paymentRequest.on(
     });
   }
 );
+
+const issuingCardElement = elements.create('issuingCardNumberDisplay', {
+  issuingCard: '',
+  nonce: '',
+  ephemeralKeySecret: '',
+  style: {
+    base: {
+      fontSize: '2rem',
+    },
+  },
+});
+
+issuingCardElement.mount('#bogus-container');
+
+issuingCardElement.update({
+  style: {
+    base: {
+      fontSize: '5rem',
+    },
+  },
+});
+
+const issuingCvcElement = elements.create('issuingCardCvcDisplay', {
+  issuingCard: '',
+  nonce: '',
+  ephemeralKeySecret: '',
+  style: {
+    base: {
+      fontSize: '2rem',
+    },
+  },
+});
+
+issuingCvcElement.mount('#bogus-container');
+
+issuingCvcElement.update({
+  style: {
+    base: {
+      fontSize: '5rem',
+    },
+  },
+});
+
+const issuingExpiryElement = elements.create('issuingCardExpiryDisplay', {
+  issuingCard: '',
+  nonce: '',
+  ephemeralKeySecret: '',
+  style: {
+    base: {
+      fontSize: '2rem',
+    },
+  },
+});
+
+issuingExpiryElement.mount('#bogus-container');
+
+issuingExpiryElement.update({
+  style: {
+    base: {
+      fontSize: '5rem',
+    },
+  },
+});
+
+const issuingPinElement = elements.create('issuingCardPinDisplay', {
+  issuingCard: '',
+  nonce: '',
+  ephemeralKeySecret: '',
+  style: {
+    base: {
+      fontSize: '2rem',
+    },
+  },
+});
+
+issuingPinElement.mount('#bogus-container');
+
+issuingPinElement.update({
+  style: {
+    base: {
+      fontSize: '5rem',
+    },
+  },
+});
+
+const issuingCopyButtonElement = elements.create('issuingCardCopyButton', {
+  toCopy: 'pin',
+  style: {
+    base: {
+      fontSize: '2rem',
+    },
+  },
+});
+
+issuingCopyButtonElement.mount('#bogus-container');
+
+issuingCopyButtonElement.update({
+  toCopy: 'number',
+  style: {
+    base: {
+      fontSize: '5rem',
+    },
+  },
+});

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -35,6 +35,16 @@ import {
   StripePaymentMethodMessagingElement,
   StripeAfterpayClearpayMessageElement,
   StripeAuBankAccountElementOptions,
+  StripeIssuingCardNumberDisplayElement,
+  StripeIssuingCardNumberDisplayElementOptions,
+  StripeIssuingCardCvcDisplayElement,
+  StripeIssuingCardCvcDisplayElementOptions,
+  StripeIssuingCardExpiryDisplayElement,
+  StripeIssuingCardExpiryDisplayElementOptions,
+  StripeIssuingCardPinDisplayElement,
+  StripeIssuingCardPinDisplayElementOptions,
+  StripeIssuingCardCopyButtonElement,
+  StripeIssuingCardCopyButtonElementOptions,
 } from './elements';
 
 export interface StripeElements {
@@ -399,6 +409,60 @@ export interface StripeElements {
   getElement(
     elementType: 'shippingAddress'
   ): StripeShippingAddressElement | null;
+
+  /////////////////////////////
+  /// issuing
+  /////////////////////////////
+
+  /**
+   * Creates an `issuingCardNumberDisplay` Element
+   *
+   * @docs https://stripe.com/docs/js/issuing_elements/create?type=issuingCardNumberDisplay
+   */
+  create(
+    elementType: 'issuingCardNumberDisplay',
+    options: StripeIssuingCardNumberDisplayElementOptions
+  ): StripeIssuingCardNumberDisplayElement;
+
+  /**
+   * Creates an `issuingCardCvcDisplay` Element
+   *
+   * @docs https://stripe.com/docs/js/issuing_elements/create?type=issuingCardCvcDisplay
+   */
+  create(
+    elementType: 'issuingCardCvcDisplay',
+    options: StripeIssuingCardCvcDisplayElementOptions
+  ): StripeIssuingCardCvcDisplayElement;
+
+  /**
+   * Creates an `issuingCardExpiryDisplay` Element
+   *
+   * @docs https://stripe.com/docs/js/issuing_elements/create?type=issuingCardExpiryDisplay
+   */
+  create(
+    elementType: 'issuingCardExpiryDisplay',
+    options: StripeIssuingCardExpiryDisplayElementOptions
+  ): StripeIssuingCardExpiryDisplayElement;
+
+  /**
+   * Creates an `issuingCardPinDisplay` Element
+   *
+   * @docs https://stripe.com/docs/js/issuing_elements/create?type=issuingCardPinDisplay
+   */
+  create(
+    elementType: 'issuingCardPinDisplay',
+    options: StripeIssuingCardPinDisplayElementOptions
+  ): StripeIssuingCardPinDisplayElement;
+
+  /**
+   * Creates an `issuingCardCopyButton` Element
+   *
+   * @docs https://stripe.com/docs/js/issuing_elements/create?type=issuingCardCopyButton
+   */
+  create(
+    elementType: 'issuingCardCopyButton',
+    options: StripeIssuingCardCopyButtonElementOptions
+  ): StripeIssuingCardCopyButtonElement;
 }
 
 export type StripeElementType =
@@ -419,7 +483,12 @@ export type StripeElementType =
   | 'paymentMethodMessaging'
   | 'paymentRequestButton'
   | 'linkAuthentication'
-  | 'shippingAddress';
+  | 'shippingAddress'
+  | 'issuingCardNumberDisplay'
+  | 'issuingCardCvcDisplay'
+  | 'issuingCardExpiryDisplay'
+  | 'issuingCardPinDisplay'
+  | 'issuingCardCopyButton';
 
 export type StripeElement =
   | StripeAffirmMessageElement
@@ -436,7 +505,12 @@ export type StripeElement =
   | StripeP24BankElement
   | StripePaymentElement
   | StripePaymentMethodMessagingElement
-  | StripePaymentRequestButtonElement;
+  | StripePaymentRequestButtonElement
+  | StripeIssuingCardNumberDisplayElement
+  | StripeIssuingCardCvcDisplayElement
+  | StripeIssuingCardExpiryDisplayElement
+  | StripeIssuingCardPinDisplayElement
+  | StripeIssuingCardCopyButtonElement;
 
 export type StripeElementLocale =
   | 'auto'

--- a/types/stripe-js/elements/index.d.ts
+++ b/types/stripe-js/elements/index.d.ts
@@ -17,3 +17,4 @@ export * from './p24-bank';
 export * from './payment-request-button';
 export * from './payment';
 export * from './shipping-address';
+export * from './issuing';

--- a/types/stripe-js/elements/issuing/index.d.ts
+++ b/types/stripe-js/elements/issuing/index.d.ts
@@ -1,0 +1,5 @@
+export * from './issuing-card-number-display';
+export * from './issuing-card-cvc-display';
+export * from './issuing-card-expiry-display';
+export * from './issuing-card-pin-display';
+export * from './issuing-card-copy-button';

--- a/types/stripe-js/elements/issuing/issuing-card-copy-button.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-card-copy-button.d.ts
@@ -1,0 +1,37 @@
+import {StripeElementBase, StripeElementStyle} from '../base';
+
+export type StripeIssuingCardCopyButtonElement = StripeElementBase & {
+  /**
+   * Triggered when the element is clicked.
+   */
+  on(
+    eventType: 'click',
+    handler: (event: {elementType: 'issuingCardCopyButton'}) => any
+  ): StripeIssuingCardCopyButtonElement;
+  once(
+    eventType: 'click',
+    handler: (event: {elementType: 'issuingCardCopyButton'}) => any
+  ): StripeIssuingCardCopyButtonElement;
+  off(
+    eventType: 'click',
+    handler?: (event: {elementType: 'issuingCardCopyButton'}) => any
+  ): StripeIssuingCardCopyButtonElement;
+
+  /**
+   * Updates the options the `IssuingCardCopyButtonElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   *
+   * The styles of an `IssuingCardCopyButtonElement` can be dynamically changed using `element.update`.
+   * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+   */
+  update(options: Partial<StripeIssuingCardCopyButtonElementOptions>): void;
+};
+
+export interface StripeIssuingCardCopyButtonElementOptions {
+  /**
+   * The issued card data element to copy to the user's clipboard
+   */
+  toCopy: 'expiry' | 'cvc' | 'number' | 'pin';
+
+  style?: StripeElementStyle;
+}

--- a/types/stripe-js/elements/issuing/issuing-card-cvc-display.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-card-cvc-display.d.ts
@@ -1,0 +1,32 @@
+import {StripeElementBase, StripeElementStyle} from '../base';
+
+export type StripeIssuingCardCvcDisplayElement = StripeElementBase & {
+  /**
+   * Updates the options the `IssuingCardCvcDisplayElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   *
+   * The styles of an `IssuingCardCvcDisplayElement` can be dynamically changed using `element.update`.
+   * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+   */
+  update(options: Partial<StripeIssuingCardCvcDisplayElementOptions>): void;
+};
+
+export interface StripeIssuingCardCvcDisplayElementOptions {
+  /**
+   * The token (e.g. `ic_abc123`) of the issued card to display in this Element
+   */
+  issuingCard: string;
+
+  /**
+   * The secret component of the ephemeral key with which to authenticate this sensitive
+   * card details request
+   */
+  ephemeralKeySecret?: string;
+
+  /**
+   * The nonce used to mint the ephemeral key provided in `ephemeralKeySecret`
+   */
+  nonce?: string;
+
+  style?: StripeElementStyle;
+}

--- a/types/stripe-js/elements/issuing/issuing-card-expiry-display.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-card-expiry-display.d.ts
@@ -1,0 +1,32 @@
+import {StripeElementBase, StripeElementStyle} from '../base';
+
+export type StripeIssuingCardExpiryDisplayElement = StripeElementBase & {
+  /**
+   * Updates the options the `IssuingCardExpiryDisplayElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   *
+   * The styles of an `IssuingCardExpiryDisplayElement` can be dynamically changed using `element.update`.
+   * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+   */
+  update(options: Partial<StripeIssuingCardExpiryDisplayElementOptions>): void;
+};
+
+export interface StripeIssuingCardExpiryDisplayElementOptions {
+  /**
+   * The token (e.g. `ic_abc123`) of the issued card to display in this Element
+   */
+  issuingCard: string;
+
+  /**
+   * The secret component of the ephemeral key with which to authenticate this sensitive
+   * card details request
+   */
+  ephemeralKeySecret?: string;
+
+  /**
+   * The nonce used to mint the ephemeral key provided in `ephemeralKeySecret`
+   */
+  nonce?: string;
+
+  style?: StripeElementStyle;
+}

--- a/types/stripe-js/elements/issuing/issuing-card-number-display.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-card-number-display.d.ts
@@ -1,0 +1,32 @@
+import {StripeElementBase, StripeElementStyle} from '../base';
+
+export type StripeIssuingCardNumberDisplayElement = StripeElementBase & {
+  /**
+   * Updates the options the `IssuingCardNumberDisplayElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   *
+   * The styles of an `IssuingCardNumberDisplayElement` can be dynamically changed using `element.update`.
+   * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+   */
+  update(options: Partial<StripeIssuingCardNumberDisplayElementOptions>): void;
+};
+
+export interface StripeIssuingCardNumberDisplayElementOptions {
+  /**
+   * The token (e.g. `ic_abc123`) of the issued card to display in this Element
+   */
+  issuingCard: string;
+
+  /**
+   * The secret component of the ephemeral key with which to authenticate this sensitive
+   * card details request
+   */
+  ephemeralKeySecret?: string;
+
+  /**
+   * The nonce used to mint the ephemeral key provided in `ephemeralKeySecret`
+   */
+  nonce?: string;
+
+  style?: StripeElementStyle;
+}

--- a/types/stripe-js/elements/issuing/issuing-card-pin-display.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-card-pin-display.d.ts
@@ -1,0 +1,32 @@
+import {StripeElementBase, StripeElementStyle} from '../base';
+
+export type StripeIssuingCardPinDisplayElement = StripeElementBase & {
+  /**
+   * Updates the options the `IssuingCardPinDisplayElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   *
+   * The styles of an `IssuingCardPinDisplayElement` can be dynamically changed using `element.update`.
+   * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
+   */
+  update(options: Partial<StripeIssuingCardPinDisplayElementOptions>): void;
+};
+
+export interface StripeIssuingCardPinDisplayElementOptions {
+  /**
+   * The token (e.g. `ic_abc123`) of the issued card to display in this Element
+   */
+  issuingCard: string;
+
+  /**
+   * The secret component of the ephemeral key with which to authenticate this sensitive
+   * card details request
+   */
+  ephemeralKeySecret?: string;
+
+  /**
+   * The nonce used to mint the ephemeral key provided in `ephemeralKeySecret`
+   */
+  nonce?: string;
+
+  style?: StripeElementStyle;
+}

--- a/types/stripe-js/ephemeral-keys.d.ts
+++ b/types/stripe-js/ephemeral-keys.d.ts
@@ -1,0 +1,3 @@
+export interface EphemeralKeyNonceOptions {
+  issuingCard: string;
+}

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -5,6 +5,7 @@ import * as orders from './orders';
 import * as tokens from './token-and-sources';
 import * as elements from './elements';
 import * as financialConnections from './financial-connections';
+import * as ephemeralKeys from './ephemeral-keys';
 
 import {StripeElements, StripeElementsOptions} from './elements-group';
 import {CheckoutLocale, RedirectToCheckoutOptions} from './checkout';
@@ -1024,6 +1025,15 @@ export interface Stripe {
   collectBankAccountToken(
     options: financialConnections.CollectBankAccountTokenOptions
   ): Promise<CollectBankAccountTokenResult>;
+
+  /**
+   * Use `stripe.createEphemeralKeyNonce` to create an ephemeral key nonce that lets you securely create ephemeral keys
+   *
+   * * @docs https://stripe.com/docs/js/issuing/create_ephemeral_key_nonce
+   */
+  createEphemeralKeyNonce(
+    options: ephemeralKeys.EphemeralKeyNonceOptions
+  ): Promise<EphemeralKeyNonceResult>;
 }
 
 export type PaymentIntentResult =
@@ -1077,6 +1087,10 @@ export type CollectBankAccountTokenResult =
       token: undefined;
       error: StripeError;
     };
+
+export type EphemeralKeyNonceResult =
+  | {nonce: string; error?: undefined}
+  | {nonce?: undefined; error: StripeError};
 
 /* A Radar Session is a snapshot of the browser metadata and device details that helps Radar make more accurate predictions on your payments. 
   This metadata includes information like IP address, browser, screen or device information, and other device characteristics. 


### PR DESCRIPTION
### Summary & motivation

This adds type definitions for [Issuing Elements](https://stripe.com/docs/js/element/issuing), and the `stripe.createEphemeralKeyNonce` method (which is used only by Issuing Elements right now, but can be used by other features that use nonced ephemeral keys for authentication)

### Testing & documentation

Tested by adding type validation tests in `valid.js` and `invalid.js`