### PR TITLE
Push release commit and tag before creating release

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -149,11 +149,14 @@ yarn version --$RELEASE_TYPE
 echo "Building"
 yarn run build
 
-create_github_release
 verify_commit_is_signed
 
 echo "Pushing git commit and tag"
 git push --follow-tags
+
+# Create release after commit and tag are pushed to ensure package.json
+# is bumped in the GitHub release.
+create_github_release
 
 echo "Publishing release"
 yarn --ignore-scripts publish --non-interactive --access=public


### PR DESCRIPTION
### Summary & motivation

When we create a release in the publish script, we currently call `hub release create` prior to pushing the commit/tag created by `yarn release`. This causes GitHub releases to not have the bumped package.json version, which can be confusing.

This commit moves the GitHub release creation after the git push, which should fix things.

### Testing & documentation

Tough one to test, we'll see if it works with next week's release.