### PR TITLE
Fix lagging version in build

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -140,14 +140,14 @@ fi
 echo "Installing dependencies according to lockfile"
 yarn install --frozen-lockfile
 
-echo "Building"
-yarn run build
-
 echo "Running tests"
 yarn run test
 
 echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
 yarn version --$RELEASE_TYPE
+
+echo "Building"
+yarn run build
 
 create_github_release
 verify_commit_is_signed


### PR DESCRIPTION
### Summary & motivation

When publishing this package, our build is run before the version bump so the output artifact's version lags behind.
This change moves the build after the version bump.
Note: the test command is still run before the version bump and should catch any immediate problems with the code.
