### PR TITLE
fix typespec for elements group

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -686,9 +686,9 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
   mode?: 'payment' | 'setup' | 'subscription';
 
   /**
-   * Three character currency code (e.g., usd).
+   * Three-character currency code (e.g., usd).
    */
-  currency?: string;
+  currency: string;
 
   /**
    * The amount to be charged. Shown in Apple Pay, Google Pay, or Buy now pay later UIs, and influences available payment methods.


### PR DESCRIPTION
### Summary & motivation

Given the following code,

```ts
function StripeElements(props: { children: React.ReactNode }) {
  return (
    <Elements
      stripe={stripePromise}
      options={{
        mode: 'setup',
        // currency: 'usd',
        paymentMethodCreation: 'manual',
      }}
    >
      {props.children}
    </Elements>
  );
}
```

I would fail if I do not specify the `currency`:

```text
react-dom.development.js:12056 Uncaught IntegrationError: Missing value for options: currency should be a string.
```

### Testing & documentation

As I previously mentioned, I tried to remove such configuration but it failed