### PR TITLE
Update amount currency option type and ECE available PMs type

### DIFF
--- a/types/stripe-js/custom-checkout.d.ts
+++ b/types/stripe-js/custom-checkout.d.ts
@@ -206,7 +206,7 @@ export type StripeCustomCheckoutTrial = {
 };
 
 export type StripeCustomCheckoutCurrencyOption = {
-  unitAmount: number;
+  amount: number;
   currency: string;
   currencyConversion?: {fxRate: number; sourceCurrency: string};
 };

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -374,8 +374,11 @@ export interface StripeExpressCheckoutElementUpdateOptions {
 }
 
 export type AvailablePaymentMethods = {
+  amazonPay: boolean;
   applePay: boolean;
   googlePay: boolean;
+  link: boolean;
+  paypal: boolean;
 };
 
 export interface StripeExpressCheckoutElementReadyEvent {


### PR DESCRIPTION
### Summary & motivation

Match our [docs](https://docs.stripe.com/js/element/events/on_ready#element_on_ready-handler-availablePaymentMethods) for the ECE type.
Updates the Custom Checkout session to match the API.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
