### PR TITLE
[types] Adding missing payment method / wallet types within TermsOption

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -381,6 +381,10 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
     bancontact: 'never',
     auBecsDebit: 'never',
     usBankAccount: 'never',
+    cashapp: 'auto',
+    applePay: 'always',
+    googlePay: 'never',
+    paypal: 'never',
   },
   business: {
     name: '',

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -167,12 +167,16 @@ export interface FieldsOption {
 export type TermOption = 'auto' | 'always' | 'never';
 
 export interface TermsOption {
+  applePay?: TermOption;
+  auBecsDebit?: TermOption;
   bancontact?: TermOption;
   card?: TermOption;
+  cashapp?: TermOption;
+  googlePay?: TermOption;
   ideal?: TermOption;
+  paypal?: TermOption;
   sepaDebit?: TermOption;
   sofort?: TermOption;
-  auBecsDebit?: TermOption;
   usBankAccount?: TermOption;
 }
 


### PR DESCRIPTION


### Summary & motivation

Some types were missing for valid `terms` options, this PR adds those.
https://stripe.com/docs/js/elements_object/create_payment_element#payment_element_create-options-terms

### Testing & documentation
Added new entries to valid type tests


