### PR TITLE
Fix `Document is not defined` in Deno/Remix

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -73,7 +73,7 @@ export const loadScript = (
   }
 
   stripePromise = new Promise((resolve, reject) => {
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
       // Resolve to null when imported server side. This makes the module
       // safe to import in an isomorphic code base.
       resolve(null);


### PR DESCRIPTION
Issue reference: https://github.com/stripe/stripe-js/issues/420#issue-1568681922

### Summary & motivation

Fix Stripe loader in Deno+Remix contexts. In typical Remix project stripe-js will be included in server code bundles, while Deno defines a global Window object. This causes Stripe loader to attempt loading the Stripe client JS which fails later due to Document not being defined in a Deno server context. 

<!-- Simple summary of what the code does or what you have changed. -->
Check that _both_ `window` and `document` are defined before proceeding with loading Stripe.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->
Not tested. But this is a pretty simple fix

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
