### PR TITLE
Add paymentMethodOptions type to the Elements group

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -90,6 +90,9 @@ const options: StripeElementsOptions = {
   captureMethod: 'automatic',
   paymentMethodTypes: ['card'],
   paymentMethodCreation: 'manual',
+  paymentMethodOptions: {
+    card: {require_cvc_recollection: true},
+  },
   appearance: {
     disableAnimations: false,
     theme: 'night',
@@ -119,6 +122,9 @@ stripe.elements({
   capture_method: 'automatic',
   payment_method_types: ['card'],
   payment_method_creation: 'manual',
+  payment_method_options: {
+    us_bank_account: {financial_connections: {permissions: ['payment_method']}},
+  },
 });
 
 const elementsClientSecret: StripeElements = stripe.elements({

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -617,6 +617,18 @@ export type StripeElementLocale =
   | 'zh-HK'
   | 'zh-TW';
 
+type PaymentMethodOptions = {
+  card?: {require_cvc_recollection?: boolean};
+  us_bank_account?: {
+    financial_connections?: {
+      permissions?: Array<
+        'balances' | 'ownership' | 'payment_method' | 'transactions'
+      >;
+    };
+    verification_method?: 'automatic' | 'instant';
+  };
+};
+
 /**
  * Options to create an `Elements` instance with.
  */
@@ -770,6 +782,20 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
    * Allows PaymentMethods to be created from the Elements instance.
    */
   payment_method_creation?: 'manual';
+
+  /**
+   * Additional payment-method-specific options for configuring Payment Element behavior.
+   *
+   * @docs https://stripe.com/docs/js/elements_object/create_without_intent#stripe_elements_no_intent-options-paymentMethodOptions
+   */
+  paymentMethodOptions?: PaymentMethodOptions;
+
+  /**
+   * Additional payment-method-specific options for configuring Payment Element behavior.
+   *
+   * @docs https://stripe.com/docs/js/elements_object/create_without_intent#stripe_elements_no_intent-options-paymentMethodOptions
+   */
+  payment_method_options?: PaymentMethodOptions;
 
   /**
    * Either use mode or clientSecret when creating an Elements group


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Adds the `paymentMethodOptions` type to `stripe.elements`

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Added some cases in `valid`
