### PR TITLE
Add 'networks' to Card Type Definition

### DIFF
--- a/types/api/payment-methods.d.ts
+++ b/types/api/payment-methods.d.ts
@@ -151,6 +151,21 @@ export namespace PaymentMethod {
     last4: string;
 
     /**
+     * Contains information about card networks that can be used to process the payment.
+     */
+    networks: {
+      /**
+       * The preferred network for co-branded cards.
+       */
+      preferred: string | null;
+
+      /**
+       * All available networks for the card.
+       */
+      available: string[];
+    } | null;
+
+    /**
      * Contains details on how this Card maybe be used for 3D Secure authentication.
      */
     three_d_secure_usage: Card.ThreeDSecureUsage | null;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

`networks` was missing from `Card` type definition when it should be included to reflect the docs accurately (https://docs.stripe.com/api/payment_methods/object?lang=node#payment_method_object-card-networks). Updating type definition to reflect that.