### PR TITLE
Add optional options parameter for getElement('address')

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -47,6 +47,7 @@ import {
   StripeIssuingCardCopyButtonElementOptions,
   StripeExpressCheckoutElement,
   StripeExpressCheckoutElementOptions,
+  StripeAddressElementGetElementOptions,
 } from './elements';
 import {StripeError} from './stripe';
 
@@ -84,7 +85,10 @@ export interface StripeElements {
   /**
    * Looks up a previously created `Element` by its type.
    */
-  getElement(elementType: 'address'): StripeAddressElement | null;
+  getElement(
+    elementType: 'address',
+    options?: StripeAddressElementGetElementOptions
+  ): StripeAddressElement | null;
 
   /////////////////////////////
   /// paymentMethodMessaging

--- a/types/stripe-js/elements/address.d.ts
+++ b/types/stripe-js/elements/address.d.ts
@@ -259,3 +259,7 @@ export interface StripeAddressElementChangeEvent {
     phone?: string;
   };
 }
+
+export interface StripeAddressElementGetElementOptions {
+  mode: AddressMode;
+}


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adding support for two AEs (billing and shipping) to be mounted in the same elements group.

Updating getElement('address') with specific mode specification in line with this support.

