### PR TITLE
Add missing payment element layout visibleAccordionItemsCount type

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -451,6 +451,13 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
     applePay: 'never',
     googlePay: 'auto',
   },
+  layout: {
+    type: 'accordion',
+    visibleAccordionItemsCount: 2,
+    defaultCollapsed: true,
+    radios: true,
+    spacedAccordionItems: true,
+  },
 });
 
 paymentElement.update({

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -225,6 +225,7 @@ export interface LayoutObject {
   defaultCollapsed?: boolean;
   radios?: boolean;
   spacedAccordionItems?: boolean;
+  visibleAccordionItemsCount?: number;
 }
 
 export interface StripePaymentElementOptions {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds a missing type: https://docs.stripe.com/js/elements_object/create_payment_element#payment_element_create-options-layout-visibleAccordionItemsCount

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
