### PR TITLE
Add item_details to cart element addLineItem shape

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -43,14 +43,33 @@ paymentElement.on('change', (e) => {
   }
 });
 
-// @ts-expect-error: either `product` or `price` is required
+// @ts-expect-error: either `product`, `price`, or `item_details` is required
 cartElement.addLineItem({});
 
-// @ts-expect-error: either `product` or `price` is required
+// @ts-expect-error: either `product`, `price`, or `item_details` is required
 cartElement.addLineItem({quantity: 1});
 
-// @ts-expect-error: only one of `product` or `price` may be specified
+// @ts-expect-error: only one of `product`, `price`, or `item_details` may be specified
 cartElement.addLineItem({product: '', price: ''});
+
+// @ts-expect-error: only one of `product`, `price`, or `item_details` may be specified
+cartElement.addLineItem({
+  product: '',
+  item_details: {
+    external_id: '',
+    name: '',
+    unit_amount: 0,
+  },
+});
+
+// @ts-expect-error: `item_details.external_id` is required if `item_details` is present
+cartElement.addLineItem({item_details: {name: '', unit_amount: 0}});
+
+// @ts-expect-error: `item_details.name` is required if `item_details` is present
+cartElement.addLineItem({item_details: {external_id: '', unit_amount: 0}});
+
+// @ts-expect-error: `item_details.unit_amount` is required if `item_details` is present
+cartElement.addLineItem({item_details: {external_id: '', name: ''}});
 
 // @ts-expect-error: `clientSecret` is not updatable
 cartElement.update({clientSecret: ''});

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -680,6 +680,26 @@ cartElement.addLineItem({product: '', quantity: 1});
 
 cartElement.addLineItem({price: '', quantity: 1});
 
+cartElement.addLineItem({
+  item_details: {
+    external_id: '',
+    name: '',
+    unit_amount: 0,
+  },
+  quantity: 1,
+});
+
+cartElement.addLineItem({
+  item_details: {
+    external_id: '',
+    name: '',
+    unit_amount: 0,
+    image: '',
+    description: '',
+  },
+  quantity: 1,
+});
+
 cartElement.on('ready', (e: StripeCartElementPayloadEvent) => {
   console.log(e.lineItems.count);
 });

--- a/types/stripe-js/elements/cart.d.ts
+++ b/types/stripe-js/elements/cart.d.ts
@@ -111,14 +111,30 @@ export type StripeCartElement = StripeElementBase & {
       | {
           product: string;
           price?: null;
+          item_details?: null;
           quantity?: number | null;
         }
       | {
-          price: string;
           product?: null;
+          price: string;
+          item_details?: null;
+          quantity?: number | null;
+        }
+      | {
+          price?: null;
+          product?: null;
+          item_details: CartItemDetails;
           quantity?: number | null;
         }
   ): Promise<{error?: StripeError}>;
+};
+
+export type CartItemDetails = {
+  external_id: string;
+  name: string;
+  description?: string;
+  image?: string;
+  unit_amount: number;
 };
 
 export type CartDescriptor = 'cart' | 'bag' | 'basket';


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

We recently added `item_details` as a parameter to `cartElement.addLineItem` to allow people to pass inline products. This PR adds stripe-js support for that new parameter

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Wrote tests in `valid.js` + `invalid.js` 
