### PR TITLE
Add disableLink parameter to card

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -39,6 +39,11 @@ elements.update({
   },
 });
 
+cardElement.update({
+  // @ts-expect-error: 'disableLink' does not exist in type 'StripeCardElementUpdateOptions'
+  disableLink: false,
+});
+
 paymentElement.on('change', (e) => {
   // @ts-expect-error: `error` is not present on PaymentElement "change" event.
   if (e.error) {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -161,6 +161,7 @@ const cardElement: StripeCardElement = elements.create('card', {
   hidePostalCode: true,
   iconStyle: 'solid',
   disabled: false,
+  disableLink: false,
 });
 
 elements.create('card', {style: {base: {fontWeight: 500}}});

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -109,10 +109,52 @@ export type StripeCardElement = StripeElementBase & {
    * The styles of an `CardElement` can be dynamically changed using `element.update`.
    * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
    */
-  update(options: Partial<StripeCardElementOptions>): void;
+  update(options: StripeCardElementUpdateOptions): void;
 };
 
 export interface StripeCardElementOptions {
+  classes?: StripeElementClasses;
+
+  style?: StripeElementStyle;
+
+  /**
+   * A pre-filled set of values to include in the input (e.g., `{postalCode: '94110'}`).
+   * Note that sensitive card information (card number, CVC, and expiration date) cannot be pre-filled.
+   */
+  value?: {postalCode?: string};
+
+  /**
+   * Hide the postal code field.
+   * Default is `false`.
+   * If you are already collecting a full billing address or postal code elsewhere, set this to `true`.
+   */
+  hidePostalCode?: boolean;
+
+  /**
+   * Appearance of the icon in the Element.
+   */
+  iconStyle?: 'default' | 'solid';
+
+  /**
+   * Hides the icon in the Element.
+   * Default is `false`.
+   */
+  hideIcon?: boolean;
+
+  /**
+   * Applies a disabled state to the Element such that user input is not accepted.
+   * Default is false.
+   */
+  disabled?: boolean;
+
+  /**
+   * Hides and disables the Link Button in the Card Element.
+   * Default is false.
+   */
+  disableLink?: boolean;
+}
+
+export interface StripeCardElementUpdateOptions {
   classes?: StripeElementClasses;
 
   style?: StripeElementStyle;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

We recently added the `disableLink` parameter to the Card Element as a way to disable Link in the Card Element. This change is to add that parameter to the stripe-js repo as well.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Wrote invalid/valid test cases.

<!-- If this is an API change, have you updated the documentation? -->

Yes, documentation change is in review

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
