### PR TITLE
Add allow_redisplay parameter to ConfirmationTokenCreateParams and ConfirmPaymentData

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2350,6 +2350,7 @@ stripe
         billing_details: {
           name: 'Jenny Rosen',
         },
+        allow_redisplay: 'always',
       },
       shipping: {
         address: {

--- a/types/api/confirmation-tokens.d.ts
+++ b/types/api/confirmation-tokens.d.ts
@@ -86,7 +86,7 @@ export interface ConfirmationTokenCreateParams {
     /**
      * Requires beta access:
      * Contact [Stripe support](https://support.stripe.com/) for more information.
-     * 
+     *
      * Specifies if the PaymentMethod should be redisplayed when using the Saved Payment Method feature
      */
     allow_redisplay?: 'always' | 'limited' | 'unspecified';

--- a/types/api/confirmation-tokens.d.ts
+++ b/types/api/confirmation-tokens.d.ts
@@ -82,6 +82,14 @@ export interface ConfirmationTokenCreateParams {
      * The customer's billing details.
      */
     billing_details?: PaymentMethodCreateParams.BillingDetails;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     * 
+     * Specifies if the PaymentMethod should be redisplayed when using the Saved Payment Method feature
+     */
+    allow_redisplay?: 'always' | 'limited' | 'unspecified';
   };
 
   /**

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -1424,6 +1424,9 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
     billing_details?: PaymentMethodCreateParams.BillingDetails;
 
     /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     * 
      * Specifies if the PaymentMethod should be redisplayed when using the Saved Payment Method feature
      */
     allow_redisplay?: 'always' | 'limited' | 'unspecified';

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -1426,7 +1426,7 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
     /**
      * Requires beta access:
      * Contact [Stripe support](https://support.stripe.com/) for more information.
-     * 
+     *
      * Specifies if the PaymentMethod should be redisplayed when using the Saved Payment Method feature
      */
     allow_redisplay?: 'always' | 'limited' | 'unspecified';


### PR DESCRIPTION
### Summary & motivation

Updates the types to include a beta param.

### Testing & documentation

Test passed and build succeeded. 
