### PR TITLE
Add amazon_pay to Elements expressPaymentType

### DIFF
--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -189,7 +189,7 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
   ): StripeExpressCheckoutElement;
 };
 
-export type ExpressPaymentType = 'google_pay' | 'apple_pay' | 'link' | 'paypal';
+export type ExpressPaymentType = 'google_pay' | 'apple_pay' | 'amazon_pay' | 'link' | 'paypal';
 
 export type ExpressCheckoutPartialAddress = {
   city: string;

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -189,7 +189,12 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
   ): StripeExpressCheckoutElement;
 };
 
-export type ExpressPaymentType = 'google_pay' | 'apple_pay' | 'amazon_pay' | 'link' | 'paypal';
+export type ExpressPaymentType =
+  | 'google_pay'
+  | 'apple_pay'
+  | 'amazon_pay'
+  | 'link'
+  | 'paypal';
 
 export type ExpressCheckoutPartialAddress = {
   city: string;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds the missing `amazon_pay` type to `ExpressPaymentType`, which is listed in [the docs ](https://docs.stripe.com/js/element/events/on_click?type=expressCheckoutElement#element_on_click-handler-expressPaymentType) and used in ECE as an accepted type.

### Testing & documentation

Documentation already reflects this change.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
