### PR TITLE
Add Embedded Checkout types

### DIFF
--- a/types/stripe-js/embedded-checkout.d.ts
+++ b/types/stripe-js/embedded-checkout.d.ts
@@ -1,10 +1,30 @@
 export interface StripeEmbeddedCheckoutOptions {
+  /**
+   * The client secret of the [Checkout Session](https://stripe.com/docs/api/checkout/sessions).
+   */
   clientSecret: string;
+  /**
+   * onComplete is called when the Checkout Session completes successfully.
+   * You can use it to unmount Embedded Checkout and render a custom success UI.
+   */
   onComplete?: () => void;
 }
 
 export interface StripeEmbeddedCheckout {
+  /**
+   * The `embeddedCheckout.mount` method attaches your Embedded Checkout to the DOM.
+   * `mount` accepts either a CSS Selector (e.g., `'#checkout'`) or a DOM element.
+   */
   mount(location: string | HTMLElement): void;
+  /**
+   * Unmounts Embedded Checkout from the DOM.
+   * Call `embeddedCheckout.mount` to re-attach it to the DOM.
+   */
   unmount(): void;
+  /**
+   * Removes Embedded Checkout from the DOM and destroys it.
+   * Once destroyed it not be re-mounted to the DOM.
+   * Use this if you want to create a new Embedded Checkout instance.
+   */
   destroy(): void;
 }

--- a/types/stripe-js/embedded-checkout.d.ts
+++ b/types/stripe-js/embedded-checkout.d.ts
@@ -1,0 +1,10 @@
+export interface StripeEmbeddedCheckoutOptions {
+  clientSecret: string;
+  onComplete?: () => void;
+}
+
+export interface StripeEmbeddedCheckout {
+  mount(location: string | HTMLElement): void;
+  unmount(): void;
+  destroy(): void;
+}

--- a/types/stripe-js/index.d.ts
+++ b/types/stripe-js/index.d.ts
@@ -1,5 +1,6 @@
 export * from './checkout';
 export * from './custom-checkout';
+export * from './embedded-checkout';
 export * from './elements';
 export * from './elements-group';
 export * from './ephemeral-keys';

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -19,6 +19,10 @@ import {
   StripeCustomCheckoutOptions,
   StripeCustomCheckout,
 } from './custom-checkout';
+import {
+  StripeEmbeddedCheckoutOptions,
+  StripeEmbeddedCheckout,
+} from './embedded-checkout';
 
 export interface Stripe {
   /////////////////////////////
@@ -1205,6 +1209,14 @@ export interface Stripe {
   initCustomCheckout(
     options: StripeCustomCheckoutOptions
   ): Promise<StripeCustomCheckout>;
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   */
+  initEmbeddedCheckout(
+    options: StripeEmbeddedCheckoutOptions
+  ): Promise<StripeEmbeddedCheckout>;
 }
 
 export type PaymentIntentResult =


### PR DESCRIPTION
### Summary & motivation
Add Embedded Checkout types (so we can use it in https://github.com/stripe/react-stripe-js)

