### PR TITLE
Add `automatic_async` to captureMethod

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -222,7 +222,7 @@ elements.update({
   currency: 'usd',
   amount: 1099,
   setupFutureUsage: 'off_session',
-  captureMethod: 'automatic',
+  captureMethod: 'automatic_async',
   paymentMethodTypes: ['card'],
   on_behalf_of: 'acct_id',
 });

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -730,14 +730,14 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
    *
    * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-capture_method
    */
-  captureMethod?: 'manual' | 'automatic';
+  captureMethod?: 'manual' | 'automatic' | 'automatic_async';
 
   /**
    * Controls when the funds will be captured from the customer’s account.
    *
    * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-capture_method
    */
-  capture_method?: 'manual' | 'automatic';
+  capture_method?: 'manual' | 'automatic' | 'automatic_async';
 
   /**
    * The Stripe account ID which is the business of record.
@@ -872,14 +872,14 @@ export interface StripeElementsUpdateOptions {
    *
    * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-capture_method
    */
-  captureMethod?: 'manual' | 'automatic';
+  captureMethod?: 'manual' | 'automatic' | 'automatic_async';
 
   /**
    * Controls when the funds will be captured from the customer’s account.
    *
    * @docs https://stripe.com/docs/api/payment_intents/create#create_payment_intent-capture_method
    */
-  capture_method?: 'manual' | 'automatic';
+  capture_method?: 'manual' | 'automatic' | 'automatic_async';
 
   /**
    * Instead of using automatic payment methods, declare specific payment methods to enable.


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Add missing type as reported in https://github.com/stripe/stripe-js/issues/677.

According to https://docs.stripe.com/api/payment_intents/create#create_payment_intent-capture_method, `automatic_async` is also a supported type for `capture_method`.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
Added test
