### PR TITLE
Extend ButtonThemeOption type

### DIFF
--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -256,9 +256,12 @@ export type ApplePayButtonTheme = 'black' | 'white' | 'white-outline';
 
 export type GooglePayButtonTheme = 'black' | 'white';
 
+export type PayPalButtonTheme = 'gold' | 'blue' | 'silver' | 'white' | 'black'
+
 export type ButtonThemeOption = {
   applePay?: ApplePayButtonTheme;
   googlePay?: GooglePayButtonTheme;
+  paypal?: PayPalButtonTheme;
 };
 
 export type ApplePayButtonType =


### PR DESCRIPTION
Type extention according to documentation

### Summary & motivation

Extended the type definitions for ExpressCheckoutElement to include paypal inside the `buttonTheme` options as per the [latest Stripe documentation](https://docs.stripe.com/js/elements_object/create_express_checkout_element#express_checkout_element_create-options-buttonTheme).

### Testing & documentation

Manually tested the changes by implementing them in the project and verifying the functionality.
Updated relevant type definitions and ensured compatibility with existing code.





