### PR TITLE
Fix mismatched types between entrypoint and pure modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dist
 *.log
 .vim
 .vscode/
-pure

--- a/lib/index.d.mts
+++ b/lib/index.d.mts
@@ -1,0 +1,1 @@
+export * from '../dist';

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+module.exports = require('../dist/stripe');

--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -1,0 +1,1 @@
+export * from '../dist/stripe.mjs';

--- a/package.json
+++ b/package.json
@@ -3,18 +3,19 @@
   "version": "3.0.5",
   "description": "Stripe.js loading utility",
   "repository": "github:stripe/stripe-js",
-  "main": "dist/stripe.js",
-  "module": "dist/stripe.mjs",
-  "jsnext:main": "dist/stripe.mjs",
-  "types": "dist/index.d.ts",
-  "typings": "dist/index.d.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.mjs",
+  "jsnext:main": "lib/index.mjs",
+  "types": "lib/index.d.ts",
+  "typings": "lib/index.d.ts",
   "scripts": {
     "test": "yarn lint && yarn test:unit && yarn test:types && yarn typecheck",
     "test:unit": "jest",
     "test:types": "zx ./tests/types/scripts/test.mjs",
     "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-check",
     "typecheck": "tsc",
-    "build": "yarn clean && yarn rollup -c",
+    "copy-types": "./scripts/copy-types",
+    "build": "yarn clean && yarn rollup -c && yarn copy-types",
     "clean": "rimraf dist",
     "prepublishOnly": "echo \"\nPlease use ./scripts/publish instead\n\" && exit 1",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
@@ -30,8 +31,9 @@
   "homepage": "https://stripe.com/docs/js",
   "files": [
     "dist",
-    "src",
-    "pure"
+    "lib",
+    "pure",
+    "src"
   ],
   "engines": {
     "node": ">=12.16"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "rimraf": "^2.6.2",
     "rollup": "^1.29.0",
     "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-typescript2": "^0.25.3",
     "ts-jest": "^24.3.0",
     "typescript": "^4.1.2",

--- a/pure/index.d.mts
+++ b/pure/index.d.mts
@@ -1,0 +1,1 @@
+export * from '../dist/pure';

--- a/pure/index.d.ts
+++ b/pure/index.d.ts
@@ -1,0 +1,1 @@
+export * from '../dist/pure';

--- a/pure/index.js
+++ b/pure/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../dist/pure');

--- a/pure/index.mjs
+++ b/pure/index.mjs
@@ -1,0 +1,1 @@
+export * from '../dist/pure.mjs';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,5 @@
 import babel from 'rollup-plugin-babel';
 import ts from 'rollup-plugin-typescript2';
-import {dts} from 'rollup-plugin-dts';
 import replace from '@rollup/plugin-replace';
 
 import pkg from './package.json';
@@ -21,33 +20,17 @@ export default [
   {
     input: 'src/index.ts',
     output: [
-      {file: pkg.main, format: 'cjs'},
-      {file: pkg.module, format: 'es'},
+      {file: 'dist/index.js', format: 'cjs'},
+      {file: 'dist/index.mjs', format: 'es'},
     ],
     plugins: PLUGINS,
-  },
-  {
-    input: 'types/index.d.ts',
-    output: [
-      {file: './dist/index.d.ts', format: 'cjs'},
-      {file: './dist/index.d.mts', format: 'es'},
-    ],
-    plugins: [dts()],
   },
   {
     input: 'src/pure.ts',
     output: [
-      {file: 'pure/index.js', format: 'cjs'},
-      {file: 'pure/index.mjs', format: 'es'},
+      {file: 'dist/pure.js', format: 'cjs'},
+      {file: 'dist/pure.mjs', format: 'es'},
     ],
     plugins: PLUGINS,
-  },
-  {
-    input: 'types/pure.d.ts',
-    output: [
-      {file: './pure/index.d.ts', format: 'cjs'},
-      {file: './pure/index.d.mts', format: 'es'},
-    ],
-    plugins: [dts()],
   },
 ];

--- a/scripts/copy-types
+++ b/scripts/copy-types
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Sets the source and destination directories
+SRC_DIR="./types"
+DEST_DIR="./dist"
+
+# Finds all .d.ts files in the source directory and copies them
+find "$SRC_DIR" -type f -name '*.d.ts' | while read -r src_file; do
+    # Constructs the destination file path
+    dest_file="${src_file/$SRC_DIR/$DEST_DIR}"
+    dest_file_mts="${dest_file/%.d.ts/.d.mts}"
+
+    # Creates the destination directory if it doesn't exist
+    mkdir -p "$(dirname "$dest_file")"
+
+    # Copys the .d.ts file to the destination directory
+    cp "$src_file" "$dest_file"
+    cp "$src_file" "$dest_file_mts"
+done
+
+echo "All .d.ts files have been copied from $SRC_DIR to $DEST_DIR."

--- a/yarn.lock
+++ b/yarn.lock
@@ -1050,7 +1050,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14":
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
@@ -3774,13 +3774,6 @@ magic-string@^0.25.5:
   dependencies:
     sourcemap-codec "^1.4.4"
 
-magic-string@^0.30.4:
-  version "0.30.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.7.tgz#0cecd0527d473298679da95a2d7aeb8c64048505"
-  integrity sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.15"
-
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -4667,15 +4660,6 @@ rollup-plugin-babel@^4.3.3:
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
-
-rollup-plugin-dts@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz#56e9c5548dac717213c6a4aa9df523faf04f75ae"
-  integrity sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==
-  dependencies:
-    magic-string "^0.30.4"
-  optionalDependencies:
-    "@babel/code-frame" "^7.22.13"
 
 rollup-plugin-typescript2@^0.25.3:
   version "0.25.3"


### PR DESCRIPTION
### Summary & motivation

This change addresses #563. Types from `pure` and the main entrypoint are not interchangeable since `rollup-plugin-dts` generates two separate sets of types. This fixes the issue and keeps the `.d.mts` files by copying the `.d.ts` files from the `types` directory into `./dist` in two copies: one with the `.d.ts` extension, and with the `.d.mts` extension as well.

I've also made two directories for module entrypoints so that the main and `pure` entrypoints live in sister folders `lib` and `pure`. This helps with testing and standardization.

### Testing & documentation

I tested these changes with a number of sample repos, as well as with the `react-stripe-js` repo. I also checked with `arethetypeswrong` and `publint`.
