### PR TITLE
Type fixes before next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-# ⚠️ v3.0.0 Notice
-
-We are aware of an issue impacting builds for some TypeScript users in our
-latest package release **v3.0.0** and are actively investigating a fix. For the
-time being, we recommend users to remain on the previous release
-[v2.4.0](https://github.com/stripe/stripe-js/releases/tag/v2.4.0).
-
 # Stripe.js ES Module
 
 Use [Stripe.js](https://stripe.com/docs/stripe-js) as an ES module.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "default": "./dist/stripe.mjs"
       },
       "require": {
-        "types": "./dist/index.d.ts",
+        "types": "./types/index.d.ts",
         "default": "./dist/stripe.js"
       }
     },
@@ -22,7 +22,7 @@
         "default": "./dist/pure.mjs"
       },
       "require": {
-        "types": "./dist/pure.d.ts",
+        "types": "./types/pure.d.ts",
         "default": "./dist/pure.js"
       }
     }


### PR DESCRIPTION
### Summary & motivation

Fixes incorrect dir references from #549 and removes the deprecation notice so the next release can go out. We will deprecate version 3.0.0 after that.