### PR TITLE
Add string as valid deliveryEstimate value for ECE

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -982,6 +982,12 @@ expressCheckoutElement.on(
           },
         },
         {
+          id: 'fast-shipping',
+          amount: 300,
+          displayName: 'Pizza time, soon',
+          deliveryEstimate: 'A couple of weeks',
+        },
+        {
           id: 'free-shipping',
           amount: 0,
           displayName: 'Pizza time, eventually',

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -230,10 +230,12 @@ export type ShippingRate = {
   id: string;
   amount: number;
   displayName: string;
-  deliveryEstimate?: string | {
-    maximum?: DeliveryEstimate;
-    minimum?: DeliveryEstimate;
-  };
+  deliveryEstimate?:
+    | string
+    | {
+        maximum?: DeliveryEstimate;
+        minimum?: DeliveryEstimate;
+      };
 };
 
 export type LayoutOption = {

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -230,7 +230,7 @@ export type ShippingRate = {
   id: string;
   amount: number;
   displayName: string;
-  deliveryEstimate?: {
+  deliveryEstimate?: string | {
     maximum?: DeliveryEstimate;
     minimum?: DeliveryEstimate;
   };


### PR DESCRIPTION
### Summary & motivation

The Express Checkout Element allows a String to be passed for the click event's resolve option parameter [shippingRates.deliveryEstimate](https://stripe.com/docs/js/elements_object/express_checkout_element_click_event#express_checkout_element_on_click-handler-resolve-shippingRates-deliveryEstimate) but the Typescript definition only  provided a type definition for the object model.

This PR adds string as a valid type for deliveryEstimate.


### Testing & documentation

Tested locally - 

![CleanShot 2023-10-24 at 16 47 07](https://github.com/stripe/stripe-js/assets/95632492/df4bbcec-0485-4a5f-a188-f28338e1e4da)
