### PR TITLE
Add `link` as a payment request wallet

### DIFF
--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -221,8 +221,8 @@ export interface PaymentRequestOptions {
 
   /**
    * An array of wallet strings.
-   * Can be one or more of `applePay`, `googlePay` and `browserCard`.
-   * Use this option to disable Google Pay, Apple Pay and/or browser-saved cards.
+   * Can be one or more of `applePay`, `googlePay`, `link` and `browserCard`.
+   * Use this option to disable Google Pay, Apple Pay, Link and/or browser-saved cards.
    */
   disableWallets?: PaymentRequestWallet[];
 
@@ -281,7 +281,7 @@ export interface PaymentRequestShippingOption {
   amount: number;
 }
 
-export type PaymentRequestWallet = 'applePay' | 'googlePay' | 'browserCard';
+export type PaymentRequestWallet = 'applePay' | 'googlePay' | 'browserCard' | 'link';
 
 export type PaymentRequestCompleteStatus =
   /**


### PR DESCRIPTION
### Summary & motivation

Fix "PaymentRequestWallet" type to support "link" as a valid option.

### Testing & documentation

The "link" type is already on Stripe's official documentation: https://stripe.com/docs/js/payment_request/create#stripe_payment_request-options-disableWallets

