### PR TITLE
Rename PMME option type

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -344,7 +344,7 @@ const paymentMethodMessagingElement = elements.create(
   'paymentMethodMessaging',
   {
     amount: 2000,
-    paymentMethods: ['afterpay_clearpay', 'klarna'],
+    paymentMethodTypes: ['afterpay_clearpay', 'klarna'],
     countryCode: 'US',
     currency: 'USD',
   }

--- a/types/stripe-js/elements/payment-method-messaging.d.ts
+++ b/types/stripe-js/elements/payment-method-messaging.d.ts
@@ -55,7 +55,12 @@ export interface StripePaymentMethodMessagingElementOptions {
   /**
    * Payment methods to show messaging for.
    */
-  paymentMethods: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
+  paymentMethodTypes: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
+
+  /**
+   * @deprecated Use `paymentMethodTypes` instead.
+   */
+  paymentMethods?: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
 
   /**
    * The country the end-buyer is in.


### PR DESCRIPTION
Update the Payment Method Messaging Element types to support the new naming of the `paymentMethodTypes` option.