### PR TITLE
Add `allow_redisplay` to Typescript definitions

### DIFF
--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -1422,6 +1422,11 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
      * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_data-billing_details
      */
     billing_details?: PaymentMethodCreateParams.BillingDetails;
+
+    /**
+     * Specifies if the PaymentMethod should be redisplayed when using the Saved Payment Method feature
+     */
+    allow_redisplay?: 'always' | 'limited' | 'unspecified';
   };
 
   /**


### PR DESCRIPTION
### Summary & motivation
Stripe has added a parameter `allow_redisplay` to `confirmParams.payment_method_data` that allows the user to specify whether a PaymentMethod created via the Saved Payment Methods feature will be redisplayed in the future.

### Testing & documentation
Tested locally - 
![CleanShot 2024-03-07 at 14 01 11](https://github.com/stripe/stripe-js/assets/95632492/4a994eb9-8694-4dd2-a8ae-544e50d7a6f2)


The other parameter within `confirmParams.payment_method_data`, `billing_details`, did not have a unit test, so I omitted one for allow_redisplay.
