### PR TITLE
Add pure dir to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 package.json
+pure


### PR DESCRIPTION
### Summary & motivation

The `pure` dir is a new compilation destination, so code in that dir should not be beautified.