### PR TITLE
Add ExpressCheckoutElement PayPal `buttonType` types

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -954,6 +954,7 @@ const expressCheckoutElement2 = elements.create('expressCheckout', {
   },
   buttonType: {
     applePay: 'check-out',
+    paypal: 'checkout',
   },
 });
 

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -306,9 +306,12 @@ export type GooglePayButtonType =
   | 'plain'
   | 'subscribe';
 
+export type PayPalButtonType = 'paypal' | 'buynow' | 'checkout' | 'pay';
+
 export type ButtonTypeOption = {
   applePay?: ApplePayButtonType;
   googlePay?: GooglePayButtonType;
+  paypal?: PayPalButtonType;
 };
 
 export interface StripeExpressCheckoutElementOptions {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

We were missing types for the PayPal button type: https://docs.stripe.com/js/elements_object/create_express_checkout_element#express_checkout_element_create-options-buttonType-paypal

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Added to valid.ts
