### PR TITLE
Update Custom Checkout types

### DIFF
--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -47,7 +47,7 @@ export type StripeCustomCheckoutAddress = {
 export type StripeCustomCheckoutContact = {
   name?: string | null;
   address: StripeCustomCheckoutAddress;
-}
+};
 
 export type StripeCustomCheckoutResult =
   | {session: StripeCustomCheckoutSession; error?: undefined}

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -36,20 +36,19 @@ export interface StripeCustomCheckoutOptions {
  */
 
 export type StripeCustomCheckoutAddress = {
-  country: string | null;
-  line1: string | null;
+  country: string;
+  line1?: string | null;
   line2?: string | null;
-  city: string | null;
-  postal_code: string | null;
-  state: string | null;
+  city?: string | null;
+  postal_code?: string | null;
+  state?: string | null;
 };
 
-export type StripeCustomCheckoutShippingAddress = {
+export type StripeCustomCheckoutContact = {
   name?: string | null;
   address: StripeCustomCheckoutAddress;
-};
+}
 
-export type StripeCustomCheckoutBillingAddress = StripeCustomCheckoutShippingAddress;
 export type StripeCustomCheckoutResult =
   | {session: StripeCustomCheckoutSession; error?: undefined}
   | {session?: undefined; error: StripeError};
@@ -60,10 +59,10 @@ export interface StripeCustomCheckoutActions {
   ) => Promise<StripeCustomCheckoutResult>;
   removePromotionCode: () => Promise<StripeCustomCheckoutResult>;
   updateShippingAddress: (
-    shippingAddress: StripeCustomCheckoutShippingAddress
+    shippingAddress: StripeCustomCheckoutContact
   ) => Promise<StripeCustomCheckoutResult>;
   updateBillingAddress: (
-    billingAddress: StripeCustomCheckoutBillingAddress
+    billingAddress: StripeCustomCheckoutContact
   ) => Promise<StripeCustomCheckoutResult>;
   updatePhoneNumber: (phoneNumber: string) => void;
   updateEmail: (email: string) => void;
@@ -92,35 +91,30 @@ export type StripeCustomCheckoutTaxAmount = {
 export type StripeCustomCheckoutDiscountAmount = {
   amount: number;
   displayName: string;
-  promotionCode?: string | null;
+  promotionCode: string | null;
 };
 
 export type StripeCustomCheckoutShipping = {
   shippingOption: StripeCustomCheckoutShippingOption;
-  taxAmounts?: Array<StripeCustomCheckoutTaxAmount> | null;
+  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
 };
 
 export type StripeCustomCheckoutShippingOption = {
   id: string;
   amount: number;
   currency: string;
-  displayName?: string | null;
-  deliveryEstimate?: StripeCustomCheckoutDeliveryEstimate | null;
+  displayName: string | null;
+  deliveryEstimate: StripeCustomCheckoutDeliveryEstimate | null;
 };
 
 export type StripeCustomCheckoutDeliveryEstimate = {
-  maximum?: StripeCustomCheckoutEstimate | null;
-  minimum?: StripeCustomCheckoutEstimate | null;
+  maximum: StripeCustomCheckoutEstimate | null;
+  minimum: StripeCustomCheckoutEstimate | null;
 };
 
 export type StripeCustomCheckoutEstimate = {
   unit: 'business_day' | 'day' | 'hour' | 'week' | 'month';
   value: number;
-};
-
-export type StripeCustomCheckoutLineItemDiscountAmount = {
-  amount: number;
-  promotionCode?: string | null;
 };
 
 export type StripeCustomCheckoutBillingInterval =
@@ -134,13 +128,14 @@ export type StripeCustomCheckoutLineItem = {
   name: string;
   amount: number;
   unitAmount: number;
-  description?: string | null;
+  description: string | null;
   quantity: number;
-  discountAmounts?: Array<StripeCustomCheckoutLineItemDiscountAmount> | null;
-  recurring?: {
+  discountAmounts: Array<StripeCustomCheckoutDiscountAmount> | null;
+  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
+  recurring: {
     interval: StripeCustomCheckoutBillingInterval;
     interval_count: number;
-  };
+  } | null;
 };
 
 export type StripeCustomCheckoutTotalSummary = {
@@ -161,15 +156,15 @@ export type StripeCustomCheckoutConfirmationRequirement =
 
 export interface StripeCustomCheckoutSession {
   lineItems: Array<StripeCustomCheckoutLineItem>;
-  taxAmounts?: Array<StripeCustomCheckoutTaxAmount> | null;
-  discountAmounts?: Array<StripeCustomCheckoutDiscountAmount> | null;
+  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
+  discountAmounts: Array<StripeCustomCheckoutDiscountAmount> | null;
   currency: string;
-  shipping?: StripeCustomCheckoutShipping | null;
+  shipping: StripeCustomCheckoutShipping | null;
   shippingOptions: Array<StripeCustomCheckoutShippingOption>;
-  shippingAddress?: StripeCustomCheckoutShippingAddress | null;
-  billingAddress?: StripeCustomCheckoutBillingAddress | null;
-  phoneNumber?: string | null;
-  email?: string | null;
+  shippingAddress: StripeCustomCheckoutContact | null;
+  billingAddress: StripeCustomCheckoutContact | null;
+  phoneNumber: string | null;
+  email: string | null;
   total: StripeCustomCheckoutTotalSummary;
   confirmationRequirements: StripeCustomCheckoutConfirmationRequirement[];
   canConfirm: boolean;
@@ -219,7 +214,6 @@ export type StripeCustomCheckoutUpdateHandler = (
 
 export interface StripeCustomCheckout
   extends StripeCustomCheckoutActions,
-    StripeCustomCheckoutSession,
     StripeCustomCheckoutElementsActions {
   session: () => StripeCustomCheckoutSession;
   on: (event: 'change', handler: StripeCustomCheckoutUpdateHandler) => void;


### PR DESCRIPTION
r? @pololi-stripe 
### Summary & motivation
Updates the types for Custom Checkout:
1. `country` in `StripeCustomCheckoutAddress` is required
2. I removed all the `undefined` types (`?`) in objects that are read-only. The remaining types that allow omitting keys are only the ones that are used in a parameter for some function, such as address or elements options
3. Renamed ShippingAddress and BillingAddress to Contact
4. Replaced LineItemDiscountAmount with DiscountAmount


### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
