### PR TITLE
don't throw error with setLoadParameters when called again with the same values

### DIFF
--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -127,7 +127,18 @@ describe('pure module', () => {
     loadStripe('pk_foo');
 
     expect(() => {
-      loadStripe.setLoadParameters({advancedFraudSignals: false});
+      loadStripe.setLoadParameters({advancedFraudSignals: true});
     }).toThrow('cannot change load parameters');
+  });
+
+  test('does not throw an error if calling setLoadParameters after loadStripe but the parameters are the same', () => {
+    const {loadStripe} = require('./pure');
+
+    loadStripe.setLoadParameters({advancedFraudSignals: false});
+    loadStripe('pk_foo');
+
+    expect(() => {
+      loadStripe.setLoadParameters({advancedFraudSignals: false});
+    }).not.toThrow('cannot change load parameters');
   });
 });

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -25,7 +25,7 @@ export const loadStripe: LoadStripe & {setLoadParameters: SetLoadParams} = (
 loadStripe.setLoadParameters = (params): void => {
   // we won't throw an error if setLoadParameters is called with the same values as before
   if (loadStripeCalled && loadParams) {
-    const parameters = Object.keys(params) as Array<keyof typeof params>;
+    const parameters = Object.keys(validateLoadParams(params));
     const sameParameters = parameters.reduce((previousValue, currentValue) => {
       return (
         previousValue && params[currentValue] === loadParams?.[currentValue]

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -25,12 +25,19 @@ export const loadStripe: LoadStripe & {setLoadParameters: SetLoadParams} = (
 loadStripe.setLoadParameters = (params): void => {
   // we won't throw an error if setLoadParameters is called with the same values as before
   if (loadStripeCalled && loadParams) {
-    const parameters = Object.keys(validateLoadParams(params));
-    const sameParameters = parameters.reduce((previousValue, currentValue) => {
-      return (
-        previousValue && params[currentValue] === loadParams?.[currentValue]
-      );
-    }, true);
+    const validatedParams = validateLoadParams(params);
+    const parameterKeys = Object.keys(validatedParams) as Array<
+      keyof LoadParams
+    >;
+
+    const sameParameters = parameterKeys.reduce(
+      (previousValue, currentValue) => {
+        return (
+          previousValue && params[currentValue] === loadParams?.[currentValue]
+        );
+      },
+      true
+    );
 
     if (sameParameters) {
       return;

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -23,10 +23,20 @@ export const loadStripe: LoadStripe & {setLoadParameters: SetLoadParams} = (
 };
 
 loadStripe.setLoadParameters = (params): void => {
-  if (loadStripeCalled) {
-    throw new Error(
-      'You cannot change load parameters after calling loadStripe'
-    );
+  // we won't throw an error if setLoadParameters is called with the same values as before
+  if (loadStripeCalled && loadParams) {
+    const parameters = Object.keys(params) as Array<keyof typeof params>;
+    const sameParameters = parameters.reduce((previousValue, currentValue) => {
+      return (
+        previousValue && params[currentValue] === loadParams?.[currentValue]
+      );
+    }, true);
+
+    if (!sameParameters) {
+      throw new Error(
+        'You cannot change load parameters after calling loadStripe'
+      );
+    }
   }
 
   loadParams = validateLoadParams(params);

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -42,5 +42,6 @@ loadStripe.setLoadParameters = (params): void => {
       'You cannot change load parameters after calling loadStripe'
     );
   }
+
   loadParams = validateLoadParams(params);
 };

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -32,12 +32,15 @@ loadStripe.setLoadParameters = (params): void => {
       );
     }, true);
 
-    if (!sameParameters) {
-      throw new Error(
-        'You cannot change load parameters after calling loadStripe'
-      );
+    if (sameParameters) {
+      return;
     }
   }
 
+  if (loadStripeCalled) {
+    throw new Error(
+      'You cannot change load parameters after calling loadStripe'
+    );
+  }
   loadParams = validateLoadParams(params);
 };


### PR DESCRIPTION
### Summary & motivation

Referencing issue #413 
In some HMR instances `setLoadParameters` is called multiple times with the same parameters. We don't want to error in those cases and instead want to return early. 

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation
Added a new unit test to enter this new code path and return

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
