### PR TITLE
Remove window declarations from pure types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,9 @@
 export * from './api';
 export * from './stripe-js';
 
-import {StripeConstructor, StripeConstructorOptions, Stripe} from './stripe-js';
+import {StripeConstructor} from './stripe-js';
 
-export const loadStripe: (
-  publishableKey: string,
-  options?: StripeConstructorOptions | undefined
-) => Promise<Stripe | null>;
+export {loadStripe} from './shared';
 
 declare global {
   interface Window {

--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -1,4 +1,4 @@
-import {loadStripe as _loadStripe} from './index';
+import {loadStripe as _loadStripe} from './shared';
 
 export const loadStripe: typeof _loadStripe & {
   setLoadParameters: (params: {advancedFraudSignals: boolean}) => void;

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -1,0 +1,6 @@
+import {StripeConstructorOptions, Stripe} from './stripe-js';
+
+export const loadStripe: (
+  publishableKey: string,
+  options?: StripeConstructorOptions | undefined
+) => Promise<Stripe | null>;


### PR DESCRIPTION
### Summary & motivation

This PR fixes an issue from this comment: https://github.com/stripe/stripe-js/issues/543#issuecomment-1956640803

Both `pure/index.d.ts` and `dist/index.d.ts` attempt to modify the `Window` class. The `types/pure.d.ts` imports `loadStripe` from `types/index.d.ts`, and the latter module monkeypatches `Window`. The `pure` module then receives both the function type it wants, as well as the monkeypatched `Window` class.

I have fixed the issue by moving the `loadStripe` declaration into a new `shared.d.ts` module.

### Testing & documentation

I built the types and verified that `Window` is no longer monkeypatched in the `pure` output types.
