### PR TITLE
Update Custom Checkout types

### DIFF
--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -13,8 +13,13 @@ import {Appearance, CssFontSource, CustomFontSource} from './elements-group';
 import {StripeError} from './stripe';
 import {
   StripeExpressCheckoutElement,
+  StripeExpressCheckoutElementBlur,
   StripeExpressCheckoutElementConfirmEvent,
+  StripeExpressCheckoutElementEscape,
+  StripeExpressCheckoutElementFocus,
+  StripeExpressCheckoutElementLoaderror,
   StripeExpressCheckoutElementOptions,
+  StripeExpressCheckoutElementReady,
 } from './elements';
 
 /**
@@ -229,26 +234,31 @@ export type StripeCustomCheckoutExpressCheckoutElementConfirmEvent = StripeExpre
   confirm: () => Promise<StripeCustomCheckoutResult>;
 };
 
-export type StripeCustomCheckoutExpressCheckoutElement = {
-  on(
-    eventType: 'confirm',
-    handler: (
-      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
-    ) => any
-  ): StripeCustomCheckoutExpressCheckoutElement;
-  once(
-    eventType: 'confirm',
-    handler: (
-      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
-    ) => any
-  ): StripeCustomCheckoutExpressCheckoutElement;
-  off(
-    eventType: 'confirm',
-    handler?: (
-      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
-    ) => any
-  ): StripeCustomCheckoutExpressCheckoutElement;
-} & StripeExpressCheckoutElement;
+export type StripeCustomCheckoutExpressCheckoutElement = StripeExpressCheckoutElementReady &
+  StripeExpressCheckoutElementFocus &
+  StripeExpressCheckoutElementBlur &
+  StripeExpressCheckoutElementEscape &
+  StripeExpressCheckoutElementLoaderror & {
+    update: StripeExpressCheckoutElement['update'];
+    on(
+      eventType: 'confirm',
+      handler: (
+        event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+      ) => any
+    ): StripeCustomCheckoutExpressCheckoutElement;
+    once(
+      eventType: 'confirm',
+      handler: (
+        event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+      ) => any
+    ): StripeCustomCheckoutExpressCheckoutElement;
+    off(
+      eventType: 'confirm',
+      handler?: (
+        event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+      ) => any
+    ): StripeCustomCheckoutExpressCheckoutElement;
+  };
 
 export interface StripeCustomCheckout {
   /* Custom Checkout methods */

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -11,15 +11,16 @@ import {
 } from './elements/address';
 import {Appearance, CssFontSource, CustomFontSource} from './elements-group';
 import {StripeError} from './stripe';
+import {
+  StripeExpressCheckoutElement,
+  StripeExpressCheckoutElementOptions,
+} from './elements';
 
 /**
  * Requires beta access:
  * Contact [Stripe support](https://support.stripe.com/) for more information.
  */
 
-/**
- * StripeCustomCheckoutInitOptions
- */
 export interface StripeCustomCheckoutElementsOptions {
   appearance?: Appearance;
   loader?: 'auto' | 'always' | 'never';
@@ -31,10 +32,7 @@ export interface StripeCustomCheckoutOptions {
   elementsOptions?: StripeCustomCheckoutElementsOptions;
 }
 
-/**
- * StripeCustomCheckoutActions
- */
-
+/* Custom Checkout types */
 export type StripeCustomCheckoutAddress = {
   country: string;
   line1?: string | null;
@@ -44,16 +42,184 @@ export type StripeCustomCheckoutAddress = {
   state?: string | null;
 };
 
+export type StripeCustomCheckoutBillingInterval =
+  | 'day'
+  | 'month'
+  | 'week'
+  | 'year';
+
+export type StripeCustomCheckoutConfirmationRequirement =
+  | 'phoneNumber'
+  | 'shippingAddress'
+  | 'billingAddress'
+  | 'paymentDetails'
+  | 'email';
+
 export type StripeCustomCheckoutContact = {
   name?: string | null;
   address: StripeCustomCheckoutAddress;
 };
 
+export type StripeCustomCheckoutDeliveryEstimate = {
+  maximum: StripeCustomCheckoutEstimate | null;
+  minimum: StripeCustomCheckoutEstimate | null;
+};
+
+export type StripeCustomCheckoutDiscountAmount = {
+  amount: number;
+  displayName: string;
+  promotionCode: string | null;
+  recurring:
+    | {type: 'forever'}
+    | {type: 'repeating'; durationInMonths: number}
+    | null;
+};
+
+export type StripeCustomCheckoutDueNext = {
+  amountSubtotal: number;
+  amountDiscount: number;
+  amountTaxInclusive: number;
+  amountTaxExclusive: number;
+  billingCycleAnchor: number | null;
+};
+
+export type StripeCustomCheckoutEstimate = {
+  unit: 'business_day' | 'day' | 'hour' | 'week' | 'month';
+  value: number;
+};
+
+export type StripeCustomCheckoutLastPaymentError = {
+  message: string;
+};
+
+export type StripeCustomCheckoutTaxAmount = {
+  amount: number;
+  inclusive: boolean;
+  displayName: string;
+};
+
+export type StripeCustomCheckoutLineItem = {
+  id: string;
+  name: string;
+  amountDiscount: number;
+  amountSubtotal: number;
+  amountTaxExclusive: number;
+  amountTaxInclusive: number;
+  unitAmount: number;
+  description: string | null;
+  quantity: number;
+  discountAmounts: Array<StripeCustomCheckoutDiscountAmount> | null;
+  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
+  recurring: {
+    interval: StripeCustomCheckoutBillingInterval;
+    intervalCount: number;
+    isProrated: boolean;
+    usageType: 'metered' | 'licensed';
+  } | null;
+};
+
+export type StripeCustomCheckoutRecurring = {
+  interval: StripeCustomCheckoutBillingInterval;
+  intervalCount: number;
+  dueNext: StripeCustomCheckoutDueNext;
+  trial: StripeCustomCheckoutTrial | null;
+};
+
+export type StripeCustomCheckoutShipping = {
+  shippingOption: StripeCustomCheckoutShippingOption;
+  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
+};
+
+export type StripeCustomCheckoutShippingOption = {
+  id: string;
+  amount: number;
+  currency: string;
+  displayName: string | null;
+  deliveryEstimate: StripeCustomCheckoutDeliveryEstimate | null;
+};
+
+export type StripeCustomCheckoutStatus =
+  | {type: 'open'}
+  | {type: 'expired'}
+  | {
+      type: 'complete';
+      paymentStatus: 'paid' | 'unpaid' | 'no_payment_required';
+    };
+
+export type StripeCustomCheckoutTaxStatus =
+  | {status: 'ready'}
+  | {status: 'requires_shipping_address'}
+  | {status: 'requires_billing_address'};
+
+export type StripeCustomCheckoutTotalSummary = {
+  appliedBalance: number;
+  balanceAppliedToNextInvoice: boolean;
+  discount: number;
+  shippingRate: number;
+  subtotal: number;
+  taxExclusive: number;
+  taxInclusive: number;
+  total: number;
+};
+
+export type StripeCustomCheckoutTrial = {
+  trialEnd: number;
+  trialPeriodDays: number;
+};
+
+/* Custom Checkout session */
+export interface StripeCustomCheckoutSession {
+  billingAddress: StripeCustomCheckoutContact | null;
+  canConfirm: boolean;
+  confirmationRequirements: StripeCustomCheckoutConfirmationRequirement[];
+  currency: string;
+  discountAmounts: Array<StripeCustomCheckoutDiscountAmount> | null;
+  email: string | null;
+  lastPaymentError: StripeCustomCheckoutLastPaymentError | null;
+  lineItems: Array<StripeCustomCheckoutLineItem>;
+  phoneNumber: string | null;
+  recurring: StripeCustomCheckoutRecurring | null;
+  shipping: StripeCustomCheckoutShipping | null;
+  shippingAddress: StripeCustomCheckoutContact | null;
+  shippingOptions: Array<StripeCustomCheckoutShippingOption>;
+  status: StripeCustomCheckoutStatus;
+  tax: StripeCustomCheckoutTaxStatus;
+  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
+  total: StripeCustomCheckoutTotalSummary;
+}
+
 export type StripeCustomCheckoutResult =
   | {session: StripeCustomCheckoutSession; error?: undefined}
   | {session?: undefined; error: StripeError};
 
-export interface StripeCustomCheckoutActions {
+export type StripeCustomCheckoutPaymentElementOptions = {
+  layout?: Layout | LayoutObject;
+  paymentMethodOrder?: Array<string>;
+  readonly?: boolean;
+  terms?: TermsOption;
+};
+
+export type StripeCustomCheckoutAddressElementOptions = {
+  mode: AddressMode;
+  contacts?: ContactOption[];
+  display?: {
+    name?: 'full' | 'split' | 'organization';
+  };
+};
+
+export type StripeCustomCheckoutExpressCheckoutElementOptions = {
+  buttonHeight: StripeExpressCheckoutElementOptions['buttonHeight'];
+  buttonTheme: StripeExpressCheckoutElementOptions['buttonTheme'];
+  buttonType: StripeExpressCheckoutElementOptions['buttonType'];
+  layout: StripeExpressCheckoutElementOptions['layout'];
+};
+
+export type StripeCustomCheckoutUpdateHandler = (
+  session: StripeCustomCheckoutSession
+) => void;
+
+export interface StripeCustomCheckout {
+  /* Custom Checkout methods */
   applyPromotionCode: (
     promotionCode: string
   ) => Promise<StripeCustomCheckoutResult>;
@@ -76,125 +242,19 @@ export interface StripeCustomCheckoutActions {
   confirm: (args?: {
     return_url?: string;
   }) => Promise<StripeCustomCheckoutResult>;
-}
+  session: () => StripeCustomCheckoutSession;
+  on: (event: 'change', handler: StripeCustomCheckoutUpdateHandler) => void;
 
-/**
- * StripeCustomCheckoutSession
- */
-
-export type StripeCustomCheckoutTaxAmount = {
-  amount: number;
-  inclusive: boolean;
-  displayName: string;
-};
-
-export type StripeCustomCheckoutDiscountAmount = {
-  amount: number;
-  displayName: string;
-  promotionCode: string | null;
-};
-
-export type StripeCustomCheckoutShipping = {
-  shippingOption: StripeCustomCheckoutShippingOption;
-  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
-};
-
-export type StripeCustomCheckoutShippingOption = {
-  id: string;
-  amount: number;
-  currency: string;
-  displayName: string | null;
-  deliveryEstimate: StripeCustomCheckoutDeliveryEstimate | null;
-};
-
-export type StripeCustomCheckoutDeliveryEstimate = {
-  maximum: StripeCustomCheckoutEstimate | null;
-  minimum: StripeCustomCheckoutEstimate | null;
-};
-
-export type StripeCustomCheckoutEstimate = {
-  unit: 'business_day' | 'day' | 'hour' | 'week' | 'month';
-  value: number;
-};
-
-export type StripeCustomCheckoutBillingInterval =
-  | 'day'
-  | 'month'
-  | 'week'
-  | 'year';
-
-export type StripeCustomCheckoutLineItem = {
-  id: string;
-  name: string;
-  amount: number;
-  unitAmount: number;
-  description: string | null;
-  quantity: number;
-  discountAmounts: Array<StripeCustomCheckoutDiscountAmount> | null;
-  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
-  recurring: {
-    interval: StripeCustomCheckoutBillingInterval;
-    interval_count: number;
-  } | null;
-};
-
-export type StripeCustomCheckoutTotalSummary = {
-  subtotal: number;
-  taxExclusive: number;
-  taxInclusive: number;
-  shippingRate: number;
-  discount: number;
-  total: number;
-};
-
-export type StripeCustomCheckoutConfirmationRequirement =
-  | 'phoneNumber'
-  | 'shippingAddress'
-  | 'billingAddress'
-  | 'paymentDetails'
-  | 'email';
-
-export interface StripeCustomCheckoutSession {
-  lineItems: Array<StripeCustomCheckoutLineItem>;
-  taxAmounts: Array<StripeCustomCheckoutTaxAmount> | null;
-  discountAmounts: Array<StripeCustomCheckoutDiscountAmount> | null;
-  currency: string;
-  shipping: StripeCustomCheckoutShipping | null;
-  shippingOptions: Array<StripeCustomCheckoutShippingOption>;
-  shippingAddress: StripeCustomCheckoutContact | null;
-  billingAddress: StripeCustomCheckoutContact | null;
-  phoneNumber: string | null;
-  email: string | null;
-  total: StripeCustomCheckoutTotalSummary;
-  confirmationRequirements: StripeCustomCheckoutConfirmationRequirement[];
-  canConfirm: boolean;
-}
-
-/**
- * StripeCustomCheckoutElements
- */
-export type StripeCustomCheckoutPaymentElementOptions = {
-  layout?: Layout | LayoutObject;
-  paymentMethodOrder?: Array<string>;
-  readonly?: boolean;
-  terms?: TermsOption;
-};
-
-export type StripeCustomCheckoutAddressElementOptions = {
-  mode: AddressMode;
-  contacts?: ContactOption[];
-  display?: {
-    name?: 'full' | 'split' | 'organization';
-  };
-};
-
-export interface StripeCustomCheckoutElementsActions {
+  /* Elements methods */
   changeAppearance: (appearance: Appearance) => void;
   getElement(elementType: 'payment'): StripePaymentElement | null;
   getElement(
     elementType: 'address',
     mode: AddressMode
   ): StripeAddressElement | null;
+  getElement(
+    elementType: 'expressCheckout'
+  ): StripeExpressCheckoutElement | null;
   createElement(
     elementType: 'payment',
     options?: StripeCustomCheckoutPaymentElementOptions
@@ -203,18 +263,8 @@ export interface StripeCustomCheckoutElementsActions {
     elementType: 'address',
     options: StripeCustomCheckoutAddressElementOptions
   ): StripeAddressElement;
-}
-
-/**
- * StripeCustomCheckout
- */
-export type StripeCustomCheckoutUpdateHandler = (
-  session: StripeCustomCheckoutSession
-) => void;
-
-export interface StripeCustomCheckout
-  extends StripeCustomCheckoutActions,
-    StripeCustomCheckoutElementsActions {
-  session: () => StripeCustomCheckoutSession;
-  on: (event: 'change', handler: StripeCustomCheckoutUpdateHandler) => void;
+  createElement(
+    elementType: 'expressCheckout',
+    options: StripeCustomCheckoutExpressCheckoutElementOptions
+  ): StripeExpressCheckoutElement;
 }

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -12,6 +12,7 @@ import {
 import {Appearance, CssFontSource, CustomFontSource} from './elements-group';
 import {StripeError} from './stripe';
 import {
+  StripeElementBase,
   StripeExpressCheckoutElement,
   StripeExpressCheckoutElementBlur,
   StripeExpressCheckoutElementConfirmEvent,
@@ -234,7 +235,8 @@ export type StripeCustomCheckoutExpressCheckoutElementConfirmEvent = StripeExpre
   confirm: () => Promise<StripeCustomCheckoutResult>;
 };
 
-export type StripeCustomCheckoutExpressCheckoutElement = StripeExpressCheckoutElementReady &
+export type StripeCustomCheckoutExpressCheckoutElement = StripeElementBase &
+  StripeExpressCheckoutElementReady &
   StripeExpressCheckoutElementFocus &
   StripeExpressCheckoutElementBlur &
   StripeExpressCheckoutElementEscape &

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -233,7 +233,7 @@ export type StripeCustomCheckoutExpressCheckoutElementConfirmEvent = StripeExpre
 
 export type StripeCustomCheckoutExpressCheckoutElement = StripeElementBase & {
   /**
-   * Triggered when the element is fully rendered and can accept `element.focus` calls.
+   * Triggered when the element is fully rendered.
    */
   on(
     eventType: 'ready',

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -13,6 +13,7 @@ import {Appearance, CssFontSource, CustomFontSource} from './elements-group';
 import {StripeError} from './stripe';
 import {
   StripeExpressCheckoutElement,
+  StripeExpressCheckoutElementConfirmEvent,
   StripeExpressCheckoutElementOptions,
 } from './elements';
 
@@ -40,6 +41,11 @@ export type StripeCustomCheckoutAddress = {
   city?: string | null;
   postal_code?: string | null;
   state?: string | null;
+};
+
+export type StripeCustomCheckoutAdjustableQuantity = {
+  maximum: number;
+  minimum: number;
 };
 
 export type StripeCustomCheckoutBillingInterval =
@@ -116,6 +122,7 @@ export type StripeCustomCheckoutLineItem = {
     isProrated: boolean;
     usageType: 'metered' | 'licensed';
   } | null;
+  adjustableQuantity: StripeCustomCheckoutAdjustableQuantity | null;
 };
 
 export type StripeCustomCheckoutRecurring = {
@@ -218,6 +225,31 @@ export type StripeCustomCheckoutUpdateHandler = (
   session: StripeCustomCheckoutSession
 ) => void;
 
+export type StripeCustomCheckoutExpressCheckoutElementConfirmEvent = StripeExpressCheckoutElementConfirmEvent & {
+  confirm: () => Promise<StripeCustomCheckoutResult>;
+};
+
+export type StripeCustomCheckoutExpressCheckoutElement = {
+  on(
+    eventType: 'confirm',
+    handler: (
+      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+    ) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'confirm',
+    handler: (
+      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+    ) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'confirm',
+    handler?: (
+      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+    ) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+} & StripeExpressCheckoutElement;
+
 export interface StripeCustomCheckout {
   /* Custom Checkout methods */
   applyPromotionCode: (
@@ -254,7 +286,7 @@ export interface StripeCustomCheckout {
   ): StripeAddressElement | null;
   getElement(
     elementType: 'expressCheckout'
-  ): StripeExpressCheckoutElement | null;
+  ): StripeCustomCheckoutExpressCheckoutElement | null;
   createElement(
     elementType: 'payment',
     options?: StripeCustomCheckoutPaymentElementOptions
@@ -266,5 +298,5 @@ export interface StripeCustomCheckout {
   createElement(
     elementType: 'expressCheckout',
     options: StripeCustomCheckoutExpressCheckoutElementOptions
-  ): StripeExpressCheckoutElement;
+  ): StripeCustomCheckoutExpressCheckoutElement;
 }

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -14,13 +14,9 @@ import {StripeError} from './stripe';
 import {
   StripeElementBase,
   StripeExpressCheckoutElement,
-  StripeExpressCheckoutElementBlur,
   StripeExpressCheckoutElementConfirmEvent,
-  StripeExpressCheckoutElementEscape,
-  StripeExpressCheckoutElementFocus,
-  StripeExpressCheckoutElementLoaderror,
   StripeExpressCheckoutElementOptions,
-  StripeExpressCheckoutElementReady,
+  StripeExpressCheckoutElementReadyEvent,
 } from './elements';
 
 /**
@@ -235,32 +231,124 @@ export type StripeCustomCheckoutExpressCheckoutElementConfirmEvent = StripeExpre
   confirm: () => Promise<StripeCustomCheckoutResult>;
 };
 
-export type StripeCustomCheckoutExpressCheckoutElement = StripeElementBase &
-  StripeExpressCheckoutElementReady &
-  StripeExpressCheckoutElementFocus &
-  StripeExpressCheckoutElementBlur &
-  StripeExpressCheckoutElementEscape &
-  StripeExpressCheckoutElementLoaderror & {
-    update: StripeExpressCheckoutElement['update'];
-    on(
-      eventType: 'confirm',
-      handler: (
-        event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
-      ) => any
-    ): StripeCustomCheckoutExpressCheckoutElement;
-    once(
-      eventType: 'confirm',
-      handler: (
-        event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
-      ) => any
-    ): StripeCustomCheckoutExpressCheckoutElement;
-    off(
-      eventType: 'confirm',
-      handler?: (
-        event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
-      ) => any
-    ): StripeCustomCheckoutExpressCheckoutElement;
-  };
+export type StripeCustomCheckoutExpressCheckoutElement = StripeElementBase & {
+  /**
+   * Triggered when the element is fully rendered and can accept `element.focus` calls.
+   */
+  on(
+    eventType: 'ready',
+    handler: (event: StripeExpressCheckoutElementReadyEvent) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'ready',
+    handler: (event: StripeExpressCheckoutElementReadyEvent) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'ready',
+    handler?: (event: StripeExpressCheckoutElementReadyEvent) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+
+  /**
+   * Triggered when the element gains focus.
+   */
+  on(
+    eventType: 'focus',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'focus',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'focus',
+    handler?: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+
+  /**
+   * Triggered when the element loses focus.
+   */
+  on(
+    eventType: 'blur',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'blur',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'blur',
+    handler?: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+
+  /**
+   * Triggered when the escape key is pressed within the element.
+   */
+  on(
+    eventType: 'escape',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'escape',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'escape',
+    handler?: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+
+  /**
+   * Triggered when the element fails to load.
+   */
+  on(
+    eventType: 'loaderror',
+    handler: (event: {
+      elementType: 'expressCheckout';
+      error: StripeError;
+    }) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'loaderror',
+    handler: (event: {
+      elementType: 'expressCheckout';
+      error: StripeError;
+    }) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'loaderror',
+    handler?: (event: {
+      elementType: 'expressCheckout';
+      error: StripeError;
+    }) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+
+  /**
+   * Triggered when a buyer authorizes a payment within a supported payment method.
+   */
+  on(
+    eventType: 'confirm',
+    handler: (
+      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+    ) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'confirm',
+    handler: (
+      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+    ) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'confirm',
+    handler?: (
+      event: StripeCustomCheckoutExpressCheckoutElementConfirmEvent
+    ) => any
+  ): StripeCustomCheckoutExpressCheckoutElement;
+
+  /**
+   * Updates the options the `ExpressCheckoutElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   */
+  update: StripeExpressCheckoutElement['update'];
+};
 
 export interface StripeCustomCheckout {
   /* Custom Checkout methods */

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -2,7 +2,7 @@ import {StripeElementBase} from './base';
 import {StripeError} from '../stripe';
 import {ApplePayOption, ApplePayUpdateOption} from './apple-pay';
 
-export type StripeExpressCheckoutElementReady = {
+export type StripeExpressCheckoutElement = StripeElementBase & {
   /**
    * Triggered when the element is fully rendered and can accept `element.focus` calls.
    */
@@ -18,9 +18,7 @@ export type StripeExpressCheckoutElementReady = {
     eventType: 'ready',
     handler?: (event: StripeExpressCheckoutElementReadyEvent) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementClick = {
   /**
    * Triggered when a button on the element is clicked.
    */
@@ -36,9 +34,7 @@ export type StripeExpressCheckoutElementClick = {
     eventType: 'click',
     handler?: (event: StripeExpressCheckoutElementClickEvent) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementFocus = {
   /**
    * Triggered when the element gains focus.
    */
@@ -54,9 +50,7 @@ export type StripeExpressCheckoutElementFocus = {
     eventType: 'focus',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementBlur = {
   /**
    * Triggered when the element loses focus.
    */
@@ -72,9 +66,7 @@ export type StripeExpressCheckoutElementBlur = {
     eventType: 'blur',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementEscape = {
   /**
    * Triggered when the escape key is pressed within the element.
    */
@@ -90,9 +82,7 @@ export type StripeExpressCheckoutElementEscape = {
     eventType: 'escape',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementLoaderror = {
   /**
    * Triggered when the element fails to load.
    */
@@ -117,9 +107,7 @@ export type StripeExpressCheckoutElementLoaderror = {
       error: StripeError;
     }) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementConfirm = {
   /**
    * Triggered when a buyer authorizes a payment within a supported payment method.
    */
@@ -135,9 +123,7 @@ export type StripeExpressCheckoutElementConfirm = {
     eventType: 'confirm',
     handler?: (event: StripeExpressCheckoutElementConfirmEvent) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementCancel = {
   /**
    * Triggered when a payment interface is dismissed (e.g., a buyer closes the payment interface)
    */
@@ -153,9 +139,7 @@ export type StripeExpressCheckoutElementCancel = {
     eventType: 'cancel',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementShippingaddresschange = {
   /**
    * Triggered when a buyer selects a different shipping address.
    */
@@ -177,9 +161,7 @@ export type StripeExpressCheckoutElementShippingaddresschange = {
       event: StripeExpressCheckoutElementShippingAddressChangeEvent
     ) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElementShippingratechange = {
   /**
    * Triggered when a buyer selects a different shipping rate.
    */
@@ -197,27 +179,15 @@ export type StripeExpressCheckoutElementShippingratechange = {
       event: StripeExpressCheckoutElementShippingRateChangeEvent
     ) => any
   ): StripeExpressCheckoutElement;
-};
 
-export type StripeExpressCheckoutElement = StripeElementBase &
-  StripeExpressCheckoutElementReady &
-  StripeExpressCheckoutElementClick &
-  StripeExpressCheckoutElementFocus &
-  StripeExpressCheckoutElementBlur &
-  StripeExpressCheckoutElementEscape &
-  StripeExpressCheckoutElementLoaderror &
-  StripeExpressCheckoutElementConfirm &
-  StripeExpressCheckoutElementCancel &
-  StripeExpressCheckoutElementShippingaddresschange &
-  StripeExpressCheckoutElementShippingratechange & {
-    /**
-     * Updates the options the `ExpressCheckoutElement` was initialized with.
-     * Updates are merged into the existing configuration.
-     */
-    update(
-      options: StripeExpressCheckoutElementUpdateOptions
-    ): StripeExpressCheckoutElement;
-  };
+  /**
+   * Updates the options the `ExpressCheckoutElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   */
+  update(
+    options: StripeExpressCheckoutElementUpdateOptions
+  ): StripeExpressCheckoutElement;
+};
 
 export type ExpressPaymentType = 'google_pay' | 'apple_pay' | 'link' | 'paypal';
 

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -2,7 +2,7 @@ import {StripeElementBase} from './base';
 import {StripeError} from '../stripe';
 import {ApplePayOption, ApplePayUpdateOption} from './apple-pay';
 
-export type StripeExpressCheckoutElement = StripeElementBase & {
+export type StripeExpressCheckoutElementReady = {
   /**
    * Triggered when the element is fully rendered and can accept `element.focus` calls.
    */
@@ -18,7 +18,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
     eventType: 'ready',
     handler?: (event: StripeExpressCheckoutElementReadyEvent) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementClick = {
   /**
    * Triggered when a button on the element is clicked.
    */
@@ -34,7 +36,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
     eventType: 'click',
     handler?: (event: StripeExpressCheckoutElementClickEvent) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementFocus = {
   /**
    * Triggered when the element gains focus.
    */
@@ -50,7 +54,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
     eventType: 'focus',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementBlur = {
   /**
    * Triggered when the element loses focus.
    */
@@ -66,7 +72,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
     eventType: 'blur',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementEscape = {
   /**
    * Triggered when the escape key is pressed within the element.
    */
@@ -82,7 +90,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
     eventType: 'escape',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementLoaderror = {
   /**
    * Triggered when the element fails to load.
    */
@@ -107,7 +117,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
       error: StripeError;
     }) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementConfirm = {
   /**
    * Triggered when a buyer authorizes a payment within a supported payment method.
    */
@@ -123,7 +135,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
     eventType: 'confirm',
     handler?: (event: StripeExpressCheckoutElementConfirmEvent) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementCancel = {
   /**
    * Triggered when a payment interface is dismissed (e.g., a buyer closes the payment interface)
    */
@@ -139,7 +153,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
     eventType: 'cancel',
     handler?: (event: {elementType: 'expressCheckout'}) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementShippingaddresschange = {
   /**
    * Triggered when a buyer selects a different shipping address.
    */
@@ -161,7 +177,9 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
       event: StripeExpressCheckoutElementShippingAddressChangeEvent
     ) => any
   ): StripeExpressCheckoutElement;
+};
 
+export type StripeExpressCheckoutElementShippingratechange = {
   /**
    * Triggered when a buyer selects a different shipping rate.
    */
@@ -179,15 +197,27 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
       event: StripeExpressCheckoutElementShippingRateChangeEvent
     ) => any
   ): StripeExpressCheckoutElement;
-
-  /**
-   * Updates the options the `ExpressCheckoutElement` was initialized with.
-   * Updates are merged into the existing configuration.
-   */
-  update(
-    options: StripeExpressCheckoutElementUpdateOptions
-  ): StripeExpressCheckoutElement;
 };
+
+export type StripeExpressCheckoutElement = StripeElementBase &
+  StripeExpressCheckoutElementReady &
+  StripeExpressCheckoutElementClick &
+  StripeExpressCheckoutElementFocus &
+  StripeExpressCheckoutElementBlur &
+  StripeExpressCheckoutElementEscape &
+  StripeExpressCheckoutElementLoaderror &
+  StripeExpressCheckoutElementConfirm &
+  StripeExpressCheckoutElementCancel &
+  StripeExpressCheckoutElementShippingaddresschange &
+  StripeExpressCheckoutElementShippingratechange & {
+    /**
+     * Updates the options the `ExpressCheckoutElement` was initialized with.
+     * Updates are merged into the existing configuration.
+     */
+    update(
+      options: StripeExpressCheckoutElementUpdateOptions
+    ): StripeExpressCheckoutElement;
+  };
 
 export type ExpressPaymentType = 'google_pay' | 'apple_pay' | 'link' | 'paypal';
 


### PR DESCRIPTION
### Summary & motivation

r? @pololi-stripe 

Update Custom Checkout types for custom_checkout_beta_2

* Added lineItem.amountsSubtotal, amountDiscount, amountTaxInclusive, amountTaxExclusive
* Removed lineItem.amount
* Added lineItem.recurring.usageType, isProrated, intervalCount
* Removed lineItem.recurring.interval_count
* Added total.appliedBalance and balanceAppliedToNextInvoice
* Added tax
* Added status
* Added recurring
* Added lastPaymentError
* Added discount.recurring
* Added lineItem.adjustableQuantity

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
