### PR TITLE
Users reports stripePromise is only instantiated once and cannot be re-instantiated on reload

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -171,6 +171,38 @@ describe('Stripe module loader', () => {
 
       return expect(stripePromise).resolves.toEqual({key: 'pk_test_foo'});
     });
+
+    it('rejects on first load and second load but succeeds on third load resolving with Stripe object', async () => {
+      const {loadStripe} = require(requirePath);
+      let stripePromise = loadStripe('pk_test_foo');
+
+      await Promise.resolve();
+      dispatchScriptEvent('error');
+
+      await expect(stripePromise).rejects.toEqual(
+        new Error('Failed to load Stripe.js')
+      );
+
+      expect(console.warn).not.toHaveBeenCalled();
+
+      stripePromise = loadStripe('pk_test_foo');
+
+      await Promise.resolve();
+      dispatchScriptEvent('error');
+
+      await expect(stripePromise).rejects.toEqual(
+        new Error('Failed to load Stripe.js')
+      );
+
+      expect(console.warn).not.toHaveBeenCalled();
+      stripePromise = loadStripe('pk_test_foo');
+
+      await new Promise((resolve) => setTimeout(resolve));
+      window.Stripe = jest.fn((key) => ({key})) as any;
+      dispatchScriptEvent('load');
+
+      return expect(stripePromise).resolves.toEqual({key: 'pk_test_foo'});
+    });
   });
 
   describe('loadStripe (index.ts)', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -153,6 +153,8 @@ describe('Stripe module loader', () => {
 
     it('rejects on first load, and succeeds on second load resolving with Stripe object', async () => {
       const {loadStripe} = require(requirePath);
+
+      // start of first load, expect load failure
       let stripePromise = loadStripe('pk_test_foo');
 
       await Promise.resolve();
@@ -163,6 +165,8 @@ describe('Stripe module loader', () => {
       );
 
       expect(console.warn).not.toHaveBeenCalled();
+
+      // start of second load, expect successful load
       stripePromise = loadStripe('pk_test_foo');
 
       await new Promise((resolve) => setTimeout(resolve));
@@ -174,6 +178,8 @@ describe('Stripe module loader', () => {
 
     it('rejects on first load and second load but succeeds on third load resolving with Stripe object', async () => {
       const {loadStripe} = require(requirePath);
+
+      // start of first load, expect load failure
       let stripePromise = loadStripe('pk_test_foo');
 
       await Promise.resolve();
@@ -185,6 +191,7 @@ describe('Stripe module loader', () => {
 
       expect(console.warn).not.toHaveBeenCalled();
 
+      // start of second load, expect load failure
       stripePromise = loadStripe('pk_test_foo');
 
       await Promise.resolve();
@@ -195,6 +202,8 @@ describe('Stripe module loader', () => {
       );
 
       expect(console.warn).not.toHaveBeenCalled();
+
+      // start of third load, expect success
       stripePromise = loadStripe('pk_test_foo');
 
       await new Promise((resolve) => setTimeout(resolve));

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,16 @@ import {loadScript, initStripe, LoadStripe} from './shared';
 
 // Execute our own script injection after a tick to give users time to do their
 // own script injection.
-const stripePromise = Promise.resolve().then(() => loadScript(null));
+let stripePromise = Promise.resolve().then(() => loadScript(null));
 
 let loadCalled = false;
 
 stripePromise.catch((err: Error) => {
   if (!loadCalled) {
     console.warn(err);
+  } else {
+    // when load fails, we re-run loadScript
+    stripePromise = Promise.resolve().then(() => loadScript(null));
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,12 @@ const getStripePromise: () => Promise<StripeConstructor | null> = () => {
     return stripePromise;
   }
 
-  stripePromise = loadScript(null);
-
-  // clear cache on error
-  return stripePromise.catch((error) => {
+  stripePromise = loadScript(null).catch((error) => {
+    // clear cache on error
     stripePromise = null;
     return Promise.reject(error);
   });
+  return stripePromise;
 };
 
 // Execute our own script injection after a tick to give users time to do their

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const getStripePromise: () => Promise<StripeConstructor | null> = () => {
 
   stripePromise = loadScript(null);
 
-  // clear cache on error 
+  // clear cache on error
   return stripePromise.catch((error) => {
     stripePromise = null;
     return Promise.reject(error);


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Related to issue linked [here](https://github.com/stripe/stripe-js/pull/518#issuecomment-1852619757). 
Users report that after fixing stripePromise caching errors, the issue is still persisted when users load Stripe from `index.ts` instead of `pure.ts`. Since `stripePromise` is only set once, I've changed it so when load has been called and it errors, we clear `stripePromise = null` and `loadStripe` now has the ability to re-call `loadScript` on subsequent calls through `getStripePromise`

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

I wrote a unit test which covers use case for both `index.ts` and `pure.ts` to prevent regressions. 

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
