### PR TITLE
Fix publish signed commit check

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -69,7 +69,7 @@ EOF
 verify_commit_is_signed() {
   local commit_hash=$(git log -1 --format="%H")
 
-  if ! git verify-commit "$commit_hash" &> /dev/null; then
+  if git show --no-patch --pretty=format:"%G?" "$commit_hash" | grep "R" &> /dev/null; then
     echo "Error! Commit $commit_hash is not signed"
     echo "Please follow https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account and sign your commit"
     exit 1

--- a/scripts/publish
+++ b/scripts/publish
@@ -69,7 +69,7 @@ EOF
 verify_commit_is_signed() {
   local commit_hash=$(git log -1 --format="%H")
 
-  if git show --no-patch --pretty=format:"%G?" "$commit_hash" | grep "R" &> /dev/null; then
+  if git show --no-patch --pretty=format:"%G?" "$commit_hash" | grep "N" &> /dev/null; then
     echo "Error! Commit $commit_hash is not signed"
     echo "Please follow https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account and sign your commit"
     exit 1


### PR DESCRIPTION
### Summary & motivation

Expand the signed commit check in the publish script to support other forms of commit signing. [Here's the documentation](https://git-scm.com/docs/git-show#Documentation/git-show.txt-emGem) for the `git show` command used to check for a signed commit. For now this will check if there is no signature present and block publishing.

### Testing & documentation

The check was executed manually to verify, but the integration will need to be tested after merging.