### PR TITLE
User reports network failure to load Stripe.js fails again after network is restored

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -57,7 +57,9 @@ const injectScript = (params: null | LoadParams): HTMLScriptElement => {
 const reloadScript = (params: null | LoadParams): HTMLScriptElement => {
   const queryString =
     params && !params.advancedFraudSignals ? '?advancedFraudSignals=false' : '';
-  const script = [...document.getElementsByTagName("script")].filter((element) => element.src === `${V3_URL}${queryString}`)[0];
+  const script = [...document.getElementsByTagName('script')].filter(
+    (element) => element.src === `${V3_URL}${queryString}`
+  )[0];
   const headOrBody = document.head || document.body;
   if (!headOrBody) {
     throw new Error(
@@ -67,7 +69,7 @@ const reloadScript = (params: null | LoadParams): HTMLScriptElement => {
   headOrBody.removeChild(script);
 
   return injectScript(params);
-}
+};
 
 const registerWrapper = (stripe: any, startTime: number): void => {
   if (!stripe || !stripe._registerWrapper) {
@@ -112,7 +114,7 @@ export const loadScript = (
       } else if (!script) {
         script = injectScript(params);
       } else {
-        // if script exists, but we are reloading due to an error, 
+        // if script exists, but we are reloading due to an error,
         // reload script to trigger 'load' event
         script = reloadScript(params);
       }
@@ -135,7 +137,11 @@ export const loadScript = (
   });
 
   // set stripePromise to null on error
-  return stripePromise.catch((error) => {throw new Error(error)}).then(stripePromise = null);
+  return stripePromise
+    .catch((error) => {
+      throw new Error(error);
+    })
+    .then((stripePromise = null));
 };
 
 export const initStripe = (

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -120,11 +120,10 @@ export const loadScript = (
     }
   });
   // Resets stripePromise on error
-  return stripePromise
-    .catch((error) => {
-      stripePromise = null;
-      return Promise.reject(error);
-    });
+  return stripePromise.catch((error) => {
+    stripePromise = null;
+    return Promise.reject(error);
+  });
 };
 
 export const initStripe = (

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -139,7 +139,7 @@ export const loadScript = (
   // set stripePromise to null on error
   return stripePromise
     .catch((error) => {
-      throw new Error(error);
+      throw error;
     })
     .then((stripePromise = null));
 };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -94,16 +94,16 @@ export const loadScript = (
       resolve(null);
       return;
     }
-  
+
     if (window.Stripe && params) {
       console.warn(EXISTING_SCRIPT_MESSAGE);
     }
-  
+
     if (window.Stripe) {
       resolve(window.Stripe);
       return;
     }
-  
+
     try {
       let script = findScript();
 


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

When stripe-js fails to load, previously we would persist the error even on reload. Now, set `stripePromise = null` on error and if the load script is called again, we retrigger the `load` event to attempt to load stripe again.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

I tested the repro stated [here](https://github.com/stripe/stripe-js/issues/26#issuecomment-1477716731) and verified that on reload we no longer see a persisting error and stripe gets reloaded properly.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
