### PR TITLE
Update types for Saved Payment Methods

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -158,6 +158,10 @@ const elementsPMCProvided = stripe.elements({
 
 const elementsNoOptions: StripeElements = stripe.elements();
 
+const elementsCustomerSessionClientSecret = stripe.elements({
+  customerSessionClientSecret: 'test_123',
+});
+
 const MY_STYLE: StripeElementStyle = {
   base: {
     iconColor: '#c4f0ff',
@@ -459,7 +463,26 @@ paymentElement
     'change',
     (e: {
       elementType: 'payment';
-      value: {type: string};
+      value: {
+        type: string;
+        payment_method?: {
+          id: string;
+          type: string;
+          billing_details: {
+            address: {
+              city: null | string;
+              country: null | string;
+              line1: null | string;
+              line2: null | string;
+              postal_code: null | string;
+              state: null | string;
+            };
+            name: null | string;
+            email: null | string;
+            phone: null | string;
+          };
+        };
+      };
       collapsed: boolean;
       complete: boolean;
       empty: boolean;

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -663,11 +663,7 @@ interface BaseStripeElementsOptions {
   customerOptions?: CustomerOptions;
 
   /**
-   * Requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
-   *
    * Display saved PaymentMethods and Customer information.
-   * Supported for the `payment`, `shippingAddress`, and `linkAuthentication` Elements.
    */
   customerSessionClientSecret?: string,
 }

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -661,6 +661,15 @@ interface BaseStripeElementsOptions {
    * Supported for the `payment`, `shippingAddress`, and `linkAuthentication` Elements.
    */
   customerOptions?: CustomerOptions;
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Display saved PaymentMethods and Customer information.
+   * Supported for the `payment`, `shippingAddress`, and `linkAuthentication` Elements.
+   */
+  customerSessionClientSecret?: string,
 }
 
 export interface StripeElementsOptionsClientSecret

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -665,7 +665,7 @@ interface BaseStripeElementsOptions {
   /**
    * Display saved PaymentMethods and Customer information.
    */
-  customerSessionClientSecret?: string,
+  customerSessionClientSecret?: string;
 }
 
 export interface StripeElementsOptionsClientSecret

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -273,23 +273,23 @@ export interface StripePaymentElementChangeEvent {
    * If a payment method is selected, it will be included in the object.
    */
   value: {
-    type: string,
+    type: string;
     payment_method?: {
-      id: string,
-      type: string,
+      id: string;
+      type: string;
       billing_details: {
         address: {
-          city: null | string,
-          country: null | string,
-          line1: null | string,
-          line2: null | string,
-          postal_code: null | string,
-          state: null | string,
-        },
-        name: null | string,
-        email: null | string,
-        phone: null | string,
-      },
-    },
+          city: null | string;
+          country: null | string;
+          line1: null | string;
+          line2: null | string;
+          postal_code: null | string;
+          state: null | string;
+        };
+        name: null | string;
+        email: null | string;
+        phone: null | string;
+      };
+    };
   };
 }

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -270,6 +270,26 @@ export interface StripePaymentElementChangeEvent {
 
   /**
    * An object containing the currently selected PaymentMethod type (in snake_case, for example "afterpay_clearpay").
+   * If a payment method is selected, it will be included in the object.
    */
-  value: {type: string};
+  value: {
+    type: string,
+    payment_method?: {
+      id: string,
+      type: string,
+      billing_details: {
+        address: {
+          city: null | string,
+          country: null | string,
+          line1: null | string,
+          line2: null | string,
+          postal_code: null | string,
+          state: null | string,
+        },
+        name: null | string,
+        email: null | string,
+        phone: null | string,
+      },
+    },
+  };
 }


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
- Added `payment_method ` field for paymentElement change event. This field will be populated when a saved payment method is selected
- Added `customerSessionClientSecret` field to the `elements.create(...)` options

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
- Have follow up story to update public docs
