### PR TITLE
Update handleNextAction for PaymentIntent or SetupIntent return results

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -214,6 +214,23 @@ stripe
     }
   });
 
+stripe.handleNextAction({clientSecret: ''}).then((res) => {
+  if (res.paymentIntent) {
+    // @ts-expect-error If result has a paymentIntent, setupIntent will be undefined
+    const setupIntentId = res.setupIntent.id;
+  }
+  if (res.setupIntent) {
+    // @ts-expect-error If result has a setupIntent, paymentIntent will be undefined
+    const paymentIntentId = res.paymentIntent.id;
+  }
+  if (res.error) {
+    // @ts-expect-error If result has an error, paymentIntent will be undefined
+    const paymentIntentId = res.paymentIntent.id;
+    // @ts-expect-error If result has an error, setupIntent will be undefined
+    const setupIntentId = res.setupIntent.id;
+  }
+});
+
 stripe.processOrder({elements, confirmParams: {return_url: ''}}).then((res) => {
   if (res.error) {
   }

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2170,9 +2170,14 @@ stripe
   .handleCardAction('')
   .then(({paymentIntent}: {paymentIntent?: PaymentIntent}) => {});
 
-stripe
-  .handleNextAction({clientSecret: ''})
-  .then(({paymentIntent}: {paymentIntent?: PaymentIntent}) => {});
+stripe.handleNextAction({clientSecret: ''}).then((res) => {
+  if (res.paymentIntent) {
+  }
+  if (res.setupIntent) {
+  }
+  if (res.error) {
+  }
+});
 
 stripe
   .verifyMicrodepositsForPayment('', {amounts: [32, 45]})

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2172,10 +2172,13 @@ stripe
 
 stripe.handleNextAction({clientSecret: ''}).then((res) => {
   if (res.paymentIntent) {
+    const paymentIntentId = res.paymentIntent.id;
   }
   if (res.setupIntent) {
+    const setupIntentId = res.setupIntent.id;
   }
   if (res.error) {
+    const errorType = res.error.type;
   }
 });
 

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -590,8 +590,8 @@ export interface Stripe {
   handleCardAction(clientSecret: string): Promise<PaymentIntentResult>;
 
   /**
-   * Use `stripe.handleNextAction` in the Payment Intents API finalizing payments on the server flow to finish confirmation of a [PaymentIntent](https://stripe.com/docs/api/payment_intents) or [SetupIntent](https://stripe.com/docs/api/setup_intents) with the `requires_action` status.
-   * It will throw an error if the `PaymentIntent` has a different status.
+   * Use `stripe.handleNextAction` in the [finalizing payments on the server](https://stripe.com/docs/payments/finalize-payments-on-the-server) flow to finish confirmation of a [PaymentIntent](https://stripe.com/docs/api/payment_intents) or [SetupIntent](https://stripe.com/docs/api/setup_intents) with the `requires_action` status.
+   * It will throw an error if the `PaymentIntent` or `SetupIntent` has a different status.
    *
    * Note that `stripe.handleNextAction` may take several seconds to complete.
    * During that time, you should disable your form from being resubmitted and show a waiting indicator like a spinner.
@@ -605,7 +605,7 @@ export interface Stripe {
    */
   handleNextAction(options: {
     clientSecret: string;
-  }): Promise<PaymentIntentResult>;
+  }): Promise<PaymentIntentOrSetupIntentResult>;
 
   /**
    * Use `stripe.verifyMicrodepositsForPayment` in the [Accept a Canadian pre-authorized debit payment](https://stripe.com/docs/payments/acss-debit/accept-a-payment) flow
@@ -1202,6 +1202,15 @@ export type PaymentIntentResult =
 export type SetupIntentResult =
   | {setupIntent: api.SetupIntent; error?: undefined}
   | {setupIntent?: undefined; error: StripeError};
+
+export type PaymentIntentOrSetupIntentResult =
+  | {
+      paymentIntent: api.PaymentIntent;
+      setupIntent?: undefined;
+      error?: undefined;
+    }
+  | {paymentIntent?: undefined; setupIntent: api.SetupIntent; error?: undefined}
+  | {paymentIntent?: undefined; setupIntent?: undefined; error: StripeError};
 
 export type ProcessOrderResult =
   | {paymentIntent: api.PaymentIntent; order: api.Order; error?: undefined}


### PR DESCRIPTION
### Summary & motivation
Update `handleNextAction` to return either a `PaymentIntentResult` or `SetupIntentResult`

### Testing & documentation
Updated the test in `valid.ts`

https://stripe.com/docs/payments/finalize-payments-on-the-server?platform=web&type=payment#next-actions