### PR TITLE
Make `paymentMethodTypes` optional in the Payment Method Messaging Element options

### DIFF
--- a/types/stripe-js/elements/payment-method-messaging.d.ts
+++ b/types/stripe-js/elements/payment-method-messaging.d.ts
@@ -53,9 +53,10 @@ export interface StripePaymentMethodMessagingElementOptions {
     | 'NZD';
 
   /**
-   * Payment methods to show messaging for.
+   * Payment methods to show messaging for. You can omit this attribute 
+   * to manage your payment methods from the Stripe Dashboard.
    */
-  paymentMethodTypes: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
+  paymentMethodTypes?: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
 
   /**
    * @deprecated Use `paymentMethodTypes` instead.

--- a/types/stripe-js/elements/payment-method-messaging.d.ts
+++ b/types/stripe-js/elements/payment-method-messaging.d.ts
@@ -53,7 +53,7 @@ export interface StripePaymentMethodMessagingElementOptions {
     | 'NZD';
 
   /**
-   * Payment methods to show messaging for. You can omit this attribute 
+   * Payment methods to show messaging for. You can omit this attribute
    * to manage your payment methods from the Stripe Dashboard.
    */
   paymentMethodTypes?: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;


### PR DESCRIPTION
### Summary & motivation

According to the Documentation for the [Payment Methods Messaging element](https://docs.stripe.com/js/elements_object/create_element?type=paymentMethodMessaging), the `paymentMethodTypes` property in the `options` object is optional. When omitted, the element will pull payment methods from the settings in the Stripe Dashboard.

This PR simply makes the `paymentMethodTypes` prop optional, to match the documentation.

### Testing & documentation

Ran `yarn prettier` and `yarn test` to confirm tests still pass.