### PR TITLE
Add paymentMethodOrder option to paymentMethodMessaging element types

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -443,3 +443,11 @@ paymentRequest.update({
   // @ts-expect-error Object literal may only specify known properties, and 'onBehalfOf' does not exist in type 'PaymentRequestUpdateOptions'.
   onBehalfOf: 'acct_123',
 });
+
+// @ts-expect-error: No overload matches this call
+elements.create('paymentMethodMessaging', {
+  amount: 2000,
+  countryCode: 'US',
+  currency: 'USD',
+  paymentMethodOrder: ['invalid_type'],
+});

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -383,6 +383,13 @@ elements.create('paymentMethodMessaging', {
   paymentMethodTypes: ['afterpay_clearpay', 'klarna', 'affirm'],
 });
 
+elements.create('paymentMethodMessaging', {
+  amount: 2000,
+  countryCode: 'US',
+  currency: 'USD',
+  paymentMethodOrder: ['klarna'],
+});
+
 const paymentElement: StripePaymentElement = elements.create('payment', {
   defaultValues: {
     billingDetails: {

--- a/types/stripe-js/elements/payment-method-messaging.d.ts
+++ b/types/stripe-js/elements/payment-method-messaging.d.ts
@@ -58,6 +58,12 @@ export interface StripePaymentMethodMessagingElementOptions {
   paymentMethodTypes: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
 
   /**
+   * Override the order in which payment methods are displayed in the Payment Method Messaging Element.
+   * By default, the Payment Method Messaging Element will use a dynamic ordering that optimizes payment method display for each user.
+   */
+  paymentMethodOrder?: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
+
+  /**
    * @deprecated Use `paymentMethodTypes` instead.
    */
   paymentMethods?: Array<'afterpay_clearpay' | 'klarna' | 'affirm'>;
@@ -89,9 +95,6 @@ export interface StripePaymentMethodMessagingElementOptions {
    */
   logoColor?: 'black' | 'white' | 'color';
 
-  /**
-   * The font size of the promotional message.
-   */
   metaData?: {
     messagingClientReferenceId: string | null;
   };


### PR DESCRIPTION
### Summary & motivation

Updating types to reflect the new `paymentMethodOrder` option for PMME.

### Testing & documentation

Updated the type tests.