### PR TITLE
Remove LAE from StripeElement

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -539,7 +539,6 @@ export type StripeElement =
   | StripeIssuingCardExpiryDisplayElement
   | StripeIssuingCardPinDisplayElement
   | StripeIssuingCardCopyButtonElement
-  | StripeLinkAuthenticationElement
   | StripeShippingAddressElement;
 
 export type StripeElementLocale =


### PR DESCRIPTION
### Summary & motivation

Remove LAE from StripeElement because it doesn't have an update function like StripeElement's should have. This was causing test failures in stripe-js

### Testing & documentation

Made this edit in react-stripe-js and ran tests to confirm this fixes the issue.
