### PR TITLE
Removing deprecated jsnext:main field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-js",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "Stripe.js loading utility",
   "repository": "github:stripe/stripe-js",
   "main": "dist/stripe.js",


### PR DESCRIPTION
### Summary & motivation

The jsnext:main field in a package.json file has been deprecated so this PR removes it.

Package lint results: https://publint.dev/@stripe/stripe-js@3.0.0

Removal of jsnext:main issue: https://github.com/jsforum/jsforum/issues/5

### Testing & documentation

Tests weren't needed as it's an unused field in the package definition.
