### PR TITLE
Add Custom Checkout Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 *.log
 .vim
+.vscode/

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -1,0 +1,216 @@
+import {
+  LayoutObject,
+  Layout,
+  TermsOption,
+  StripePaymentElement,
+} from './elements/payment';
+import {
+  AddressMode,
+  ContactOption,
+  StripeAddressElement,
+} from './elements/address';
+import {Appearance, CssFontSource, CustomFontSource} from './elements-group';
+
+/**
+ * Requires beta access:
+ * Contact [Stripe support](https://support.stripe.com/) for more information.
+ */
+
+/**
+ * StripeCustomCheckoutInitOptions
+ */
+export interface StripeCustomCheckoutElementsOptions {
+  appearance?: Appearance;
+  loader?: 'auto' | 'always' | 'never';
+  fonts?: Array<CssFontSource | CustomFontSource>;
+}
+
+export interface StripeCustomCheckoutOptions {
+  clientSecret: string;
+  elementsOptions?: StripeCustomCheckoutElementsOptions;
+}
+
+/**
+ * StripeCustomCheckoutActions
+ */
+
+export type StripeCustomCheckoutAddress = {
+  country: string | null;
+  line1: string | null;
+  line2?: string | null;
+  city: string | null;
+  postal_code: string | null;
+  state: string | null;
+};
+
+export type StripeCustomCheckoutShippingAddress = {
+  name?: string | null;
+  address: StripeCustomCheckoutAddress;
+};
+
+export type StripeCustomCheckoutBillingAddress = StripeCustomCheckoutShippingAddress;
+
+export interface StripeCustomCheckoutActions {
+  applyPromotionCode: (promotionCode: string) => Promise<void>;
+  removePromotionCode: () => Promise<void>;
+  updateShippingAddress: (
+    shippingAddress: StripeCustomCheckoutShippingAddress
+  ) => Promise<void>;
+  updateBillingAddress: (
+    billingAddress: StripeCustomCheckoutBillingAddress
+  ) => Promise<void>;
+  updatePhoneNumber: (phoneNumber: string) => void;
+  updateEmail: (email: string) => void;
+  updateLineItemQuantity: (args: {
+    lineItem: string;
+    quantity: number;
+  }) => Promise<void>;
+  updateShippingOption: (shippingOption: string) => Promise<void>;
+  confirm: (args?: {return_url?: string}) => Promise<void>;
+}
+
+/**
+ * StripeCustomCheckoutSession
+ */
+
+export type StripeCustomCheckoutTaxAmount = {
+  amount: number;
+  inclusive: boolean;
+  displayName: string;
+};
+
+export type StripeCustomCheckoutDiscountAmount = {
+  amount: number;
+  displayName: string;
+  promotionCode?: string | null;
+};
+
+export type StripeCustomCheckoutShipping = {
+  shippingOption: StripeCustomCheckoutShippingOption;
+  taxAmounts?: Array<StripeCustomCheckoutTaxAmount> | null;
+};
+
+export type StripeCustomCheckoutShippingOption = {
+  id: string;
+  amount: number;
+  currency: string;
+  displayName?: string | null;
+  deliveryEstimate?: StripeCustomCheckoutDeliveryEstimate | null;
+};
+
+export type StripeCustomCheckoutDeliveryEstimate = {
+  maximum?: StripeCustomCheckoutEstimate | null;
+  minimum?: StripeCustomCheckoutEstimate | null;
+};
+
+export type StripeCustomCheckoutEstimate = {
+  unit: 'business_day' | 'day' | 'hour' | 'week' | 'month';
+  value: number;
+};
+
+export type StripeCustomCheckoutLineItemDiscountAmount = {
+  amount: number;
+  promotionCode?: string | null;
+};
+
+export type StripeCustomCheckoutBillingInterval =
+  | 'day'
+  | 'month'
+  | 'week'
+  | 'year';
+
+export type StripeCustomCheckoutLineItem = {
+  id: string;
+  name: string;
+  amount: number;
+  unitAmount: number;
+  description?: string | null;
+  quantity: number;
+  discountAmounts?: Array<StripeCustomCheckoutLineItemDiscountAmount> | null;
+  recurring?: {
+    interval: StripeCustomCheckoutBillingInterval;
+    interval_count: number;
+  };
+};
+
+export type StripeCustomCheckoutTotalSummary = {
+  subtotal: number;
+  taxExclusive: number;
+  taxInclusive: number;
+  shippingRate: number;
+  discount: number;
+  total: number;
+};
+
+export type StripeCustomCheckoutConfirmationRequirement =
+  | 'phoneNumber'
+  | 'shippingAddress'
+  | 'billingAddress'
+  | 'paymentDetails'
+  | 'email';
+
+export interface StripeCustomCheckoutSession {
+  lineItems: Array<StripeCustomCheckoutLineItem>;
+  taxAmounts?: Array<StripeCustomCheckoutTaxAmount> | null;
+  discountAmounts?: Array<StripeCustomCheckoutDiscountAmount> | null;
+  currency: string;
+  shipping?: StripeCustomCheckoutShipping | null;
+  shippingOptions: Array<StripeCustomCheckoutShippingOption>;
+  shippingAddress?: StripeCustomCheckoutShippingAddress | null;
+  billingAddress?: StripeCustomCheckoutBillingAddress | null;
+  phoneNumber?: string | null;
+  email?: string | null;
+  total: StripeCustomCheckoutTotalSummary;
+  confirmationRequirements: StripeCustomCheckoutConfirmationRequirement[];
+  canConfirm: boolean;
+}
+
+/**
+ * StripeCustomCheckoutElements
+ */
+export type StripeCustomCheckoutPaymentElementOptions = {
+  layout?: Layout | LayoutObject;
+  paymentMethodOrder?: Array<string>;
+  readonly?: boolean;
+  terms?: TermsOption;
+};
+
+export type StripeCustomCheckoutAddressElementOptions = {
+  mode: AddressMode;
+  contacts?: ContactOption[];
+  display?: {
+    name?: 'full' | 'split' | 'organization';
+  };
+};
+
+export interface StripeCustomCheckoutElementsActions {
+  changeAppearance: (appearance: Appearance) => void;
+  getElement(elementType: 'payment'): StripePaymentElement | null;
+  getElement(
+    elementType: 'address',
+    mode: AddressMode
+  ): StripeAddressElement | null;
+  createElement(
+    elementType: 'payment',
+    options?: StripeCustomCheckoutPaymentElementOptions
+  ): StripePaymentElement;
+  createElement(
+    elementType: 'address',
+    options: StripeCustomCheckoutAddressElementOptions
+  ): StripeAddressElement;
+}
+
+/**
+ * StripeCustomCheckout
+ */
+export type StripeCustomCheckoutUpdateHandler = (
+  session: StripeCustomCheckoutSession
+) => void;
+
+export interface StripeCustomCheckout
+  extends StripeCustomCheckoutActions,
+    StripeCustomCheckoutSession,
+    StripeCustomCheckoutElementsActions {
+  session: () => StripeCustomCheckoutSession;
+  on: (event: 'change', handler: StripeCustomCheckoutUpdateHandler) => void;
+}

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -1,4 +1,5 @@
 export * from './checkout';
+export * from './custom-checkout';
 export * from './elements';
 export * from './elements-group';
 export * from './ephemeral-keys';

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -15,6 +15,10 @@ import {
 import {CheckoutLocale, RedirectToCheckoutOptions} from './checkout';
 import {PaymentRequestOptions, PaymentRequest} from './payment-request';
 import {StripeElement, StripeElementLocale} from './elements-group';
+import {
+  StripeCustomCheckoutOptions,
+  StripeCustomCheckout,
+} from './custom-checkout';
 
 export interface Stripe {
   /////////////////////////////
@@ -1193,6 +1197,14 @@ export interface Stripe {
   createEphemeralKeyNonce(
     options: ephemeralKeys.EphemeralKeyNonceOptions
   ): Promise<EphemeralKeyNonceResult>;
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   */
+  initCustomCheckout(
+    options: StripeCustomCheckoutOptions
+  ): Promise<StripeCustomCheckout>;
 }
 
 export type PaymentIntentResult =


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

- add Custom Checkout types (so we can use it in https://github.com/stripe/react-stripe-js)
  - I didn't add any documentation to each function/type/interface. Since we are still in beta, this may get changed. We can add the documentation when GA, sounds good?

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
