### PR TITLE
Add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@stripe/stripe-js",
   "version": "2.1.1",
   "description": "Stripe.js loading utility",
+  "repository": "github:stripe/stripe-js",
   "main": "dist/stripe.js",
   "module": "dist/stripe.esm.js",
   "jsnext:main": "dist/stripe.esm.js",


### PR DESCRIPTION
### Summary & motivation

Adding the repository information to the package.json helps automation tools like [Renovate](https://github.com/renovatebot/renovate) to fetch release notes from the repository itself. Currently there are no release notes shown and you always need to visit the GitHub repository to look them up for new versions.

### Testing & documentation

No testing needed, you can verify the changes [here](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository).
