### PR TITLE
Add if_required type to PE fields.billingDetails.address

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -100,6 +100,14 @@ elements.create('payment', {
   defaultValues: {card: {network: 'invalid_network'}},
 });
 
+// invalid value for fields
+// @ts-expect-error: No overload matches this call
+elements.create('payment', {
+  fields: {
+    billingDetails: 'if_required',
+  },
+});
+
 paymentElement.on('change', (e) => {
   // @ts-expect-error: `error` is not present on PaymentElement "change" event.
   if (e.error) {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -413,7 +413,7 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
     billingDetails: {
       email: 'never',
       phone: 'auto',
-      address: 'never',
+      address: 'if_required',
     },
   },
   terms: {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -158,6 +158,7 @@ export interface FieldsOption {
         phone?: FieldOption;
         address?:
           | FieldOption
+          | 'if_required'
           | {
               country?: FieldOption;
               postalCode?: FieldOption;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Add `if_required` as a new type option to PE fields.billingDetails.address

### Testing & documentation

Added invalid and valid tests.
<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
