### PR TITLE
In publish script, build before running tests

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -140,6 +140,9 @@ fi
 echo "Installing dependencies according to lockfile"
 yarn install --frozen-lockfile
 
+echo "Building"
+yarn run build
+
 echo "Running tests"
 yarn run test
 
@@ -151,9 +154,6 @@ verify_commit_is_signed
 
 echo "Pushing git commit and tag"
 git push --follow-tags
-
-echo "Building"
-yarn run build
 
 echo "Publishing release"
 yarn --ignore-scripts publish --non-interactive --access=public


### PR DESCRIPTION
### Summary & motivation

This changes the publish script to build distribution files before running tests. Doing so will ensure that `yarn run test:package-types` is able to succeed, since it requires assets to be built.

### Testing & documentation

Tested in #597