### PR TITLE
[wip] types for `createConfirmationToken`

### DIFF
--- a/types/api/confirmation-tokens.d.ts
+++ b/types/api/confirmation-tokens.d.ts
@@ -1,0 +1,73 @@
+import {StripeElements} from '../stripe-js';
+import {Address} from './shared';
+import {PaymentMethodCreateParams} from './payment-methods';
+
+/**
+ * The ConfirmationToken object.
+ */
+export interface ConfirmationToken {
+  // TODO
+}
+
+export interface ConfirmationTokenCreateParams {
+  /**
+   * Data used to create a new payment method.
+   *
+   */
+  payment_method_data?: {
+    /**
+     * The customer's billing details.
+     */
+    billing_details?: PaymentMethodCreateParams.BillingDetails;
+  };
+
+  /**
+   * The ID of an existing PaymentMethod.
+   */
+  payment_method?: string;
+
+  /**
+   * Shipping information.
+   */
+  shipping?: ConfirmationToken.Shipping
+
+  /**
+   * The url your customer will be directed to after they complete authentication.
+   */
+  return_url?: string;
+
+}
+
+export interface CreateConfirmationToken {
+  /**
+   * The Elements instance.
+   *
+   * @docs https://stripe.com/docs/js/elements_object
+   */
+  elements: StripeElements;
+
+  /**
+   * Parameters for creating the ConfirmationToken.
+   * Details collected by Elements will be overriden by values passed here.
+   */
+  params?: ConfirmationTokenCreateParams;
+}
+
+export namespace ConfirmationToken {
+  export interface Shipping {
+    /**
+     * Recipient address.
+     */
+    address: Address;
+
+    /**
+     * Recipient name.
+     */
+    name: string | null;
+
+    /**
+     * Recipient phone (including extension).
+     */
+    phone?: string | null;
+  }
+}

--- a/types/api/index.d.ts
+++ b/types/api/index.d.ts
@@ -1,5 +1,6 @@
 export * from './shared';
 export * from './payment-methods';
+export * from './confirmation-tokens';
 export * from './payment-intents';
 export * from './orders';
 export * from './setup-intents';

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -45,6 +45,7 @@ export type CreatePaymentMethodData =
 export {
   CreatePaymentMethodFromElement,
   CreatePaymentMethodFromElements,
+  CreateConfirmationToken
 } from '../api';
 
 export interface CreatePaymentMethodAlipayData

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -664,6 +664,15 @@ export interface Stripe {
   ): Promise<PaymentMethodResult>;
 
   /**
+   * Use stripe.createConfirmationToken to convert payment information collected by elements into a [ConfirmationToken](https://stripe.com/docs/api/confirmation_tokens) object that you safely pass to your server to use in an API call.
+   *
+   * @docs https://stripe.com/docs/js/confirmation_tokens/create_confirmation_token
+   */
+  createConfirmationToken(
+    options: paymentIntents.CreateConfirmationToken
+  ): Promise<ConfirmationTokenResult>;
+
+  /**
    * Retrieve a [PaymentIntent](https://stripe.com/docs/api/payment_intents) using its [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret).
    *
    * @docs https://stripe.com/docs/js/payment_intents/retrieve_payment_intent
@@ -1225,6 +1234,10 @@ export type PaymentMethodResult =
   | {paymentMethod: api.PaymentMethod; error?: undefined}
   | {paymentMethod?: undefined; error: StripeError};
 
+export type ConfirmationTokenResult =
+| {confirmationToken: api.ConfirmationToken; error?: undefined}
+| {confirmationToken?: undefined; error: StripeError};
+
 export type SourceResult =
   | {source: api.Source; error?: undefined}
   | {source?: undefined; error: StripeError};
@@ -1260,8 +1273,8 @@ export type EphemeralKeyNonceResult =
   | {nonce: string; error?: undefined}
   | {nonce?: undefined; error: StripeError};
 
-/* A Radar Session is a snapshot of the browser metadata and device details that helps Radar make more accurate predictions on your payments. 
-  This metadata includes information like IP address, browser, screen or device information, and other device characteristics. 
+/* A Radar Session is a snapshot of the browser metadata and device details that helps Radar make more accurate predictions on your payments.
+  This metadata includes information like IP address, browser, screen or device information, and other device characteristics.
   You can find more details about how Radar uses this data by reading about how Radar performs [advanced fraud detection](https://stripe.com/docs/disputes/prevention/advanced-fraud-detection).
   */
 export type RadarSessionPayload =


### PR DESCRIPTION
### Summary & motivation

 (missing ConfirmationToken obj definition)

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
