### PR TITLE
Add type definition for elements group update-end event

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -236,6 +236,8 @@ elements.update({
   payment_method_types: ['card'],
 });
 
+elements.on('update-end', () => {});
+
 const fetchUpdates = async () => {
   const {error} = await elements.fetchUpdates();
 };

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -60,6 +60,11 @@ export interface StripeElements {
   update(options: StripeElementsUpdateOptions): void;
 
   /**
+   * Triggered when the call to elements.update() is complete.
+   */
+  on(eventType: 'update-end', handler: () => void): void;
+
+  /**
    * Fetches updates from the associated PaymentIntent or SetupIntent on an existing
    * instance of Elements, and reflects these updates in the Payment Element.
    */


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds type definition for https://docs.stripe.com/js/element/events/on_update_end

### Testing & documentation

Added test case.

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
