### PR TITLE
Add ExternalPaymentMethod option to Elements.create()

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -802,14 +802,14 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
    *
    * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
    */
-  externalPaymentMethodTypes?: string;
+  externalPaymentMethodTypes?: string[];
 
   /**
    * The external payment methods to be displayed in the Payment Element that you are already integrated with.
    *
    * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
    */
-  external_payment_method_types?: string;
+  external_payment_method_types?: string[];
 }
 
 export type StripeElementsOptions =

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -796,6 +796,20 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
    * Either use mode or clientSecret when creating an Elements group
    */
   clientSecret?: never;
+
+  /**
+   * The external payment methods to be displayed in the Payment Element that you are already integrated with.
+   * 
+   * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
+   */
+  externalPaymentMethodTypes? : string;
+
+  /**
+   * The external payment methods to be displayed in the Payment Element that you are already integrated with.
+   * 
+   * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
+   */
+  external_payment_method_types? : string;
 }
 
 export type StripeElementsOptions =

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -803,13 +803,6 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
    * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
    */
   externalPaymentMethodTypes?: string[];
-
-  /**
-   * The external payment methods to be displayed in the Payment Element that you are already integrated with.
-   *
-   * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
-   */
-  external_payment_method_types?: string[];
 }
 
 export type StripeElementsOptions =

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -799,17 +799,17 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
 
   /**
    * The external payment methods to be displayed in the Payment Element that you are already integrated with.
-   * 
+   *
    * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
    */
-  externalPaymentMethodTypes? : string;
+  externalPaymentMethodTypes?: string;
 
   /**
    * The external payment methods to be displayed in the Payment Element that you are already integrated with.
-   * 
+   *
    * @docs https://stripe.com/docs/js/elements_object/create#stripe_elements-options-externalPaymentMethodTypes
    */
-  external_payment_method_types? : string;
+  external_payment_method_types?: string;
 }
 
 export type StripeElementsOptions =

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -1394,6 +1394,11 @@ export type StripeErrorType =
   | 'card_error'
 
   /**
+   * Generic error. See the code of this error for more details.
+   */
+  | 'error'
+
+  /**
    * Idempotency errors occur when an `Idempotency-Key` is re-used on a request that does not match the first request's API endpoint and parameters.
    */
   | 'idempotency_error'

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -1394,11 +1394,6 @@ export type StripeErrorType =
   | 'card_error'
 
   /**
-   * Generic error. See the code of this error for more details.
-   */
-  | 'error'
-
-  /**
    * Idempotency errors occur when an `Idempotency-Key` is re-used on a request that does not match the first request's API endpoint and parameters.
    */
   | 'idempotency_error'


### PR DESCRIPTION
### Summary & motivation

External Payment Methods allows your team to show payment methods on the Stripe payment element for which you already have an integration. Learn more at https://stripe.com/docs/payments/external-payment-methods

### Testing & documentation

Already have documentation about the option here: https://stripe.com/docs/payments/external-payment-methods