### PR TITLE
Mark paymentMethodTypes as optional for PMME

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -376,6 +376,16 @@ const paymentMethodMessagingElement = elements.create(
   }
 );
 
+elements.create(
+  'paymentMethodMessaging',
+  {
+    amount: 2000,
+    countryCode: 'US',
+    currency: 'USD',
+    paymentMethodTypes: ['afterpay_clearpay', 'klarna', 'affirm'],
+  }
+);
+
 const paymentElement: StripePaymentElement = elements.create('payment', {
   defaultValues: {
     billingDetails: {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -371,7 +371,6 @@ const paymentMethodMessagingElement = elements.create(
   'paymentMethodMessaging',
   {
     amount: 2000,
-    paymentMethodTypes: ['afterpay_clearpay', 'klarna'],
     countryCode: 'US',
     currency: 'USD',
   }

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -376,15 +376,12 @@ const paymentMethodMessagingElement = elements.create(
   }
 );
 
-elements.create(
-  'paymentMethodMessaging',
-  {
-    amount: 2000,
-    countryCode: 'US',
-    currency: 'USD',
-    paymentMethodTypes: ['afterpay_clearpay', 'klarna', 'affirm'],
-  }
-);
+elements.create('paymentMethodMessaging', {
+  amount: 2000,
+  countryCode: 'US',
+  currency: 'USD',
+  paymentMethodTypes: ['afterpay_clearpay', 'klarna', 'affirm'],
+});
 
 const paymentElement: StripePaymentElement = elements.create('payment', {
   defaultValues: {

--- a/types/stripe-js/elements/payment-method-messaging.d.ts
+++ b/types/stripe-js/elements/payment-method-messaging.d.ts
@@ -55,7 +55,7 @@ export interface StripePaymentMethodMessagingElementOptions {
   /**
    * Payment methods to show messaging for.
    */
-  paymentMethodTypes: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
+  paymentMethodTypes?: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
 
   /**
    * @deprecated Use `paymentMethodTypes` instead.
@@ -89,9 +89,6 @@ export interface StripePaymentMethodMessagingElementOptions {
    */
   logoColor?: 'black' | 'white' | 'color';
 
-  /**
-   * The font size of the promotional message.
-   */
   metaData?: {
     messagingClientReferenceId: string | null;
   };


### PR DESCRIPTION
### Summary & motivation

`paymentMethodTypes` is optional. When it's omitted, dynamic payment method functionality is applied, where Stripe finds the BNPL payment methods that are enabled and have a relevant BNPL plan to show: https://docs.stripe.com/payments/payment-method-messaging#dynamic-display

### Testing & documentation

Updated the TypeScript test file.
