### PR TITLE
Update stripe.d.ts for updating the StripeError interface

### DIFF
--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -1463,7 +1463,7 @@ export interface StripeError {
    * For example, you can use this to display a message near the correct form field.
    */
   param?: string;
-  
+
   /**
    * A URL to the request log entry in your dashboard.
    */

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -1463,6 +1463,11 @@ export interface StripeError {
    * For example, you can use this to display a message near the correct form field.
    */
   param?: string;
+  
+  /**
+   * A URL to the request log entry in your dashboard.
+   */
+  request_log_url?: string;
 
   /**
    * The `PaymentIntent` object for errors returned on a request involving a `PaymentIntent`.


### PR DESCRIPTION
adding the request_log_url type on the StripeError

### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Added the `request_log_url`  type in the `StripeError` interface.
https://docs.stripe.com/api/errors#errors-request_log_url

e.g.:
```js
{
    code: "resource_missing",
    doc_url: "https://stripe.com/docs/error-codes/resource-missing",
    message: "No such payment_intent: 'pi_xxxxxxxxx'",
    param: "intent",
    request_log_url: "https://dashboard.stripe.com/test/logs/req_xxxxxxxx?t=1711953549",
    type: "invalid_request_error"
  }
```
