### PR TITLE
Make onBehalfOf/on_behalf_of updateable

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -124,6 +124,7 @@ stripe.elements({
   payment_method_options: {
     us_bank_account: {financial_connections: {permissions: ['payment_method']}},
   },
+  on_behalf_of: 'acct_id',
 });
 
 const elementsClientSecret: StripeElements = stripe.elements({
@@ -203,6 +204,7 @@ elements.update({
   setupFutureUsage: 'off_session',
   captureMethod: 'automatic',
   paymentMethodTypes: ['card'],
+  on_behalf_of: 'acct_id',
 });
 
 elements.update({

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -904,6 +904,20 @@ export interface StripeElementsUpdateOptions {
    * @docs https://stripe.com/docs/payments/payment-methods/overview
    */
   paymentMethodTypes?: string[];
+
+  /**
+   * The Stripe account ID which is the business of record.
+   *
+   * @docs https://stripe.com/docs/js/elements_object/create_without_intent#stripe_elements_no_intent-options-onBehalfOf
+   */
+  onBehalfOf?: string;
+
+  /**
+   * The Stripe account ID which is the business of record.
+   *
+   * @docs https://stripe.com/docs/js/elements_object/create_without_intent#stripe_elements_no_intent-options-onBehalfOf
+   */
+  on_behalf_of?: string;
 }
 
 /*


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Previously, onBehalfOf/on_behalf_of were only codified Elements group create options, when they should also be Elements group update options, as indicated in the update docs:

https://docs.stripe.com/js/elements_object/update#elements_update-options-onBehalfOf

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

- Added to the valid.js file
- Also verified manually with an integration to confirm that updating onBehalfOf/on_behalf_of succeeds
