### PR TITLE
Add network preference to PE defaultValues

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -88,6 +88,18 @@ cardNumberElement.update({
   preferredNetwork: ['cartes_bancaires'],
 });
 
+// invalid preferred network
+// @ts-expect-error: No overload matches this call
+elements.create('payment', {
+  defaultValues: {card: {network: ['invalid_network']}},
+});
+
+// invalid type for preferred network
+// @ts-expect-error: No overload matches this call
+elements.create('payment', {
+  defaultValues: {card: {network: 'invalid_network'}},
+});
+
 paymentElement.on('change', (e) => {
   // @ts-expect-error: `error` is not present on PaymentElement "change" event.
   if (e.error) {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -392,6 +392,9 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
         postal_code: '94080',
       },
     },
+    card: {
+      network: ['cartes_bancaires', 'visa'],
+    },
   },
   fields: {
     billingDetails: {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -1,6 +1,7 @@
 import {StripeElementBase} from './base';
 import {StripeError} from '../stripe';
 import {ApplePayOption} from './apple-pay';
+import {CardNetworkBrand} from '../elements-group';
 
 export type StripePaymentElement = StripeElementBase & {
   /**
@@ -140,6 +141,9 @@ export interface DefaultValuesOption {
       line1?: string;
       line2?: string;
     };
+  };
+  card?: {
+    network?: CardNetworkBrand[];
   };
 }
 


### PR DESCRIPTION
### Summary & motivation
Add Payment Element `defaultValues[card][network]` type, which allows merchants to specify their preferred networks for use with co-branded cards.

https://github.com/stripe/stripe-js/issues/627

### Testing & documentation
I wrote unit tests

https://docs.stripe.com/js/elements_object/create_payment_element#payment_element_create-options-defaultValues-card-network
