### PR TITLE
Add onBehalfOf type to PaymentRequest

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -416,3 +416,18 @@ stripe
     // @ts-expect-error mandate_data is not a valid parameter
     result.confirmationToken.mandate_data;
   });
+
+const paymentRequest = stripe.paymentRequest({
+  country: 'US',
+  currency: 'usd',
+  total: {
+    label: 'Demo total',
+    amount: 1000,
+  },
+  // @ts-expect-error Type 'number' is not assignable to type 'string'.
+  onBehalfOf: 123,
+});
+paymentRequest.update({
+  // @ts-expect-error Object literal may only specify known properties, and 'onBehalfOf' does not exist in type 'PaymentRequestUpdateOptions'.
+  onBehalfOf: 'acct_123',
+});

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3184,6 +3184,13 @@ const paymentRequest: PaymentRequest = stripe.paymentRequest({
   },
 });
 
+const paymentRequestOBO: PaymentRequest = stripe.paymentRequest({
+  country: 'US',
+  currency: 'usd',
+  total: {label: 'Demo total', amount: 1000},
+  onBehalfOf: 'acct_123',
+});
+
 paymentRequest.canMakePayment().then((result) => {
   if (result) {
     const {applePay}: CanMakePaymentResult = result;

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -238,6 +238,11 @@ export interface PaymentRequestOptions {
   applePay?: ApplePayOption;
 
   /**
+   * The Stripe account ID which is the business of record.
+   */
+  onBehalfOf?: string;
+
+  /**
    * @deprecated
    * Use disableWallets instead.
    */


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds `onBehalfOf` as a valid parameter for `PaymentRequest`s

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->
Unit test

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
