### PR TITLE
Remove unsupported Appearance API theme `‘none’`

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -890,7 +890,7 @@ export interface CustomFontSource {
 export interface Appearance {
   disableAnimations?: boolean;
 
-  theme?: 'stripe' | 'night' | 'flat' | 'none';
+  theme?: 'stripe' | 'night' | 'flat';
 
   variables?: {
     // General font styles


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Removed `'none'` from the `theme` enum in the Appearance API.

### Testing & documentation

N/A

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
