### PR TITLE
Change ExpressCheckout Element wallets type to paymentMethods

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -95,8 +95,8 @@ paymentElement.on('change', (e) => {
 });
 
 expressCheckoutElement.update({
-  // @ts-expect-error: `wallets` option can't be updated
-  wallets: {
+  // @ts-expect-error: `paymentMethods` option can't be updated
+  paymentMethods: {
     applePay: 'never',
   },
 });

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -801,9 +801,10 @@ const expressCheckoutElement = elements.create('expressCheckout', {
   buttonHeight: 55,
   layout: {maxRows: 1, maxColumns: 1, overflow: 'auto'},
   paymentMethodOrder: ['apple_pay', 'google_pay'],
-  wallets: {
+  paymentMethods: {
     googlePay: 'always',
     applePay: 'auto',
+    link: 'auto',
   },
   buttonTheme: {
     applePay: 'white-outline',
@@ -819,7 +820,7 @@ const expressCheckoutElement2 = elements.create('expressCheckout', {
   layout: {
     maxRows: 1,
   },
-  wallets: {
+  paymentMethods: {
     applePay: 'never',
   },
   buttonTheme: {

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -258,6 +258,11 @@ export type ExpressCheckoutPaymentMethodsOption = {
   paypal?: ExpressCheckoutPaymentMethodOption;
 };
 
+export type ExpressCheckoutWalletsOption = {
+  applePay?: ExpressCheckoutPaymentMethodOptionWithAlways;
+  googlePay?: ExpressCheckoutPaymentMethodOptionWithAlways;
+};
+
 export type ApplePayButtonTheme = 'black' | 'white' | 'white-outline';
 
 export type GooglePayButtonTheme = 'black' | 'white';
@@ -332,6 +337,14 @@ export interface StripeExpressCheckoutElementOptions {
    * Control payment method display in the Express Checkout Element.
    */
   paymentMethods?: ExpressCheckoutPaymentMethodsOption;
+
+  /**
+   * @deprecated
+   * Use `paymentMethods` instead.
+   *
+   * Control wallets display in the Express Checkout Element.
+   */
+  wallets?: ExpressCheckoutWalletsOption;
 }
 
 /*

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -245,11 +245,17 @@ export type LayoutOption = {
   overflow?: 'auto' | 'never';
 };
 
-export type ExpressCheckoutWalletOption = 'always' | 'auto' | 'never';
+export type ExpressCheckoutPaymentMethodOptionWithAlways =
+  | 'always'
+  | ExpressCheckoutPaymentMethodOption;
+export type ExpressCheckoutPaymentMethodOption = 'auto' | 'never';
 
-export type ExpressCheckoutWalletsOption = {
-  applePay?: ExpressCheckoutWalletOption;
-  googlePay?: ExpressCheckoutWalletOption;
+export type ExpressCheckoutPaymentMethodsOption = {
+  amazonPay?: ExpressCheckoutPaymentMethodOption;
+  applePay?: ExpressCheckoutPaymentMethodOptionWithAlways;
+  googlePay?: ExpressCheckoutPaymentMethodOptionWithAlways;
+  link?: ExpressCheckoutPaymentMethodOption;
+  paypal?: ExpressCheckoutPaymentMethodOption;
 };
 
 export type ApplePayButtonTheme = 'black' | 'white' | 'white-outline';
@@ -323,9 +329,9 @@ export interface StripeExpressCheckoutElementOptions {
   paymentMethodOrder?: string[];
 
   /**
-   * Control wallets display in the Express Checkout Element.
+   * Control payment method display in the Express Checkout Element.
    */
-  wallets?: ExpressCheckoutWalletsOption;
+  paymentMethods?: ExpressCheckoutPaymentMethodsOption;
 }
 
 /*


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

`wallets` was renamed to `paymentMethods`, and `link`, `paypal`, and `amazonPay` were added as options.

https://docs.stripe.com/js/elements_object/create_express_checkout_element#express_checkout_element_create-options-paymentMethods

Resolves https://github.com/stripe/stripe-js/issues/621

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Modified the valid and invalid tests

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
