### PR TITLE
Update payment.d.ts

### DIFF
--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -145,11 +145,11 @@ export interface DefaultValuesOption {
   };
   paymentMethods?: {
     ideal?: {
-      bank: string;
+      bank?: string;
     };
   };
   card?: {
-    network: CardNetworkOption[];
+    network?: CardNetworkOption[];
   };
 }
 

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -127,6 +127,8 @@ export type StripePaymentElement = StripeElementBase & {
   collapse(): StripePaymentElement;
 };
 
+export type CardNetworkOption = 'cartes_bancaires' | 'mastercard' | 'visa';
+
 export interface DefaultValuesOption {
   billingDetails?: {
     name?: string;
@@ -147,7 +149,7 @@ export interface DefaultValuesOption {
     };
   };
   card?: {
-    network: 'cartes_bancaires' | 'mastercard' | 'visa';
+    network: CardNetworkOption[];
   };
 }
 

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -141,6 +141,14 @@ export interface DefaultValuesOption {
       line2?: string;
     };
   };
+  paymentMethods?: {
+    ideal?: {
+      bank: string;
+    };
+  };
+  card?: {
+    network: 'cartes_bancaires' | 'mastercard' | 'visa';
+  };
 }
 
 export type FieldOption = 'auto' | 'never';


### PR DESCRIPTION
Adds the missing type definitions for defaultValues in case of the PaymentElement

### Summary & motivation

Related issue:
https://github.com/stripe/stripe-js/issues/627

### Testing & documentation

I did not test this. Feel free to do so though.

https://docs.stripe.com/js/elements_object/create_payment_element#payment_element_create-options-defaultValues
