### PR TITLE
Remove requires beta access for initEmbeddedCheckout

### DIFF
--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -1211,8 +1211,9 @@ export interface Stripe {
   ): Promise<StripeCustomCheckout>;
 
   /**
-   * Requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   * Use `stripe.initEmbeddedCheckout` to initialize an embedded Checkout instance
+   *
+   * * @docs https://stripe.com/docs/payments/accept-a-payment?platform=web&ui=embedded-checkout
    */
   initEmbeddedCheckout(
     options: StripeEmbeddedCheckoutOptions


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Removes documentation that `initEmbeddedCheckout` requires beta access and links to the docs instead

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->
This is a documentation change so no tests

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
