### PR TITLE
fix: subpath exports types

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
   "module": "dist/stripe.mjs",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./dist/stripe.mjs",
       "default": "./dist/stripe.js"
     },
     "./pure": {
+      "types": "./types/pure.d.ts",
       "import": "./dist/pure.mjs",
       "default": "./dist/pure.js"
     }


### PR DESCRIPTION
### Summary & motivation

This PR addresses https://github.com/stripe/stripe-js/issues/543 and https://github.com/stripe/stripe-js/issues/545.
It fixes the missing types for subpath exports while supporting the legacy pattern.

### Testing & documentation

I tested the type resolution locally and executed `yarn test`.