### PR TITLE
Add `preferredNetwork` option

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -1,6 +1,7 @@
 import {
   Stripe,
   StripeCardElement,
+  StripeCardNumberElement,
   StripeIbanElement,
   StripePaymentElement,
   StripeCartElement,
@@ -11,6 +12,7 @@ import {ApplePayUpdateOption} from '../../../types/stripe-js/elements/apple-pay'
 
 declare const stripe: Stripe;
 declare const cardElement: StripeCardElement;
+declare const cardNumberElement: StripeCardNumberElement;
 declare const ibanElement: StripeIbanElement;
 declare const paymentElement: StripePaymentElement;
 declare const cartElement: StripeCartElement;
@@ -54,6 +56,11 @@ elements.update({
 
 cardElement.update({
   // @ts-expect-error: 'disableLink' does not exist in type 'StripeCardElementUpdateOptions'
+  disableLink: false,
+});
+
+cardNumberElement.update({
+  // @ts-expect-error: 'disableLink' does not exist in type 'StripeCardNumberElementUpdateOptions'
   disableLink: false,
 });
 

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -54,6 +54,22 @@ elements.update({
   },
 });
 
+// invalid value for 'preferredNetwork'
+// @ts-expect-error: No overload matches this call
+elements.create('cardNumber', {preferredNetwork: ['invalid_network']});
+
+// invalid value for 'preferredNetwork'
+// @ts-expect-error: No overload matches this call
+elements.create('card', {preferredNetwork: ['invalid_network']});
+
+// invalid type for 'preferredNetwork'
+// @ts-expect-error: No overload matches this call
+elements.create('cardNumber', {preferredNetwork: 'cartes_bancaires'});
+
+// invalid type for 'preferredNetwork'
+// @ts-expect-error: No overload matches this call
+elements.create('card', {preferredNetwork: 'cartes_bancaires'});
+
 cardElement.update({
   // @ts-expect-error: 'disableLink' does not exist in type 'StripeCardElementUpdateOptions'
   disableLink: false,
@@ -62,6 +78,16 @@ cardElement.update({
 cardNumberElement.update({
   // @ts-expect-error: 'disableLink' does not exist in type 'StripeCardNumberElementUpdateOptions'
   disableLink: false,
+});
+
+cardElement.update({
+  // @ts-expect-error: 'preferredNetwork' does not exist in type 'StripeCardElementUpdateOptions'
+  preferredNetwork: ['cartes_bancaires'],
+});
+
+cardNumberElement.update({
+  // @ts-expect-error: 'preferredNetwork' does not exist in type 'StripeCardNumberElementUpdateOptions'
+  preferredNetwork: ['cartes_bancaires'],
 });
 
 paymentElement.on('change', (e) => {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -238,6 +238,10 @@ const cardElement: StripeCardElement = elements.create('card', {
   disableLink: false,
 });
 
+elements.create('card', {preferredNetwork: undefined});
+
+elements.create('card', {preferredNetwork: ['cartes_bancaires', 'accel']});
+
 elements.create('card', {style: {base: {fontWeight: 500}}});
 
 const cardElementDefaults: StripeCardElement = elements.create('card');
@@ -255,6 +259,10 @@ const cardNumberElement: StripeCardNumberElement = elements.create(
     disableLink: false,
   }
 );
+
+elements.create('cardNumber', {preferredNetwork: undefined});
+
+elements.create('cardNumber', {preferredNetwork: ['cartes_bancaires', 'accel']});
 
 elements.create('cardNumber', {style: {base: {fontWeight: 500}}});
 elements.create('cardCvc', {style: {base: {fontWeight: 500}}});

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -262,7 +262,9 @@ const cardNumberElement: StripeCardNumberElement = elements.create(
 
 elements.create('cardNumber', {preferredNetwork: undefined});
 
-elements.create('cardNumber', {preferredNetwork: ['cartes_bancaires', 'accel']});
+elements.create('cardNumber', {
+  preferredNetwork: ['cartes_bancaires', 'accel'],
+});
 
 elements.create('cardNumber', {style: {base: {fontWeight: 500}}});
 elements.create('cardCvc', {style: {base: {fontWeight: 500}}});

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -252,6 +252,7 @@ const cardNumberElement: StripeCardNumberElement = elements.create(
     style: MY_STYLE,
     showIcon: true,
     iconStyle: 'solid',
+    disableLink: false,
   }
 );
 

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -617,25 +617,25 @@ export type StripeElementLocale =
   | 'zh-HK'
   | 'zh-TW';
 
-export type CardNetworkBrand = 
-| 'accel'
-| 'amex'
-| 'carnet'
-| 'cartes_bancaires'
-| 'diners'
-| 'discover'
-| 'eftpos_au'
-| 'elo'
-| 'girocard'
-| 'interac'
-| 'jcb'
-| 'mastercard'
-| 'nyce'
-| 'pulse'
-| 'rupay'
-| 'star'
-| 'unionpay'
-| 'visa'
+export type CardNetworkBrand =
+  | 'accel'
+  | 'amex'
+  | 'carnet'
+  | 'cartes_bancaires'
+  | 'diners'
+  | 'discover'
+  | 'eftpos_au'
+  | 'elo'
+  | 'girocard'
+  | 'interac'
+  | 'jcb'
+  | 'mastercard'
+  | 'nyce'
+  | 'pulse'
+  | 'rupay'
+  | 'star'
+  | 'unionpay'
+  | 'visa';
 
 type PaymentMethodOptions = {
   card?: {require_cvc_recollection?: boolean};

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -617,6 +617,26 @@ export type StripeElementLocale =
   | 'zh-HK'
   | 'zh-TW';
 
+export type CardNetworkBrand = 
+| 'accel'
+| 'amex'
+| 'carnet'
+| 'cartes_bancaires'
+| 'diners'
+| 'discover'
+| 'eftpos_au'
+| 'elo'
+| 'girocard'
+| 'interac'
+| 'jcb'
+| 'mastercard'
+| 'nyce'
+| 'pulse'
+| 'rupay'
+| 'star'
+| 'unionpay'
+| 'visa'
+
 type PaymentMethodOptions = {
   card?: {require_cvc_recollection?: boolean};
   us_bank_account?: {

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -148,7 +148,7 @@ export interface StripeCardNumberElementOptions {
    * network on the entered card will be selected as the default in the Card Brand Choice dropdown upon
    * entry of a co-branded card.
    *
-   * Default is an empty array, meaning no network will be selected by default in the Card Brand choice dropdown.
+   * Default is an empty array, meaning no default selection will be made in the Card Brand choice dropdown.
    */
   preferredNetwork?: Array<CardNetworkBrand>;
 }

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -144,7 +144,7 @@ export interface StripeCardNumberElementOptions {
   disableLink?: boolean;
 
   /**
-   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this 
+   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this
    * parameter will result in the most preferred network being selected by default in the dropdown.
    * Defaults to the automatic network ordering if no value is specified.
    */

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -122,7 +122,7 @@ export interface StripeCardNumberElementOptions {
 
   /**
    * Applies a disabled state to the Element such that user input is not accepted.
-   * Default is false.
+   * Default is `false`.
    */
   disabled?: boolean;
 
@@ -139,7 +139,7 @@ export interface StripeCardNumberElementOptions {
 
   /**
    * Hides and disables the Link Button in the Card Element.
-   * Default is false.
+   * Default is `false`.
    */
   disableLink?: boolean;
 
@@ -147,6 +147,8 @@ export interface StripeCardNumberElementOptions {
    * Specifies a network preference for Card Brand Choice. The first network in the array which is a valid
    * network on the entered card will be selected as the default in the Card Brand Choice dropdown upon
    * entry of a co-branded card.
+   *
+   * Default is an empty array, meaning no network will be selected by default in the Card Brand choice dropdown.
    */
   preferredNetwork?: Array<CardNetworkBrand>;
 }
@@ -160,7 +162,7 @@ export interface StripeCardNumberElementUpdateOptions {
 
   /**
    * Applies a disabled state to the Element such that user input is not accepted.
-   * Default is false.
+   * Default is `false`.
    */
   disabled?: boolean;
 

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -4,6 +4,7 @@ import {
   StripeElementClasses,
   StripeElementChangeEvent,
 } from './base';
+import {CardNetworkBrand} from '../elements-group';
 
 export type StripeCardNumberElement = StripeElementBase & {
   /**
@@ -141,6 +142,13 @@ export interface StripeCardNumberElementOptions {
    * Default is false.
    */
   disableLink?: boolean;
+
+  /**
+   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this 
+   * parameter will result in the most preferred network being selected by default in the dropdown.
+   * Defaults to the automatic network ordering if no value is specified.
+   */
+  preferredNetwork?: Array<CardNetworkBrand>;
 }
 
 export interface StripeCardNumberElementUpdateOptions {

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -144,9 +144,9 @@ export interface StripeCardNumberElementOptions {
   disableLink?: boolean;
 
   /**
-   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this
-   * parameter will result in the most preferred network being selected by default in the dropdown.
-   * Defaults to the automatic network ordering if no value is specified.
+   * Specifies a network preference for Card Brand Choice. The first network in the array which is a valid
+   * network on the entered card will be selected as the default in the Card Brand Choice dropdown upon
+   * entry of a co-branded card.
    */
   preferredNetwork?: Array<CardNetworkBrand>;
 }

--- a/types/stripe-js/elements/card-number.d.ts
+++ b/types/stripe-js/elements/card-number.d.ts
@@ -109,10 +109,41 @@ export type StripeCardNumberElement = StripeElementBase & {
    * The styles of an `Element` can be dynamically changed using `element.update`.
    * This method can be used to simulate CSS media queries that automatically adjust the size of elements when viewed on different devices.
    */
-  update(options: Partial<StripeCardNumberElementOptions>): void;
+  update(options: Partial<StripeCardNumberElementUpdateOptions>): void;
 };
 
 export interface StripeCardNumberElementOptions {
+  classes?: StripeElementClasses;
+
+  style?: StripeElementStyle;
+
+  placeholder?: string;
+
+  /**
+   * Applies a disabled state to the Element such that user input is not accepted.
+   * Default is false.
+   */
+  disabled?: boolean;
+
+  /**
+   * Show a card brand icon in the Element.
+   * Default is `false`.
+   */
+  showIcon?: boolean;
+
+  /**
+   * Appearance of the brand icon in the Element.
+   */
+  iconStyle?: 'default' | 'solid';
+
+  /**
+   * Hides and disables the Link Button in the Card Element.
+   * Default is false.
+   */
+  disableLink?: boolean;
+}
+
+export interface StripeCardNumberElementUpdateOptions {
   classes?: StripeElementClasses;
 
   style?: StripeElementStyle;

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -144,13 +144,13 @@ export interface StripeCardElementOptions {
 
   /**
    * Applies a disabled state to the Element such that user input is not accepted.
-   * Default is false.
+   * Default is `false`.
    */
   disabled?: boolean;
 
   /**
    * Hides and disables the Link Button in the Card Element.
-   * Default is false.
+   * Default is `false`.
    */
   disableLink?: boolean;
 
@@ -158,6 +158,8 @@ export interface StripeCardElementOptions {
    * Specifies a network preference for Card Brand Choice. The first network in the array which is a valid
    * network on the entered card will be selected as the default in the Card Brand Choice dropdown upon
    * entry of a co-branded card.
+   *
+   * Default is an empty array, meaning no network will be selected by default in the Card Brand choice dropdown.
    */
   preferredNetwork?: Array<CardNetworkBrand>;
 }
@@ -193,7 +195,7 @@ export interface StripeCardElementUpdateOptions {
 
   /**
    * Applies a disabled state to the Element such that user input is not accepted.
-   * Default is false.
+   * Default is `false`.
    */
   disabled?: boolean;
 }

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -155,7 +155,7 @@ export interface StripeCardElementOptions {
   disableLink?: boolean;
 
   /**
-   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this 
+   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this
    * parameter will result in the most preferred network being selected by default in the dropdown.
    * Defaults to the automatic network ordering if no value is specified.
    */

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -155,9 +155,9 @@ export interface StripeCardElementOptions {
   disableLink?: boolean;
 
   /**
-   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this
-   * parameter will result in the most preferred network being selected by default in the dropdown.
-   * Defaults to the automatic network ordering if no value is specified.
+   * Specifies a network preference for Card Brand Choice. The first network in the array which is a valid
+   * network on the entered card will be selected as the default in the Card Brand Choice dropdown upon
+   * entry of a co-branded card.
    */
   preferredNetwork?: Array<CardNetworkBrand>;
 }

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -159,7 +159,7 @@ export interface StripeCardElementOptions {
    * network on the entered card will be selected as the default in the Card Brand Choice dropdown upon
    * entry of a co-branded card.
    *
-   * Default is an empty array, meaning no network will be selected by default in the Card Brand choice dropdown.
+   * Default is an empty array, meaning no default selection will be made in the Card Brand choice dropdown.
    */
   preferredNetwork?: Array<CardNetworkBrand>;
 }

--- a/types/stripe-js/elements/card.d.ts
+++ b/types/stripe-js/elements/card.d.ts
@@ -4,6 +4,7 @@ import {
   StripeElementClasses,
   StripeElementChangeEvent,
 } from './base';
+import {CardNetworkBrand} from '../elements-group';
 
 export type StripeCardElement = StripeElementBase & {
   /**
@@ -152,6 +153,13 @@ export interface StripeCardElementOptions {
    * Default is false.
    */
   disableLink?: boolean;
+
+  /**
+   * The preferred card network order for the Card Brand Choice dropdown. Specifying a value for this 
+   * parameter will result in the most preferred network being selected by default in the dropdown.
+   * Defaults to the automatic network ordering if no value is specified.
+   */
+  preferredNetwork?: Array<CardNetworkBrand>;
 }
 
 export interface StripeCardElementUpdateOptions {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds a `preferredNetwork` option that can be passed upon `card` and `cardNumber` create. The shape is an array of card networks.

Also adds the `disableLink` option on create to `cardNumber`. It had previously been added to `card`, and it should've been added to `cardNumber` as well, but was forgotten.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

I wrote unit tests

Public documentation will be updated later on (feature is not yet released)
