### PR TITLE
adds "on" property handler to StripeIssuingCardNumberDisplayElement

### DIFF
--- a/types/stripe-js/elements/issuing/issuing-card-number-display.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-card-number-display.d.ts
@@ -9,6 +9,14 @@ export type StripeIssuingCardNumberDisplayElement = StripeElementBase & {
    * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
    */
   update(options: Partial<StripeIssuingCardNumberDisplayElementOptions>): void;
+
+  /**
+   * Triggered when the element is fully rendered and can accept `element.focus` calls.
+   */
+  on(
+    eventType: 'ready',
+    handler: (event: {elementType: 'issuingCardNumberDisplay'}) => any
+  ): StripeIssuingCardNumberDisplayElement;
 };
 
 export interface StripeIssuingCardNumberDisplayElementOptions {


### PR DESCRIPTION
### Summary & motivation

Following conventions in other type definitions, we're adding an "on" property handler to the `StripeIssuingCardNumberDisplayElement`

closes #418 

### Testing & documentation

Tested locally
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->
This api is already documented [here](https://stripe.com/docs/js/element/events/on_ready)

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
