### PR TITLE
Add paymentMethodOrder to StripeCustomCheckoutExpressCheckoutElementsOptions

### DIFF
--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -221,7 +221,7 @@ export type StripeCustomCheckoutExpressCheckoutElementOptions = {
   buttonTheme: StripeExpressCheckoutElementOptions['buttonTheme'];
   buttonType: StripeExpressCheckoutElementOptions['buttonType'];
   layout: StripeExpressCheckoutElementOptions['layout'];
-  paymentMethodOrder: StripeExpressCheckoutElementOptions['paymentMethodOrder']
+  paymentMethodOrder: StripeExpressCheckoutElementOptions['paymentMethodOrder'];
 };
 
 export type StripeCustomCheckoutUpdateHandler = (

--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -221,6 +221,7 @@ export type StripeCustomCheckoutExpressCheckoutElementOptions = {
   buttonTheme: StripeExpressCheckoutElementOptions['buttonTheme'];
   buttonType: StripeExpressCheckoutElementOptions['buttonType'];
   layout: StripeExpressCheckoutElementOptions['layout'];
+  paymentMethodOrder: StripeExpressCheckoutElementOptions['paymentMethodOrder']
 };
 
 export type StripeCustomCheckoutUpdateHandler = (


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

`paymentMethodOrder` was recently added as an option to ECE in Custom Checkout. Updating options to reflect the change. 
### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
