### PR TITLE
[Types] Add optional payment_method in confirmPayment param type definition

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -165,8 +165,11 @@ elements.create('expressCheckout', {
 // @ts-expect-error at least one of elements or clientSecret is required
 stripe.confirmPayment({confirmParams: {return_url: ''}});
 
-// @ts-expect-error Existing payment method by ID string only, not object
-stripe.confirmPayment({clientSecret: '', confirmParams: {return_url: '', payment_method: {}}});
+stripe.confirmPayment({
+  clientSecret: '',
+  // @ts-expect-error Existing payment method by ID string only, not object
+  confirmParams: {return_url: '', payment_method: {}},
+});
 
 stripe
   .confirmPayment({elements, confirmParams: {return_url: ''}})
@@ -197,8 +200,11 @@ stripe
 // @ts-expect-error either elements or clientSecret is required
 stripe.confirmSetup({confirmParams: {return_url: ''}});
 
-// @ts-expect-error Existing payment method by ID string only, not object
-stripe.confirmSetup({clientSecret: '', confirmParams: {return_url: '', payment_method: {}}});
+stripe.confirmSetup({
+  clientSecret: '',
+  // @ts-expect-error Existing payment method by ID string only, not object
+  confirmParams: {return_url: '', payment_method: {}},
+});
 
 stripe.confirmSetup({elements, confirmParams: {return_url: ''}}).then((res) => {
   if (res.error) {

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -165,6 +165,9 @@ elements.create('expressCheckout', {
 // @ts-expect-error at least one of elements or clientSecret is required
 stripe.confirmPayment({confirmParams: {return_url: ''}});
 
+// @ts-expect-error Existing payment method by ID string only, not object
+stripe.confirmPayment({clientSecret: '', confirmParams: {return_url: '', payment_method: {}}});
+
 stripe
   .confirmPayment({elements, confirmParams: {return_url: ''}})
   .then((res) => {
@@ -193,6 +196,9 @@ stripe
 
 // @ts-expect-error either elements or clientSecret is required
 stripe.confirmSetup({confirmParams: {return_url: ''}});
+
+// @ts-expect-error Existing payment method by ID string only, not object
+stripe.confirmSetup({clientSecret: '', confirmParams: {return_url: '', payment_method: {}}});
 
 stripe.confirmSetup({elements, confirmParams: {return_url: ''}}).then((res) => {
   if (res.error) {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2947,7 +2947,6 @@ stripe
     }
   });
 
-
 stripe
   .processOrder({
     elements,

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2813,6 +2813,22 @@ stripe
     }
   });
 
+// confirmPayment redirect: 'if_required' with clientSecret and existing PM
+stripe
+  .confirmPayment({
+    clientSecret: '',
+    redirect: 'if_required',
+    confirmParams: {
+      payment_method: '',
+    },
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.paymentIntent) {
+    }
+  });
+
 // confirmSetup: redirect: 'always' without clientSecret
 stripe
   .confirmSetup({
@@ -2914,6 +2930,23 @@ stripe
     if (res.setupIntent) {
     }
   });
+
+// confirmSetup redirect: 'if_required' with clientSecret and existing PM
+stripe
+  .confirmSetup({
+    clientSecret: '',
+    redirect: 'if_required',
+    confirmParams: {
+      payment_method: '',
+    },
+  })
+  .then((res) => {
+    if (res.error) {
+    }
+    if (res.setupIntent) {
+    }
+  });
+
 
 stripe
   .processOrder({

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -1425,6 +1425,13 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
   };
 
   /**
+   * Optional `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+   *
+   * @docs https://stripe.com/docs/js/payment_intents/confirm_payment#confirm_payment_intent-options-confirmParams-payment_method
+   */
+  payment_method?: string
+
+  /**
    * Specifies which fields in the response should be expanded.
    */
   expand?: Array<string>;

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -1429,7 +1429,7 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
    *
    * @docs https://stripe.com/docs/js/payment_intents/confirm_payment#confirm_payment_intent-options-confirmParams-payment_method
    */
-  payment_method?: string
+  payment_method?: string;
 
   /**
    * Specifies which fields in the response should be expanded.


### PR DESCRIPTION
### Summary & motivation

Adds missing optional `payment_method` parameter within `confirmParams` for `confirmPayment`
<!-- Simple summary of what the code does or what you have changed. -->
https://github.com/stripe/stripe-js/issues/496

### Testing & documentation
Added valid/invalid type tests
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
