### PR TITLE
Update types for Apple Pay JS Recurring, Deferred and Automatic Reload payment requests

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -145,7 +145,6 @@ expressCheckoutElement.on('shippingaddresschange', ({address, resolve}) => {
         amount: 2000,
       },
       managementURL: 'https://atnnews.com/manage-subscription',
-      // @ts-expect-error: Object literal may only specify known properties, and 'billingAgreement' does not exist in type 'Omit<ApplePayRecurringPaymentRequest, "billingAgreement">'.
       billingAgreement: 'You agree to pay ATN News $20.00 every month.',
     },
   };

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -113,16 +113,76 @@ expressCheckoutElement.update({
   },
 });
 
-expressCheckoutElement.on('shippingaddresschange', ({address}) => {
+expressCheckoutElement.on('shippingaddresschange', ({address, resolve}) => {
   // @ts-expect-error Property 'line1' does not exist on type 'PartialAddress'.
   address.line1;
   // @ts-expect-error Property 'line2' does not exist on type 'PartialAddress'.
   address.line2;
+
+  resolve({
+    applePay: {
+      // @ts-expect-error: Object literal may only specify known properties, and 'deferredPaymentRequest' does not exist in type 'ApplePayUpdateOption'.
+      deferredPaymentRequest: {
+        paymentDescription: 'Deferred payment',
+        deferredBilling: {
+          label: 'Deferred payment',
+          amount: 2000,
+          deferredPaymentDate: new Date(Date.now()),
+        },
+        managementURL: 'https://atnnews.com/manage-subscription',
+        billingAgreement:
+          'You agree to pay 20 dollars some time in the future.',
+      },
+    },
+  });
+
+  resolve({
+    applePay: {
+      recurringPaymentRequest: {
+        paymentDescription: 'Subscription to ATN News',
+        regularBilling: {
+          label: 'Online & paper news',
+          amount: 2000,
+        },
+        managementURL: 'https://atnnews.com/manage-subscription',
+        // @ts-expect-error: Object literal may only specify known properties, and 'billingAgreement' does not exist in type 'Omit<ApplePayRecurringPaymentRequest, "billingAgreement">'.
+        billingAgreement: 'You agree to pay ATN News $20.00 every month.',
+      },
+    },
+  });
 });
 
 expressCheckoutElement.on('confirm', ({paymentFailed}) => {
   // @ts-expect-error Can only fail a payment for a reason of 'fail' or 'invalid-shipping-address'
   paymentFailed({reason: 'pizza-time'});
+});
+
+expressCheckoutElement.on('click', ({resolve}) => {
+  resolve({
+    applePay: {
+      recurringPaymentRequest: {
+        paymentDescription: 'Subscription to ATN News',
+        regularBilling: {
+          label: 'Online & paper news',
+          amount: 2000,
+        },
+        managementURL: 'https://atnnews.com/manage-subscription',
+        billingAgreement: 'You agree to pay ATN News $20.00 every month.',
+      },
+      // @ts-expect-error: Type '{ paymentDescription: string; deferredBilling: { label: string; amount: number; deferredPaymentDate: Date; }; managementURL: string; billingAgreement: string; }' is not assignable to type 'null | undefined'.
+      deferredPaymentRequest: {
+        paymentDescription: 'Deferred payment',
+        deferredBilling: {
+          label: 'Deferred payment',
+          amount: 2000,
+          deferredPaymentDate: new Date(Date.now()),
+        },
+        managementURL: 'https://atnnews.com/manage-subscription',
+        billingAgreement:
+          'You agree to pay 20 dollars some time in the future.',
+      },
+    },
+  });
 });
 
 // @ts-expect-error: AddressElement requires a mode

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -7,6 +7,7 @@ import {
   StripeExpressCheckoutElement,
   StripeElementsOptions,
 } from '../../../types';
+import {ApplePayUpdateOption} from '../../../types/stripe-js/elements/apple-pay';
 
 declare const stripe: Stripe;
 declare const cardElement: StripeCardElement;
@@ -136,19 +137,21 @@ expressCheckoutElement.on('shippingaddresschange', ({address, resolve}) => {
     },
   });
 
-  resolve({
-    applePay: {
-      recurringPaymentRequest: {
-        paymentDescription: 'Subscription to ATN News',
-        regularBilling: {
-          label: 'Online & paper news',
-          amount: 2000,
-        },
-        managementURL: 'https://atnnews.com/manage-subscription',
-        // @ts-expect-error: Object literal may only specify known properties, and 'billingAgreement' does not exist in type 'Omit<ApplePayRecurringPaymentRequest, "billingAgreement">'.
-        billingAgreement: 'You agree to pay ATN News $20.00 every month.',
+  const applePayUpdateOptions: ApplePayUpdateOption = {
+    recurringPaymentRequest: {
+      paymentDescription: 'Subscription to ATN News',
+      regularBilling: {
+        label: 'Online & paper news',
+        amount: 2000,
       },
+      managementURL: 'https://atnnews.com/manage-subscription',
+      // @ts-expect-error: Object literal may only specify known properties, and 'billingAgreement' does not exist in type 'Omit<ApplePayRecurringPaymentRequest, "billingAgreement">'.
+      billingAgreement: 'You agree to pay ATN News $20.00 every month.',
     },
+  };
+
+  resolve({
+    applePay: applePayUpdateOptions,
   });
 });
 
@@ -160,6 +163,7 @@ expressCheckoutElement.on('confirm', ({paymentFailed}) => {
 expressCheckoutElement.on('click', ({resolve}) => {
   resolve({
     applePay: {
+      // @ts-ignore
       recurringPaymentRequest: {
         paymentDescription: 'Subscription to ATN News',
         regularBilling: {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -405,9 +405,32 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
   },
   readOnly: true,
   paymentMethodOrder: ['card', 'sepa_debit'],
+  applePay: {
+    recurringPaymentRequest: {
+      paymentDescription: 'Subscription to ATN News',
+      regularBilling: {
+        label: 'Online & paper news',
+        amount: 2000,
+      },
+      managementURL: 'https://atnnews.com/manage-subscription',
+    },
+  },
   wallets: {
     applePay: 'never',
     googlePay: 'auto',
+  },
+});
+
+paymentElement.update({
+  applePay: {
+    recurringPaymentRequest: {
+      paymentDescription: 'Subscription to ATN News',
+      regularBilling: {
+        label: 'Online & paper news',
+        amount: 2000,
+      },
+      managementURL: 'https://atnnews.com/manage-subscription',
+    },
   },
 });
 
@@ -874,7 +897,54 @@ expressCheckoutElement
       availablePaymentMethods: undefined | AvailablePaymentMethods;
     }) => {}
   )
-  .on('click', (e: StripeExpressCheckoutElementClickEvent) => {})
+  .on('click', (e: StripeExpressCheckoutElementClickEvent) => {
+    e.resolve({
+      applePay: {
+        recurringPaymentRequest: {
+          paymentDescription: 'Subscription to ATN News',
+          regularBilling: {
+            label: 'Online & paper news',
+            amount: 2000,
+          },
+          managementURL: 'https://atnnews.com/manage-subscription',
+          billingAgreement: 'You agree to pay ATN News $20.00 every month.',
+        },
+      },
+    });
+  })
+  .on('click', (e: StripeExpressCheckoutElementClickEvent) => {
+    e.resolve({
+      applePay: {
+        deferredPaymentRequest: {
+          paymentDescription: 'Deferred payment',
+          deferredBilling: {
+            label: 'Deferred payment',
+            amount: 2000,
+            deferredPaymentDate: new Date(Date.now()),
+          },
+          managementURL: 'https://atnnews.com/manage-subscription',
+          billingAgreement:
+            'You agree to pay 20 dollars some time in the future.',
+        },
+      },
+    });
+  })
+  .on('click', (e: StripeExpressCheckoutElementClickEvent) => {
+    e.resolve({
+      applePay: {
+        automaticReloadPaymentRequest: {
+          paymentDescription: 'Automatic Reload Payment',
+          automaticReloadBilling: {
+            label: 'Online & paper news',
+            amount: 2000,
+            automaticReloadPaymentThresholdAmount: 1000,
+          },
+          managementURL: 'https://atnnews.com/manage-subscription',
+          billingAgreement: "You agree to reload your card when it's low.",
+        },
+      },
+    });
+  })
   .on('focus', (e: {elementType: 'expressCheckout'}) => {})
   .on('blur', (e: {elementType: 'expressCheckout'}) => {})
   .on('escape', (e: {elementType: 'expressCheckout'}) => {})
@@ -906,6 +976,18 @@ expressCheckoutElement.on(
     e.resolve();
     e.resolve({
       lineItems: [{name: 'Pizza', amount: 1200}],
+    });
+    e.resolve({
+      applePay: {
+        recurringPaymentRequest: {
+          paymentDescription: 'Subscription to ATN News',
+          regularBilling: {
+            label: 'Online & paper news',
+            amount: 2000,
+          },
+          managementURL: 'https://atnnews.com/manage-subscription',
+        },
+      },
     });
     e.resolve({
       shippingRates: [
@@ -952,6 +1034,18 @@ expressCheckoutElement.on(
     e.resolve();
     e.resolve({
       lineItems: [{name: 'Pizza', amount: 1200}],
+    });
+    e.resolve({
+      applePay: {
+        recurringPaymentRequest: {
+          paymentDescription: 'Subscription to ATN News',
+          regularBilling: {
+            label: 'Online & paper news',
+            amount: 2000,
+          },
+          managementURL: 'https://atnnews.com/manage-subscription',
+        },
+      },
     });
     e.resolve({
       shippingRates: [
@@ -3091,6 +3185,16 @@ const paymentRequest: PaymentRequest = stripe.paymentRequest({
   total: {label: 'Demo total', amount: 1000},
   requestPayerName: true,
   requestPayerEmail: true,
+  applePay: {
+    recurringPaymentRequest: {
+      paymentDescription: 'Subscription to ATN News',
+      regularBilling: {
+        label: 'Online & paper news',
+        amount: 2000,
+      },
+      managementURL: 'https://atnnews.com/manage-subscription',
+    },
+  },
 });
 
 paymentRequest.canMakePayment().then((result) => {
@@ -3115,6 +3219,16 @@ paymentRequest.update({
       amount: 995,
     },
   ],
+  applePay: {
+    recurringPaymentRequest: {
+      paymentDescription: 'Subscription to ATN News',
+      regularBilling: {
+        label: 'Online & paper news',
+        amount: 2000,
+      },
+      managementURL: 'https://atnnews.com/manage-subscription',
+    },
+  },
 });
 
 paymentRequest.on('paymentmethod', function(ev) {
@@ -3167,6 +3281,16 @@ paymentRequest.on('shippingaddresschange', function(ev) {
         ev.updateWith({
           status: 'success',
           shippingOptions: result.supportedShippingOptions,
+          applePay: {
+            recurringPaymentRequest: {
+              paymentDescription: 'Subscription to ATN News',
+              regularBilling: {
+                label: 'Online & paper news',
+                amount: 2000,
+              },
+              managementURL: 'https://atnnews.com/manage-subscription',
+            },
+          },
         });
       });
   }
@@ -3191,6 +3315,16 @@ paymentRequest.on(
           amount: 9.99,
         },
       ],
+      applePay: {
+        recurringPaymentRequest: {
+          paymentDescription: 'Subscription to ATN News',
+          regularBilling: {
+            label: 'Online & paper news',
+            amount: 2000,
+          },
+          managementURL: 'https://atnnews.com/manage-subscription',
+        },
+      },
     });
   }
 );

--- a/types/stripe-js/elements/apple-pay.d.ts
+++ b/types/stripe-js/elements/apple-pay.d.ts
@@ -1,0 +1,156 @@
+export type ApplePayRecurringPaymentRequestIntervalUnit =
+  | 'year'
+  | 'month'
+  | 'day'
+  | 'hour'
+  | 'minute';
+
+export interface ApplePayLineItem {
+  /**
+   * A short, localized description of the line item.
+   */
+  label: string;
+
+  /**
+   * The monetary amount displayed on the payment sheet.
+   */
+  amount: number;
+}
+
+export type ApplePayRegularBilling = ApplePayLineItem & {
+  /**
+   * The date of the first payment.
+   */
+  recurringPaymentStartDate?: Date;
+
+  /**
+   * The date of the final payment.
+   */
+  recurringPaymentEndDate?: Date;
+
+  /**
+   * The amount of time — in calendar units, such as day, month, or year — that represents a fraction of the total payment interval.
+   */
+  recurringPaymentIntervalUnit?: ApplePayRecurringPaymentRequestIntervalUnit;
+
+  /**
+   * The number of interval units that make up the total payment interval.
+   */
+  recurringPaymentIntervalCount?: number;
+};
+
+export interface ApplePayRecurringPaymentRequest {
+  /**
+   * The description of the payment that the customer will see in their Apple Pay wallet.
+   */
+  paymentDescription: string;
+
+  /**
+   * The URL to manage items related to the recurring payment on your website.
+   */
+  managementURL: string;
+  regularBilling: ApplePayRegularBilling;
+
+  /**
+   * The billing agreement label that is displayed to the customer in the Apple Pay payment sheet.
+   */
+  billingAgreement?: string;
+}
+
+export type ApplePayAutomaticReloadBilling = ApplePayLineItem & {
+  /**
+   * The balance an account reaches before the merchant applies the automatic reload amount.
+   */
+  automaticReloadPaymentThresholdAmount: number;
+};
+
+export interface ApplePayAutomaticReloadPaymentRequest {
+  /**
+   * The description of the payment that the customer will see in their Apple Pay wallet.
+   */
+  paymentDescription: string;
+
+  /**
+   * The URL to manage items related to the automatic reload payment on your website.
+   */
+  managementURL: string;
+  automaticReloadBilling: ApplePayAutomaticReloadBilling;
+
+  /**
+   * The billing agreement label that is displayed to the customer in the Apple Pay payment sheet.
+   */
+  billingAgreement?: string;
+}
+
+export type ApplePayDeferredBilling = ApplePayLineItem & {
+  /**
+   * The date, in the future, of the payment.
+   */
+  deferredPaymentDate: Date;
+};
+
+export interface ApplePayDeferredPaymentRequest {
+  /**
+   * The description of the payment that the customer will see in their Apple Pay wallet.
+   */
+  paymentDescription: string;
+
+  /**
+   * The URL to manage items related to the deferred payment on your website.
+   */
+  managementURL: string;
+  deferredBilling: ApplePayDeferredBilling;
+
+  /**
+   * The billing agreement label that is displayed to the customer in the Apple Pay payment sheet.
+   */
+  billingAgreement?: string;
+
+  /**
+   * The future date before which the customer can cancel the deferred payment for free.
+   */
+  freeCancellationDate?: Date;
+
+  /**
+   * The time zone of the free cancellation date.
+   *
+   * These are [tz](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) timezones such as `America/Los_Angeles`, `Europe/Dublin`, and `Asia/Singapore`.
+   */
+  freeCancellationDateTimeZone?: string;
+}
+
+export type ApplePayOption =
+  | {
+      recurringPaymentRequest: ApplePayRecurringPaymentRequest;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest: ApplePayDeferredPaymentRequest;
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest: ApplePayAutomaticReloadPaymentRequest;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
+    };
+
+export type ApplePayUpdateOption =
+  | {
+      recurringPaymentRequest: ApplePayRecurringPaymentRequest;
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      automaticReloadPaymentRequest: ApplePayAutomaticReloadPaymentRequest;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
+    };

--- a/types/stripe-js/elements/apple-pay.d.ts
+++ b/types/stripe-js/elements/apple-pay.d.ts
@@ -12,7 +12,7 @@ export interface ApplePayLineItem {
   label: string;
 
   /**
-   * The monetary amount displayed on the payment interface.
+   * The amount in the currency's subunit (e.g. cents, yen, etc.)
    */
   amount: number;
 }

--- a/types/stripe-js/elements/apple-pay.d.ts
+++ b/types/stripe-js/elements/apple-pay.d.ts
@@ -12,7 +12,7 @@ export interface ApplePayLineItem {
   label: string;
 
   /**
-   * The monetary amount displayed on the payment sheet.
+   * The monetary amount displayed on the payment interface.
    */
   amount: number;
 }
@@ -52,7 +52,7 @@ export interface ApplePayRecurringPaymentRequest {
   regularBilling: ApplePayRegularBilling;
 
   /**
-   * The billing agreement label that is displayed to the customer in the Apple Pay payment sheet.
+   * The billing agreement label that is displayed to the customer in the Apple Pay payment interface.
    */
   billingAgreement?: string;
 }
@@ -77,7 +77,7 @@ export interface ApplePayAutomaticReloadPaymentRequest {
   automaticReloadBilling: ApplePayAutomaticReloadBilling;
 
   /**
-   * The billing agreement label that is displayed to the customer in the Apple Pay payment sheet.
+   * The billing agreement label that is displayed to the customer in the Apple Pay payment interface.
    */
   billingAgreement?: string;
 }
@@ -102,7 +102,7 @@ export interface ApplePayDeferredPaymentRequest {
   deferredBilling: ApplePayDeferredBilling;
 
   /**
-   * The billing agreement label that is displayed to the customer in the Apple Pay payment sheet.
+   * The billing agreement label that is displayed to the customer in the Apple Pay payment interface.
    */
   billingAgreement?: string;
 
@@ -143,12 +143,18 @@ export type ApplePayOption =
 
 export type ApplePayUpdateOption =
   | {
-      recurringPaymentRequest: ApplePayRecurringPaymentRequest;
+      recurringPaymentRequest: Omit<
+        ApplePayRecurringPaymentRequest,
+        'billingAgreement'
+      >;
       automaticReloadPaymentRequest?: null;
     }
   | {
       recurringPaymentRequest?: null;
-      automaticReloadPaymentRequest: ApplePayAutomaticReloadPaymentRequest;
+      automaticReloadPaymentRequest: Omit<
+        ApplePayAutomaticReloadPaymentRequest,
+        'billingAgreement'
+      >;
     }
   | {
       recurringPaymentRequest?: null;

--- a/types/stripe-js/elements/apple-pay.d.ts
+++ b/types/stripe-js/elements/apple-pay.d.ts
@@ -143,18 +143,12 @@ export type ApplePayOption =
 
 export type ApplePayUpdateOption =
   | {
-      recurringPaymentRequest: Omit<
-        ApplePayRecurringPaymentRequest,
-        'billingAgreement'
-      >;
+      recurringPaymentRequest: ApplePayRecurringPaymentRequest;
       automaticReloadPaymentRequest?: null;
     }
   | {
       recurringPaymentRequest?: null;
-      automaticReloadPaymentRequest: Omit<
-        ApplePayAutomaticReloadPaymentRequest,
-        'billingAgreement'
-      >;
+      automaticReloadPaymentRequest: ApplePayAutomaticReloadPaymentRequest;
     }
   | {
       recurringPaymentRequest?: null;

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -370,7 +370,7 @@ export type ExpressCheckoutRecurringPaymentIntervalUnit =
   | 'minute';
 
 export type ExpressCheckoutApplePayOption = {
-  recurringPaymentRequest?: {
+  recurringPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     regularBilling: {
@@ -382,12 +382,12 @@ export type ExpressCheckoutApplePayOption = {
       recurringPaymentIntervalCount?: number;
     };
     billingAgreement?: string;
-  } | null;
+  };
   deferredPaymentRequest?: null;
   automaticReloadPaymentRequest?: null;
 } | {
   recurringPaymentRequest?: null;
-  deferredPaymentRequest?: {
+  deferredPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     deferredBilling: {
@@ -398,12 +398,12 @@ export type ExpressCheckoutApplePayOption = {
     billingAgreement?: string;
     freeCancellationDate?: Date;
     freeCancellationDateTimeZone?: string;
-  } | null;
+  };
   automaticReloadPaymentRequest?: null;
 } | {
   recurringPaymentRequest?: null;
   deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: {
+  automaticReloadPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     automaticReloadBilling: {
@@ -412,7 +412,7 @@ export type ExpressCheckoutApplePayOption = {
       automaticReloadPaymentThresholdAmount: number;
     };
     billingAgreement?: string;
-  } | null;
+  };
 } | {
   recurringPaymentRequest?: null;
   deferredPaymentRequest?: null;

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -383,6 +383,10 @@ export type ExpressCheckoutApplePayOption = {
     };
     billingAgreement?: string;
   } | null;
+  deferredPaymentRequest?: null;
+  automaticReloadPaymentRequest?: null;
+} | {
+  recurringPaymentRequest?: null;
   deferredPaymentRequest?: {
     paymentDescription: string;
     managementURL: string;
@@ -395,6 +399,10 @@ export type ExpressCheckoutApplePayOption = {
     freeCancellationDate?: Date;
     freeCancellationDateTimeZone?: string;
   } | null;
+  automaticReloadPaymentRequest?: null;
+} | {
+  recurringPaymentRequest?: null;
+  deferredPaymentRequest?: null;
   automaticReloadPaymentRequest?: {
     paymentDescription: string;
     managementURL: string;

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -362,14 +362,14 @@ export interface StripeExpressCheckoutElementReadyEvent {
   availablePaymentMethods: undefined | AvailablePaymentMethods;
 }
 
-export type RecurringPaymentIntervalUnit =
+export type ExpressCheckoutRecurringPaymentIntervalUnit =
   | 'year'
   | 'month'
   | 'day'
   | 'hour'
   | 'minute';
 
-export type ApplePayOption = {
+export type ExpressCheckoutApplePayOption = {
   recurringPaymentRequest?: {
     paymentDescription: string;
     managementURL: string;
@@ -378,11 +378,33 @@ export type ApplePayOption = {
       label: string;
       recurringPaymentStartDate?: Date;
       recurringPaymentEndDate?: Date;
-      recurringPaymentIntervalUnit?: RecurringPaymentIntervalUnit;
+      recurringPaymentIntervalUnit?: ExpressCheckoutRecurringPaymentIntervalUnit;
       recurringPaymentIntervalCount?: number;
     };
     billingAgreement?: string;
-  };
+  } | null;
+  deferredPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    deferredBilling: {
+      amount: number;
+      label: string;
+      deferredPaymentDate: Date;
+    };
+    billingAgreement?: string;
+    freeCancellationDate?: Date;
+    freeCancellationDateTimeZone?: string;
+  } | null;
+  automaticReloadPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    automaticReloadBilling: {
+      amount: number;
+      label: string;
+      automaticReloadPaymentThresholdAmount: number;
+    };
+    billingAgreement?: string;
+  } | null;
 };
 
 export type ClickResolveDetails = {
@@ -410,7 +432,7 @@ export type ClickResolveDetails = {
 
   shippingRates?: Array<ShippingRate>;
 
-  applePay?: ApplePayOption;
+  applePay?: ExpressCheckoutApplePayOption;
 };
 
 export interface StripeExpressCheckoutElementClickEvent {
@@ -451,6 +473,7 @@ export interface StripeExpressCheckoutElementConfirmEvent {
 export type ChangeResolveDetails = {
   lineItems?: Array<LineItem>;
   shippingRates?: Array<ShippingRate>;
+  applePay?: ExpressCheckoutApplePayOption;
 };
 
 export interface StripeExpressCheckoutElementShippingAddressChangeEvent {

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -369,55 +369,59 @@ export type ExpressCheckoutRecurringPaymentIntervalUnit =
   | 'hour'
   | 'minute';
 
-export type ExpressCheckoutApplePayOption = {
-  recurringPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    regularBilling: {
-      amount: number;
-      label: string;
-      recurringPaymentStartDate?: Date;
-      recurringPaymentEndDate?: Date;
-      recurringPaymentIntervalUnit?: ExpressCheckoutRecurringPaymentIntervalUnit;
-      recurringPaymentIntervalCount?: number;
+export type ExpressCheckoutApplePayOption =
+  | {
+      recurringPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        regularBilling: {
+          amount: number;
+          label: string;
+          recurringPaymentStartDate?: Date;
+          recurringPaymentEndDate?: Date;
+          recurringPaymentIntervalUnit?: ExpressCheckoutRecurringPaymentIntervalUnit;
+          recurringPaymentIntervalCount?: number;
+        };
+        billingAgreement?: string;
+      };
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        deferredBilling: {
+          amount: number;
+          label: string;
+          deferredPaymentDate: Date;
+        };
+        billingAgreement?: string;
+        freeCancellationDate?: Date;
+        freeCancellationDateTimeZone?: string;
+      };
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        automaticReloadBilling: {
+          amount: number;
+          label: string;
+          automaticReloadPaymentThresholdAmount: number;
+        };
+        billingAgreement?: string;
+      };
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
     };
-    billingAgreement?: string;
-  };
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: null;
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    deferredBilling: {
-      amount: number;
-      label: string;
-      deferredPaymentDate: Date;
-    };
-    billingAgreement?: string;
-    freeCancellationDate?: Date;
-    freeCancellationDateTimeZone?: string;
-  };
-  automaticReloadPaymentRequest?: null;
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    automaticReloadBilling: {
-      amount: number;
-      label: string;
-      automaticReloadPaymentThresholdAmount: number;
-    };
-    billingAgreement?: string;
-  };
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: null;
-};
 
 export type ClickResolveDetails = {
   /**

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -1,5 +1,6 @@
 import {StripeElementBase} from './base';
 import {StripeError} from '../stripe';
+import {ApplePayOption, ApplePayUpdateOption} from './apple-pay';
 
 export type StripeExpressCheckoutElement = StripeElementBase & {
   /**
@@ -362,67 +363,6 @@ export interface StripeExpressCheckoutElementReadyEvent {
   availablePaymentMethods: undefined | AvailablePaymentMethods;
 }
 
-export type ExpressCheckoutRecurringPaymentIntervalUnit =
-  | 'year'
-  | 'month'
-  | 'day'
-  | 'hour'
-  | 'minute';
-
-export type ExpressCheckoutApplePayOption =
-  | {
-      recurringPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        regularBilling: {
-          amount: number;
-          label: string;
-          recurringPaymentStartDate?: Date;
-          recurringPaymentEndDate?: Date;
-          recurringPaymentIntervalUnit?: ExpressCheckoutRecurringPaymentIntervalUnit;
-          recurringPaymentIntervalCount?: number;
-        };
-        billingAgreement?: string;
-      };
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest?: null;
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        deferredBilling: {
-          amount: number;
-          label: string;
-          deferredPaymentDate: Date;
-        };
-        billingAgreement?: string;
-        freeCancellationDate?: Date;
-        freeCancellationDateTimeZone?: string;
-      };
-      automaticReloadPaymentRequest?: null;
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        automaticReloadBilling: {
-          amount: number;
-          label: string;
-          automaticReloadPaymentThresholdAmount: number;
-        };
-        billingAgreement?: string;
-      };
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest?: null;
-    };
-
 export type ClickResolveDetails = {
   /**
    * An array of two-letter ISO country codes representing which countries
@@ -448,7 +388,7 @@ export type ClickResolveDetails = {
 
   shippingRates?: Array<ShippingRate>;
 
-  applePay?: ExpressCheckoutApplePayOption;
+  applePay?: ApplePayOption;
 };
 
 export interface StripeExpressCheckoutElementClickEvent {
@@ -489,7 +429,7 @@ export interface StripeExpressCheckoutElementConfirmEvent {
 export type ChangeResolveDetails = {
   lineItems?: Array<LineItem>;
   shippingRates?: Array<ShippingRate>;
-  applePay?: ExpressCheckoutApplePayOption;
+  applePay?: ApplePayUpdateOption;
 };
 
 export interface StripeExpressCheckoutElementShippingAddressChangeEvent {

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -413,6 +413,10 @@ export type ExpressCheckoutApplePayOption = {
     };
     billingAgreement?: string;
   } | null;
+} | {
+  recurringPaymentRequest?: null;
+  deferredPaymentRequest?: null;
+  automaticReloadPaymentRequest?: null;
 };
 
 export type ClickResolveDetails = {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -1,5 +1,6 @@
 import {StripeElementBase} from './base';
 import {StripeError} from '../stripe';
+import {ApplePayOption} from './apple-pay';
 
 export type StripePaymentElement = StripeElementBase & {
   /**
@@ -196,67 +197,6 @@ export interface LayoutObject {
   spacedAccordionItems?: boolean;
 }
 
-export type PaymentRecurringPaymentIntervalUnit =
-  | 'year'
-  | 'month'
-  | 'day'
-  | 'hour'
-  | 'minute';
-
-export type PaymentApplePayOption =
-  | {
-      recurringPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        regularBilling: {
-          amount: number;
-          label: string;
-          recurringPaymentStartDate?: Date;
-          recurringPaymentEndDate?: Date;
-          recurringPaymentIntervalUnit?: PaymentRecurringPaymentIntervalUnit;
-          recurringPaymentIntervalCount?: number;
-        };
-        billingAgreement?: string;
-      };
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest?: null;
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        deferredBilling: {
-          amount: number;
-          label: string;
-          deferredPaymentDate: Date;
-        };
-        billingAgreement?: string;
-        freeCancellationDate?: Date;
-        freeCancellationDateTimeZone?: string;
-      };
-      automaticReloadPaymentRequest?: null;
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        automaticReloadBilling: {
-          amount: number;
-          label: string;
-          automaticReloadPaymentThresholdAmount: number;
-        };
-        billingAgreement?: string;
-      };
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest?: null;
-    };
-
 export interface StripePaymentElementOptions {
   /**
    * Provide initial customer information that will be displayed in the Payment Element.
@@ -304,7 +244,7 @@ export interface StripePaymentElementOptions {
   /**
    * Specify the options to be used when the Apple Pay payment sheet opens.
    */
-  applePay?: PaymentApplePayOption;
+  applePay?: ApplePayOption;
 }
 
 export interface StripePaymentElementChangeEvent {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -247,6 +247,10 @@ export type PaymentApplePayOption = {
     };
     billingAgreement?: string;
   } | null;
+} | {
+  recurringPaymentRequest?: null;
+  deferredPaymentRequest?: null;
+  automaticReloadPaymentRequest?: null;
 };
 
 export interface StripePaymentElementOptions {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -217,6 +217,10 @@ export type PaymentApplePayOption = {
     };
     billingAgreement?: string;
   } | null;
+  deferredPaymentRequest?: null;
+  automaticReloadPaymentRequest?: null;
+} | {
+  recurringPaymentRequest?: null;
   deferredPaymentRequest?: {
     paymentDescription: string;
     managementURL: string;
@@ -229,6 +233,10 @@ export type PaymentApplePayOption = {
     freeCancellationDate?: Date;
     freeCancellationDateTimeZone?: string;
   } | null;
+  automaticReloadPaymentRequest?: null;
+} | {
+  recurringPaymentRequest?: null;
+  deferredPaymentRequest?: null;
   automaticReloadPaymentRequest?: {
     paymentDescription: string;
     managementURL: string;

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -196,6 +196,51 @@ export interface LayoutObject {
   spacedAccordionItems?: boolean;
 }
 
+export type PaymentRecurringPaymentIntervalUnit =
+  | 'year'
+  | 'month'
+  | 'day'
+  | 'hour'
+  | 'minute';
+
+export type PaymentApplePayOption = {
+  recurringPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    regularBilling: {
+      amount: number;
+      label: string;
+      recurringPaymentStartDate?: Date;
+      recurringPaymentEndDate?: Date;
+      recurringPaymentIntervalUnit?: PaymentRecurringPaymentIntervalUnit;
+      recurringPaymentIntervalCount?: number;
+    };
+    billingAgreement?: string;
+  } | null;
+  deferredPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    deferredBilling: {
+      amount: number;
+      label: string;
+      deferredPaymentDate: Date;
+    };
+    billingAgreement?: string;
+    freeCancellationDate?: Date;
+    freeCancellationDateTimeZone?: string;
+  } | null;
+  automaticReloadPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    automaticReloadBilling: {
+      amount: number;
+      label: string;
+      automaticReloadPaymentThresholdAmount: number;
+    };
+    billingAgreement?: string;
+  } | null;
+};
+
 export interface StripePaymentElementOptions {
   /**
    * Provide initial customer information that will be displayed in the Payment Element.
@@ -239,6 +284,11 @@ export interface StripePaymentElementOptions {
    * Specify a layout to use when rendering a Payment Element.
    */
   layout?: Layout | LayoutObject;
+
+  /**
+   * Specify the options to be used when the Apple Pay payment sheet opens.
+   */
+  applePay?: PaymentApplePayOption;
 }
 
 export interface StripePaymentElementChangeEvent {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -203,55 +203,59 @@ export type PaymentRecurringPaymentIntervalUnit =
   | 'hour'
   | 'minute';
 
-export type PaymentApplePayOption = {
-  recurringPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    regularBilling: {
-      amount: number;
-      label: string;
-      recurringPaymentStartDate?: Date;
-      recurringPaymentEndDate?: Date;
-      recurringPaymentIntervalUnit?: PaymentRecurringPaymentIntervalUnit;
-      recurringPaymentIntervalCount?: number;
+export type PaymentApplePayOption =
+  | {
+      recurringPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        regularBilling: {
+          amount: number;
+          label: string;
+          recurringPaymentStartDate?: Date;
+          recurringPaymentEndDate?: Date;
+          recurringPaymentIntervalUnit?: PaymentRecurringPaymentIntervalUnit;
+          recurringPaymentIntervalCount?: number;
+        };
+        billingAgreement?: string;
+      };
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        deferredBilling: {
+          amount: number;
+          label: string;
+          deferredPaymentDate: Date;
+        };
+        billingAgreement?: string;
+        freeCancellationDate?: Date;
+        freeCancellationDateTimeZone?: string;
+      };
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        automaticReloadBilling: {
+          amount: number;
+          label: string;
+          automaticReloadPaymentThresholdAmount: number;
+        };
+        billingAgreement?: string;
+      };
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
     };
-    billingAgreement?: string;
-  };
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: null;
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    deferredBilling: {
-      amount: number;
-      label: string;
-      deferredPaymentDate: Date;
-    };
-    billingAgreement?: string;
-    freeCancellationDate?: Date;
-    freeCancellationDateTimeZone?: string;
-  };
-  automaticReloadPaymentRequest?: null;
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    automaticReloadBilling: {
-      amount: number;
-      label: string;
-      automaticReloadPaymentThresholdAmount: number;
-    };
-    billingAgreement?: string;
-  };
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: null;
-};
 
 export interface StripePaymentElementOptions {
   /**

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -204,7 +204,7 @@ export type PaymentRecurringPaymentIntervalUnit =
   | 'minute';
 
 export type PaymentApplePayOption = {
-  recurringPaymentRequest?: {
+  recurringPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     regularBilling: {
@@ -216,12 +216,12 @@ export type PaymentApplePayOption = {
       recurringPaymentIntervalCount?: number;
     };
     billingAgreement?: string;
-  } | null;
+  };
   deferredPaymentRequest?: null;
   automaticReloadPaymentRequest?: null;
 } | {
   recurringPaymentRequest?: null;
-  deferredPaymentRequest?: {
+  deferredPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     deferredBilling: {
@@ -232,12 +232,12 @@ export type PaymentApplePayOption = {
     billingAgreement?: string;
     freeCancellationDate?: Date;
     freeCancellationDateTimeZone?: string;
-  } | null;
+  };
   automaticReloadPaymentRequest?: null;
 } | {
   recurringPaymentRequest?: null;
   deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: {
+  automaticReloadPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     automaticReloadBilling: {
@@ -246,7 +246,7 @@ export type PaymentApplePayOption = {
       automaticReloadPaymentThresholdAmount: number;
     };
     billingAgreement?: string;
-  } | null;
+  };
 } | {
   recurringPaymentRequest?: null;
   deferredPaymentRequest?: null;

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -242,7 +242,7 @@ export interface StripePaymentElementOptions {
   layout?: Layout | LayoutObject;
 
   /**
-   * Specify the options to be used when the Apple Pay payment sheet opens.
+   * Specify the options to be used when the Apple Pay payment interface opens.
    */
   applePay?: ApplePayOption;
 }

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -157,7 +157,7 @@ export interface PaymentRequestUpdateOptions {
   shippingOptions?: PaymentRequestShippingOption[];
 
   /**
-   * Specify the options to be used when the Apple Pay payment sheet opens.
+   * Specify the options to be used when the Apple Pay payment interface opens.
    */
   applePay?: ApplePayOption;
 }
@@ -233,7 +233,7 @@ export interface PaymentRequestOptions {
   disableWallets?: PaymentRequestWallet[];
 
   /**
-   * Specify the options to be used when the Apple Pay payment sheet opens.
+   * Specify the options to be used when the Apple Pay payment interface opens.
    */
   applePay?: ApplePayOption;
 
@@ -510,7 +510,7 @@ export interface PaymentRequestUpdateDetails {
   shippingOptions?: PaymentRequestShippingOption[];
 
   /**
-   * Specify new options to refresh the Apple Pay payment sheet.
+   * Specify new options to refresh the Apple Pay payment interface.
    */
   applePay?: ApplePayUpdateOption;
 }

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -154,6 +154,11 @@ export interface PaymentRequestUpdateOptions {
    */
 
   shippingOptions?: PaymentRequestShippingOption[];
+
+  /**
+   * Specify the options to be used when the Apple Pay payment sheet opens.
+   */
+  applePay?: PaymentRequestApplePayOption;
 }
 
 /**
@@ -227,6 +232,11 @@ export interface PaymentRequestOptions {
   disableWallets?: PaymentRequestWallet[];
 
   /**
+   * Specify the options to be used when the Apple Pay payment sheet opens.
+   */
+  applePay?: PaymentRequestApplePayOption;
+
+  /**
    * @deprecated
    * Use disableWallets instead.
    */
@@ -286,6 +296,51 @@ export type PaymentRequestWallet =
   | 'googlePay'
   | 'link'
   | 'browserCard';
+
+export type PaymentRequestRecurringPaymentIntervalUnit =
+  | 'year'
+  | 'month'
+  | 'day'
+  | 'hour'
+  | 'minute';
+
+export type PaymentRequestApplePayOption = {
+  recurringPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    regularBilling: {
+      amount: number;
+      label: string;
+      recurringPaymentStartDate?: Date;
+      recurringPaymentEndDate?: Date;
+      recurringPaymentIntervalUnit?: PaymentRequestRecurringPaymentIntervalUnit;
+      recurringPaymentIntervalCount?: number;
+    };
+    billingAgreement?: string;
+  } | null;
+  deferredPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    deferredBilling: {
+      amount: number;
+      label: string;
+      deferredPaymentDate: Date;
+    };
+    billingAgreement?: string;
+    freeCancellationDate?: Date;
+    freeCancellationDateTimeZone?: string;
+  } | null;
+  automaticReloadPaymentRequest?: {
+    paymentDescription: string;
+    managementURL: string;
+    automaticReloadBilling: {
+      amount: number;
+      label: string;
+      automaticReloadPaymentThresholdAmount: number;
+    };
+    billingAgreement?: string;
+  } | null;
+};
 
 export type PaymentRequestCompleteStatus =
   /**
@@ -497,6 +552,11 @@ export interface PaymentRequestUpdateDetails {
    * The first shipping option listed appears in the browser payment interface as the default option.
    */
   shippingOptions?: PaymentRequestShippingOption[];
+
+  /**
+   * Specify new options to refresh the Apple Pay payment sheet.
+   */
+  applePay?: PaymentRequestApplePayOption;
 }
 
 export interface PaymentRequestShippingOptionEvent {

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -304,55 +304,59 @@ export type PaymentRequestRecurringPaymentIntervalUnit =
   | 'hour'
   | 'minute';
 
-export type PaymentRequestApplePayOption = {
-  recurringPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    regularBilling: {
-      amount: number;
-      label: string;
-      recurringPaymentStartDate?: Date;
-      recurringPaymentEndDate?: Date;
-      recurringPaymentIntervalUnit?: PaymentRequestRecurringPaymentIntervalUnit;
-      recurringPaymentIntervalCount?: number;
+export type PaymentRequestApplePayOption =
+  | {
+      recurringPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        regularBilling: {
+          amount: number;
+          label: string;
+          recurringPaymentStartDate?: Date;
+          recurringPaymentEndDate?: Date;
+          recurringPaymentIntervalUnit?: PaymentRequestRecurringPaymentIntervalUnit;
+          recurringPaymentIntervalCount?: number;
+        };
+        billingAgreement?: string;
+      };
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        deferredBilling: {
+          amount: number;
+          label: string;
+          deferredPaymentDate: Date;
+        };
+        billingAgreement?: string;
+        freeCancellationDate?: Date;
+        freeCancellationDateTimeZone?: string;
+      };
+      automaticReloadPaymentRequest?: null;
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest: {
+        paymentDescription: string;
+        managementURL: string;
+        automaticReloadBilling: {
+          amount: number;
+          label: string;
+          automaticReloadPaymentThresholdAmount: number;
+        };
+        billingAgreement?: string;
+      };
+    }
+  | {
+      recurringPaymentRequest?: null;
+      deferredPaymentRequest?: null;
+      automaticReloadPaymentRequest?: null;
     };
-    billingAgreement?: string;
-  };
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: null;
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    deferredBilling: {
-      amount: number;
-      label: string;
-      deferredPaymentDate: Date;
-    };
-    billingAgreement?: string;
-    freeCancellationDate?: Date;
-    freeCancellationDateTimeZone?: string;
-  };
-  automaticReloadPaymentRequest?: null;
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest: {
-    paymentDescription: string;
-    managementURL: string;
-    automaticReloadBilling: {
-      amount: number;
-      label: string;
-      automaticReloadPaymentThresholdAmount: number;
-    };
-    billingAgreement?: string;
-  };
-} | {
-  recurringPaymentRequest?: null;
-  deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: null;
-};
 
 export type PaymentRequestCompleteStatus =
   /**

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -305,7 +305,7 @@ export type PaymentRequestRecurringPaymentIntervalUnit =
   | 'minute';
 
 export type PaymentRequestApplePayOption = {
-  recurringPaymentRequest?: {
+  recurringPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     regularBilling: {
@@ -317,12 +317,12 @@ export type PaymentRequestApplePayOption = {
       recurringPaymentIntervalCount?: number;
     };
     billingAgreement?: string;
-  } | null;
+  };
   deferredPaymentRequest?: null;
   automaticReloadPaymentRequest?: null;
 } | {
   recurringPaymentRequest?: null;
-  deferredPaymentRequest?: {
+  deferredPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     deferredBilling: {
@@ -333,12 +333,12 @@ export type PaymentRequestApplePayOption = {
     billingAgreement?: string;
     freeCancellationDate?: Date;
     freeCancellationDateTimeZone?: string;
-  } | null;
+  };
   automaticReloadPaymentRequest?: null;
 } | {
   recurringPaymentRequest?: null;
   deferredPaymentRequest?: null;
-  automaticReloadPaymentRequest?: {
+  automaticReloadPaymentRequest: {
     paymentDescription: string;
     managementURL: string;
     automaticReloadBilling: {
@@ -347,7 +347,7 @@ export type PaymentRequestApplePayOption = {
       automaticReloadPaymentThresholdAmount: number;
     };
     billingAgreement?: string;
-  } | null;
+  };
 } | {
   recurringPaymentRequest?: null;
   deferredPaymentRequest?: null;

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -1,4 +1,5 @@
 import {Token, PaymentMethod, Source} from '../api';
+import {ApplePayOption, ApplePayUpdateOption} from './elements/apple-pay';
 
 export interface PaymentRequest {
   /**
@@ -158,7 +159,7 @@ export interface PaymentRequestUpdateOptions {
   /**
    * Specify the options to be used when the Apple Pay payment sheet opens.
    */
-  applePay?: PaymentRequestApplePayOption;
+  applePay?: ApplePayOption;
 }
 
 /**
@@ -234,7 +235,7 @@ export interface PaymentRequestOptions {
   /**
    * Specify the options to be used when the Apple Pay payment sheet opens.
    */
-  applePay?: PaymentRequestApplePayOption;
+  applePay?: ApplePayOption;
 
   /**
    * @deprecated
@@ -296,67 +297,6 @@ export type PaymentRequestWallet =
   | 'googlePay'
   | 'link'
   | 'browserCard';
-
-export type PaymentRequestRecurringPaymentIntervalUnit =
-  | 'year'
-  | 'month'
-  | 'day'
-  | 'hour'
-  | 'minute';
-
-export type PaymentRequestApplePayOption =
-  | {
-      recurringPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        regularBilling: {
-          amount: number;
-          label: string;
-          recurringPaymentStartDate?: Date;
-          recurringPaymentEndDate?: Date;
-          recurringPaymentIntervalUnit?: PaymentRequestRecurringPaymentIntervalUnit;
-          recurringPaymentIntervalCount?: number;
-        };
-        billingAgreement?: string;
-      };
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest?: null;
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        deferredBilling: {
-          amount: number;
-          label: string;
-          deferredPaymentDate: Date;
-        };
-        billingAgreement?: string;
-        freeCancellationDate?: Date;
-        freeCancellationDateTimeZone?: string;
-      };
-      automaticReloadPaymentRequest?: null;
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest: {
-        paymentDescription: string;
-        managementURL: string;
-        automaticReloadBilling: {
-          amount: number;
-          label: string;
-          automaticReloadPaymentThresholdAmount: number;
-        };
-        billingAgreement?: string;
-      };
-    }
-  | {
-      recurringPaymentRequest?: null;
-      deferredPaymentRequest?: null;
-      automaticReloadPaymentRequest?: null;
-    };
 
 export type PaymentRequestCompleteStatus =
   /**
@@ -572,7 +512,7 @@ export interface PaymentRequestUpdateDetails {
   /**
    * Specify new options to refresh the Apple Pay payment sheet.
    */
-  applePay?: PaymentRequestApplePayOption;
+  applePay?: ApplePayUpdateOption;
 }
 
 export interface PaymentRequestShippingOptionEvent {

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -348,6 +348,10 @@ export type PaymentRequestApplePayOption = {
     };
     billingAgreement?: string;
   } | null;
+} | {
+  recurringPaymentRequest?: null;
+  deferredPaymentRequest?: null;
+  automaticReloadPaymentRequest?: null;
 };
 
 export type PaymentRequestCompleteStatus =

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -318,6 +318,10 @@ export type PaymentRequestApplePayOption = {
     };
     billingAgreement?: string;
   } | null;
+  deferredPaymentRequest?: null;
+  automaticReloadPaymentRequest?: null;
+} | {
+  recurringPaymentRequest?: null;
   deferredPaymentRequest?: {
     paymentDescription: string;
     managementURL: string;
@@ -330,6 +334,10 @@ export type PaymentRequestApplePayOption = {
     freeCancellationDate?: Date;
     freeCancellationDateTimeZone?: string;
   } | null;
+  automaticReloadPaymentRequest?: null;
+} | {
+  recurringPaymentRequest?: null;
+  deferredPaymentRequest?: null;
   automaticReloadPaymentRequest?: {
     paymentDescription: string;
     managementURL: string;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds types for MPAN type payments on Apple Pay. This includes recurringPaymentRequests, deferredPaymentRequests, and automaticReloadPaymentRequests.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

These are the types we use internally.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
