### PR TITLE
Fix types for package.json exports (#542, #543, #545)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,24 @@
   "module": "dist/stripe.mjs",
   "exports": {
     ".": {
-      "import": "./dist/stripe.mjs",
-      "default": "./dist/stripe.js"
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/stripe.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/stripe.js"
+      }
     },
     "./pure": {
-      "import": "./dist/pure.mjs",
-      "default": "./dist/pure.js"
+      "import": {
+        "types": "./types/pure.d.ts",
+        "default": "./dist/pure.mjs"
+      },
+      "require": {
+        "types": "./dist/pure.d.ts",
+        "default": "./dist/pure.js"
+      }
     }
   },
   "jsnext:main": "dist/stripe.mjs",

--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -1,4 +1,4 @@
-///<reference path='./types/index.d.ts' />
+///<reference path='./index.d.ts' />
 
 export const loadStripe: typeof import('@stripe/stripe-js').loadStripe & {
   setLoadParameters: (params: {advancedFraudSignals: boolean}) => void;


### PR DESCRIPTION
### Summary & motivation

Two fixes here:
1. Types for ES modules need to be specified on a per-module basis, as suggested in https://github.com/microsoft/TypeScript/issues/52363#issuecomment-1659179354
1. A separate path reference fix for the `pure` module

### Testing & documentation

I tested this against packages which were compiled in webpack/vite with `"moduleResolution": "node16"` and `"moduleResolution": "bundler"` in `tsconfig.json`. I confirmed this fix works fore TypeScript 4+.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
