### PR TITLE
Add dedicated confirmSetup types; add confirmation_token to confirmPayment and confirmSetup

### DIFF
--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -1433,6 +1433,13 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
   };
 
   /**
+   * Optional `id` of an existing [ConfirmationToken](https://stripe.com/docs/api/confirmation_tokens).
+   *
+   * @docs https://stripe.com/docs/js/payment_intents/confirm_payment#confirm_payment_intent-options-confirmParams-confirmation_token
+   */
+  confirmation_token?: string;
+
+  /**
    * Optional `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
    *
    * @docs https://stripe.com/docs/js/payment_intents/confirm_payment#confirm_payment_intent-options-confirmParams-payment_method

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -1,4 +1,4 @@
-import {SetupIntentConfirmParams} from '../api';
+import {PaymentMethodCreateParams, SetupIntentConfirmParams} from '../api';
 
 import {
   CreatePaymentMethodAcssDebitData,
@@ -16,6 +16,59 @@ import {
 } from './payment-intents';
 
 import {Omit} from '../utils';
+
+/**
+ * Data to be sent with a `stripe.confirmSetup` request.
+ * Refer to the [Setup Intents API](https://stripe.com/docs/api/setup_intents/confirm) for a full list of parameters.
+ */
+export interface ConfirmSetupData extends SetupIntentConfirmParams {
+  /**
+   * The url your customer will be directed to after they complete payment.
+   */
+  return_url: string;
+
+  /**
+   * An object to attach additional billing_details to the PaymentMethod created via Elements.
+   *
+   * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_data
+   */
+  payment_method_data?: {
+    /**
+     * The customer's billing details. Details collected by Elements will override values passed here.
+     * Billing fields that are omitted in the Payment Element via the `fields` option required.
+     *
+     * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_data-billing_details
+     */
+    billing_details?: PaymentMethodCreateParams.BillingDetails;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Specifies if the PaymentMethod should be redisplayed when using the Saved Payment Method feature
+     */
+    allow_redisplay?: 'always' | 'limited' | 'unspecified';
+  };
+
+  /**
+   * Optional `id` of an existing [ConfirmationToken](https://stripe.com/docs/api/confirmation_tokens).
+   *
+   * @docs https://stripe.com/docs/js/payment_intents/confirm_payment#confirm_payment_intent-options-confirmParams-confirmation_token
+   */
+  confirmation_token?: string;
+
+  /**
+   * Optional `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+   *
+   * @docs https://stripe.com/docs/js/payment_intents/confirm_payment#confirm_payment_intent-options-confirmParams-payment_method
+   */
+  payment_method?: string;
+
+  /**
+   * Specifies which fields in the response should be expanded.
+   */
+  expand?: Array<string>;
+}
 
 /**
  * Data to be sent with a `stripe.confirmCardSetup` request.

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -707,7 +707,7 @@ export interface Stripe {
    */
   confirmSetup(options: {
     elements: StripeElements;
-    confirmParams?: Partial<paymentIntents.ConfirmPaymentData>;
+    confirmParams?: Partial<setupIntents.ConfirmSetupData>;
     redirect: 'if_required';
   }): Promise<SetupIntentResult>;
 
@@ -725,7 +725,7 @@ export interface Stripe {
   confirmSetup(options: {
     elements?: StripeElements;
     clientSecret: string;
-    confirmParams?: Partial<paymentIntents.ConfirmPaymentData>;
+    confirmParams?: Partial<setupIntents.ConfirmSetupData>;
     redirect: 'if_required';
   }): Promise<SetupIntentResult>;
 
@@ -738,7 +738,7 @@ export interface Stripe {
    */
   confirmSetup(options: {
     elements: StripeElements;
-    confirmParams: paymentIntents.ConfirmPaymentData;
+    confirmParams: setupIntents.ConfirmSetupData;
     redirect?: 'always';
   }): Promise<never | {error: StripeError}>;
 
@@ -752,7 +752,7 @@ export interface Stripe {
   confirmSetup(options: {
     elements?: StripeElements;
     clientSecret: string;
-    confirmParams: paymentIntents.ConfirmPaymentData;
+    confirmParams: setupIntents.ConfirmSetupData;
     redirect?: 'always';
   }): Promise<never | {error: StripeError}>;
 
@@ -1299,8 +1299,8 @@ export type EphemeralKeyNonceResult =
   | {nonce: string; error?: undefined}
   | {nonce?: undefined; error: StripeError};
 
-/* A Radar Session is a snapshot of the browser metadata and device details that helps Radar make more accurate predictions on your payments. 
-  This metadata includes information like IP address, browser, screen or device information, and other device characteristics. 
+/* A Radar Session is a snapshot of the browser metadata and device details that helps Radar make more accurate predictions on your payments.
+  This metadata includes information like IP address, browser, screen or device information, and other device characteristics.
   You can find more details about how Radar uses this data by reading about how Radar performs [advanced fraud detection](https://stripe.com/docs/disputes/prevention/advanced-fraud-detection).
   */
 export type RadarSessionPayload =


### PR DESCRIPTION
### Summary & motivation

- Add dedicated confirmSetup types (same as confirmPayment for now)
- Add confirmation_token to confirmPayment and confirmSetup

### Testing & documentation
- Existing tests for confirmSetup
