### PR TITLE
Fix types for node16/bundler module resolution strategies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 20.x
     - run: yarn install --frozen-lockfile
     - run: yarn run lint
     - run: yarn run typecheck

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ of features of Stripe.js.
 ## Minimum requirements
 
 - Node.js: v12.16
+- TypeScript: v.3.1.1
 
 ## Installation
 
@@ -76,6 +77,18 @@ or ignoring and overriding the type definitions as necessary.
 Note that we may release new [minor and patch](https://semver.org/) versions of
 `@stripe/stripe-js` with small but backwards-incompatible fixes to the type
 declarations. These changes will not affect Stripe.js itself.
+
+### [`moduleResolution`](https://www.typescriptlang.org/tsconfig#moduleResolution) support
+
+This package supports the following module resolution strategies:
+
+- `bundler`
+- `node16`
+- `nodenext`
+
+This package does not support `node10` or `node` strategies, which do not
+support ES6 modules. Using `node16` or `nodenext` is recommended as a
+replacement configuration.
 
 ## Ensuring Stripe.js is available everywhere
 

--- a/package.json
+++ b/package.json
@@ -8,21 +8,21 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./types/index.d.ts",
+        "types": "./dist/index.d.mts",
         "default": "./dist/stripe.mjs"
       },
       "require": {
-        "types": "./types/index.d.ts",
+        "types": "./dist/index.d.ts",
         "default": "./dist/stripe.js"
       }
     },
     "./pure": {
       "import": {
-        "types": "./types/pure.d.ts",
+        "types": "./dist/pure.d.mts",
         "default": "./dist/pure.mjs"
       },
       "require": {
-        "types": "./types/pure.d.ts",
+        "types": "./dist/pure.d.ts",
         "default": "./dist/pure.js"
       }
     }
@@ -78,6 +78,7 @@
     "rimraf": "^2.6.2",
     "rollup": "^1.29.0",
     "rollup-plugin-babel": "^4.3.3",
+    "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-typescript2": "^0.25.3",
     "ts-jest": "^24.3.0",
     "typescript": "^4.1.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import babel from 'rollup-plugin-babel';
 import ts from 'rollup-plugin-typescript2';
+import {dts} from 'rollup-plugin-dts';
 import replace from '@rollup/plugin-replace';
 
 import pkg from './package.json';
@@ -26,11 +27,27 @@ export default [
     plugins: PLUGINS,
   },
   {
+    input: 'types/index.d.ts',
+    output: [
+      {file: './dist/index.d.ts', format: 'cjs'},
+      {file: './dist/index.d.mts', format: 'es'},
+    ],
+    plugins: [dts()],
+  },
+  {
     input: 'src/pure.ts',
     output: [
       {file: 'dist/pure.js', format: 'cjs'},
       {file: 'dist/pure.mjs', format: 'es'},
     ],
     plugins: PLUGINS,
+  },
+  {
+    input: 'types/pure.d.ts',
+    output: [
+      {file: './dist/pure.d.ts', format: 'cjs'},
+      {file: './dist/pure.d.mts', format: 'es'},
+    ],
+    plugins: [dts()],
   },
 ];

--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -1,5 +1,5 @@
-///<reference path='./index.d.ts' />
+import {loadStripe as _loadStripe} from './index';
 
-export const loadStripe: typeof import('@stripe/stripe-js').loadStripe & {
+export const loadStripe: typeof _loadStripe & {
   setLoadParameters: (params: {advancedFraudSignals: boolean}) => void;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,7 +1050,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -3774,6 +3774,13 @@ magic-string@^0.25.5:
   dependencies:
     sourcemap-codec "^1.4.4"
 
+magic-string@^0.30.4:
+  version "0.30.7"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.7.tgz#0cecd0527d473298679da95a2d7aeb8c64048505"
+  integrity sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -4660,6 +4667,15 @@ rollup-plugin-babel@^4.3.3:
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
+
+rollup-plugin-dts@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz#56e9c5548dac717213c6a4aa9df523faf04f75ae"
+  integrity sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==
+  dependencies:
+    magic-string "^0.30.4"
+  optionalDependencies:
+    "@babel/code-frame" "^7.22.13"
 
 rollup-plugin-typescript2@^0.25.3:
   version "0.25.3"


### PR DESCRIPTION
### Summary & motivation

This is a more canonical fix for types than what shipped in v3.0.1, as verified w/ this command:

```
yarn build && npx @arethetypeswrong/cli --pack .
```

This fix took a couple days because the combination of quirks in our codebase, quirks in TypeScript, and quirks in available tooling made it difficult to ascertain a fix. Historically, we have shipped types from a `./types` directory with corresponding entrypoint definition files. And since we shipped multiple `.d.ts` files, we essentially shipped our types as written. This approach is not compatible with `.d.mts` files, since these are not apparently resolved by any TypeScript tooling. As a result, it took some time to find a way to ship a single `.d.mts` definition file for ES modules.

The [`rollup-plugin-dts`](https://www.npmjs.com/package/rollup-plugin-dts) Rollup plugin turned out to be the best option after trial and error. It requires minimal changes. As a result of this change, both `.d.ts` and `.d.mts` declarations are now shipped as single files. However, this is not a breaking change because we have allowed the use of barrel exports from the main TypeScript modules.

As a result of this change, we now ship compliant types for `node16` CJS, `node16` ESM, and `bundler` resolution configurations. `node10` support is included for the main `@stripe/stripe-js` module. Support for `@stripe/stripe-js/pure` is not included in this fix.
