### PR TITLE
Fix TypeScript types for some builds (#543)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./types/index.d.ts",
+        "types": "./types/index.d.mts",
         "default": "./dist/stripe.mjs"
       },
       "require": {
@@ -18,7 +18,7 @@
     },
     "./pure": {
       "import": {
-        "types": "./types/pure.d.ts",
+        "types": "./types/pure.d.mts",
         "default": "./dist/pure.mjs"
       },
       "require": {

--- a/types/index.d.mts
+++ b/types/index.d.mts
@@ -1,0 +1,17 @@
+export * from './api';
+export * from './stripe-js';
+
+import {StripeConstructor, StripeConstructorOptions, Stripe} from './stripe-js';
+
+export const loadStripe: (
+  publishableKey: string,
+  options?: StripeConstructorOptions | undefined
+) => Promise<Stripe | null>;
+
+declare global {
+  interface Window {
+    // Stripe.js must be loaded directly from https://js.stripe.com/v3, which
+    // places a `Stripe` object on the window
+    Stripe?: StripeConstructor;
+  }
+}

--- a/types/pure.d.mts
+++ b/types/pure.d.mts
@@ -1,0 +1,5 @@
+///<reference path='./index.d.ts' />
+
+export const loadStripe: typeof import('@stripe/stripe-js').loadStripe & {
+  setLoadParameters: (params: {advancedFraudSignals: boolean}) => void;
+};


### PR DESCRIPTION
### Summary & motivation

TypeScript declaration files for ES modules are assumed to be CJS unless they end in `.d.mts` extensions. This change duplicates the existing `.d.ts` files to fix the problem in the short term.

### Testing & documentation

I used `publint` to verify the output.