### PR TITLE
Remove payment_method_creation from types

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -15,8 +15,13 @@ declare const paymentElement: StripePaymentElement;
 declare const cartElement: StripeCartElement;
 declare const expressCheckoutElement: StripeExpressCheckoutElement;
 
-// @ts-expect-error: Passing `clientSecret` or `mode` implies different integration paths which cannot be combined
-const options: StripeElementsOptions = {clientSecret: '', mode: ''};
+
+const options: StripeElementsOptions = {
+  clientSecret: '',
+  // @ts-expect-error Type 'string' is not assignable to type '"payment" | "setup" | "subscription" | undefined'.ts(2322)
+  mode: '',
+  payment_method_creation: 'manual',
+};
 
 // @ts-expect-error: Passing `clientSecret` or `mode` implies different integration paths which cannot be combined
 const elements = stripe.elements(options);

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -15,7 +15,6 @@ declare const paymentElement: StripePaymentElement;
 declare const cartElement: StripeCartElement;
 declare const expressCheckoutElement: StripeExpressCheckoutElement;
 
-
 const options: StripeElementsOptions = {
   clientSecret: '',
   // @ts-expect-error Type 'string' is not assignable to type '"payment" | "setup" | "subscription" | undefined'.ts(2322)

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -121,7 +121,6 @@ stripe.elements({
   setup_future_usage: 'off_session',
   capture_method: 'automatic',
   payment_method_types: ['card'],
-  payment_method_creation: 'manual',
   payment_method_options: {
     us_bank_account: {financial_connections: {permissions: ['payment_method']}},
   },

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -779,11 +779,6 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
   paymentMethodCreation?: 'manual';
 
   /**
-   * Allows PaymentMethods to be created from the Elements instance.
-   */
-  payment_method_creation?: 'manual';
-
-  /**
    * Additional payment-method-specific options for configuring Payment Element behavior.
    *
    * @docs https://stripe.com/docs/js/elements_object/create_without_intent#stripe_elements_no_intent-options-paymentMethodOptions


### PR DESCRIPTION
### Summary & motivation

Underscore aliasing is used for properties that exist on payment intents. `payment_method_creation` does not exist on payment intents.

This change is safe to make as our backend already prevent payment_method_creation from being used. It also does not impact the docs as we do not list `payment_method_creation` as an [option](https://stripe.com/docs/js/elements_object/create_without_intent#stripe_elements_no_intent-options-paymentMethodCreation).

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Added tests
