### PR TITLE
Chain Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-typescript2": "^0.25.3",
     "ts-jest": "^24.3.0",
-    "typescript": "^4.1.2",
+    "typescript": "~4.8.0",
     "zx": "^4.2.0"
   }
 }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -64,11 +64,11 @@ const registerWrapper = (stripe: any, startTime: number): void => {
 
 let stripePromise: Promise<StripeConstructor | null> | null = null;
 
-let onErrorListener: (() => void) | null = null;
+let onErrorListener: ((cause?: unknown) => void) | null = null;
 let onLoadListener: (() => void) | null = null;
 
-const onError = (reject: (reason?: any) => void) => () => {
-  reject(new Error('Failed to load Stripe.js'));
+const onError = (reject: (reason?: any) => void) => (cause?: unknown) => {
+  reject(new Error('Failed to load Stripe.js', {cause}));
 };
 
 const onLoad = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -5547,10 +5547,10 @@ typescript@5.3.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
 
-typescript@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
-  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
+typescript@~4.8.0:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
### Summary & motivation

Currently Stripe is swallowing the underlying errors and returning a generic error:
> Failed to load Stripe.js

https://github.com/stripe/stripe-js/blob/085deba18806b5f519d78194bec39f29b36a2b4f/src/shared.ts#L71

This can make it difficult to debug since every error gets reported the same way.

Since every JavaScript runtime [now supports](https://caniuse.com/mdn-javascript_builtins_error_cause) [chaining errors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), we could also chain errors here.

### Testing & documentation

Unfortunately this change requires _at least_ [TypeScript 4.8](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html) ([change](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-6.html#--target-es2022)) ([change](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-8.html#libdts-updates)) I was forced to upgrade it to at least that in order to get the tests to pass.
