### PR TITLE
Fix Billing Details Types

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2263,6 +2263,21 @@ stripe.createPaymentMethod({
 });
 
 stripe.createPaymentMethod({
+  element: cardElement,
+  params: {
+    billing_details: {
+      name: 'Jenny Rosen',
+      address: {line1: '1234 Main St',
+      line2: null,
+      city: 'San Francisco',
+      state: 'CA',
+      country: 'US',
+      postal_code: '94111',}
+    },
+  },
+});
+
+stripe.createPaymentMethod({
   type: 'acss_debit',
   billing_details: {name: '', email: ''},
 });

--- a/types/api/payment-methods.d.ts
+++ b/types/api/payment-methods.d.ts
@@ -398,22 +398,22 @@ export namespace PaymentMethodCreateParams {
     /**
      * Billing address.
      */
-    address?: BillingDetails.Address;
+    address: BillingDetails.Address;
 
     /**
      * Email address.
      */
-    email?: string;
+    email: string | null;
 
     /**
      * Full name.
      */
-    name?: string;
+    name: string | null;
 
     /**
      * Billing phone number (including extension).
      */
-    phone?: string;
+    phone: string | null;
   }
 
   export namespace BillingDetails {

--- a/types/api/payment-methods.d.ts
+++ b/types/api/payment-methods.d.ts
@@ -398,22 +398,22 @@ export namespace PaymentMethodCreateParams {
     /**
      * Billing address.
      */
-    address: BillingDetails.Address;
+    address?: BillingDetails.Address;
 
     /**
      * Email address.
      */
-    email: string | null;
+    email?: string;
 
     /**
      * Full name.
      */
-    name: string | null;
+    name?: string;
 
     /**
      * Billing phone number (including extension).
      */
-    phone: string | null;
+    phone?: string;
   }
 
   export namespace BillingDetails {
@@ -421,32 +421,32 @@ export namespace PaymentMethodCreateParams {
       /**
        * City, district, suburb, town, or village.
        */
-      city: string | null;
+      city?: string;
 
       /**
        * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
        */
-      country: string | null;
+      country?: string;
 
       /**
        * Address line 1 (e.g., street, PO Box, or company name).
        */
-      line1: string | null;
+      line1?: string;
 
       /**
        * Address line 2 (e.g., apartment, suite, unit, or building).
        */
-      line2: string | null;
+      line2?: string | null;
 
       /**
        * ZIP or postal code.
        */
-      postal_code: string | null;
+      postal_code?: string;
 
       /**
        * State, county, province, or region.
        */
-      state: string | null;
+      state?: string;
     }
   }
 }

--- a/types/api/payment-methods.d.ts
+++ b/types/api/payment-methods.d.ts
@@ -421,32 +421,32 @@ export namespace PaymentMethodCreateParams {
       /**
        * City, district, suburb, town, or village.
        */
-      city?: string;
+      city: string | null;
 
       /**
        * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
        */
-      country?: string;
+      country: string | null;
 
       /**
        * Address line 1 (e.g., street, PO Box, or company name).
        */
-      line1?: string;
+      line1: string | null;
 
       /**
        * Address line 2 (e.g., apartment, suite, unit, or building).
        */
-      line2?: string;
+      line2: string | null;
 
       /**
        * ZIP or postal code.
        */
-      postal_code?: string;
+      postal_code: string | null;
 
       /**
        * State, county, province, or region.
        */
-      state?: string;
+      state: string | null;
     }
   }
 }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Allow `line2` to be null to be consistent with Address Element typing.
### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Added a type check in `valid.ts`
