### PR TITLE
Add us_bank_account.financial_connections.return_url to Elements PaymentMethodOptions

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -121,7 +121,12 @@ stripe.elements({
   capture_method: 'automatic',
   payment_method_types: ['card'],
   payment_method_options: {
-    us_bank_account: {financial_connections: {permissions: ['payment_method'], return_url: 'https://example.com/return'}},
+    us_bank_account: {
+      financial_connections: {
+        permissions: ['payment_method'],
+        return_url: 'https://example.com/return',
+      },
+    },
   },
   on_behalf_of: 'acct_id',
 });

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -121,7 +121,7 @@ stripe.elements({
   capture_method: 'automatic',
   payment_method_types: ['card'],
   payment_method_options: {
-    us_bank_account: {financial_connections: {permissions: ['payment_method']}},
+    us_bank_account: {financial_connections: {permissions: ['payment_method'], return_url: 'https://example.com/return'}},
   },
   on_behalf_of: 'acct_id',
 });

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -621,7 +621,7 @@ type PaymentMethodOptions = {
       permissions?: Array<
         'balances' | 'ownership' | 'payment_method' | 'transactions'
       >;
-      return_url?: string
+      return_url?: string;
     };
     verification_method?: 'automatic' | 'instant';
   };

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -621,7 +621,7 @@ type PaymentMethodOptions = {
       permissions?: Array<
         'balances' | 'ownership' | 'payment_method' | 'transactions'
       >;
-      return_url?: String
+      return_url?: string
     };
     verification_method?: 'automatic' | 'instant';
   };

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -621,6 +621,7 @@ type PaymentMethodOptions = {
       permissions?: Array<
         'balances' | 'ownership' | 'payment_method' | 'transactions'
       >;
+      return_url?: String
     };
     verification_method?: 'automatic' | 'instant';
   };


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Add `us_bank_account.financial_connections.return_url` to PaymentMethodOptions for Elements.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Added valid tests.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
