### PR TITLE
Fix return type for verifyMicrodepositsForSetup

### DIFF
--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -804,7 +804,7 @@ export interface Stripe {
   verifyMicrodepositsForSetup(
     clientSecret: string,
     data?: setupIntents.VerifyMicrodepositsForSetupData
-  ): Promise<PaymentIntentResult>;
+  ): Promise<SetupIntentResult>;
 
   /**
    * Use `stripe.collectBankAccountForSetup` in the [Save bank details](https://stripe.com/docs/payments/ach-debit/set-up-payment) flow for the [ACH Direct Debit](https://stripe.com/docs/payments/ach-debit)


### PR DESCRIPTION
### Summary & motivation

Small fix for return type for `verifyMicrodepositsForSetup` method

### Testing & documentation

I think no tests are required in this case, really simple fix.
