### PR TITLE
Add release candidate configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "jsnext:main": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",
+  "releaseCandidate": false,
   "scripts": {
     "test": "yarn lint && yarn test:unit && yarn test:package-types && yarn test:types && yarn typecheck",
     "test:unit": "jest",

--- a/scripts/is_release_candidate.js
+++ b/scripts/is_release_candidate.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {releaseCandidate} = require('../package.json');
+
+// coerce boolean to 0 or 1 and default undefined to 0
+console.log(+!!releaseCandidate);

--- a/scripts/publish
+++ b/scripts/publish
@@ -4,6 +4,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 RELEASE_TYPE=${1:-}
+IS_RELEASE_CANDIDATE=$(node scripts/is_release_candidate.js)
 
 echo_help() {
   cat << EOF
@@ -99,18 +100,23 @@ case $1 in
     ;;
 esac
 
-# Validate passed release type
-case $RELEASE_TYPE in
-  patch | minor | major)
-    ;;
+# Require release type when not a beta release
+# Not necessary for beta releases because the prerelease versions
+# can be incremented automatically
+if [ "$IS_RELEASE_CANDIDATE" -ne 1 ]; then
+  # Validate passed release type
+  case $RELEASE_TYPE in
+    patch | minor | major)
+      ;;
 
-  *)
-    echo "Error! Invalid release type supplied"
-    echo ""
-    echo_help
-    exit 1
-    ;;
-esac
+    *)
+      echo "Error! Invalid release type supplied"
+      echo ""
+      echo_help
+      exit 1
+      ;;
+  esac
+fi
 
 check_github_token
 
@@ -144,7 +150,27 @@ echo "Running tests"
 yarn run test
 
 echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
-yarn version --$RELEASE_TYPE
+if [ "$IS_RELEASE_CANDIDATE" -eq 1 ]; then
+  # The Github changelog is based on tag history, so do not create tags for beta versions
+  # rc = release candidate
+  if [ -z "$RELEASE_TYPE" ]; then
+    # increment only the prerelease version if necessary, e.g. 
+    # 1.2.3-rc.0 -> 1.2.3-rc.1
+    # 1.2.3 -> 1.2.3-rc.0
+    yarn version --tag=rc --preid=rc --no-git-tag-version
+  else
+    # always increment the main version, e.g. 
+    # patch: 1.2.3-rc.0 -> 1.2.4-rc.0
+    # patch: 1.2.3 -> 1.2.4-rc.0
+    # major: 1.2.3 -> 2.0.0-rc.0
+    yarn version "--pre$RELEASE_TYPE" --tag=rc --preid=rc --no-git-tag-version
+  fi
+else
+  # increment the main version with no prerelease version, e.g.
+  # patch: 1.2.3-rc.0 -> 1.2.4
+  # major: 1.2.3 -> 2.0.0
+  yarn version "--$RELEASE_TYPE" 
+fi
 
 echo "Building"
 yarn run build
@@ -154,9 +180,11 @@ verify_commit_is_signed
 echo "Pushing git commit and tag"
 git push --follow-tags
 
-# Create release after commit and tag are pushed to ensure package.json
-# is bumped in the GitHub release.
-create_github_release
+if [ "$IS_RELEASE_CANDIDATE" -ne 1 ]; then
+  # Create release after commit and tag are pushed to ensure package.json
+  # is bumped in the GitHub release.
+  create_github_release
+fi
 
 echo "Publishing release"
 yarn --ignore-scripts publish --non-interactive --access=public


### PR DESCRIPTION
### Summary & motivation
This change adds a `releaseCandidate` configuration to the `package.json` which enables publishing test versions to npm.

The general flow looks like:
1. Set `"releaseCandidate": true` in `package.json`
2. `./scripts/publish` or `./scripts/publish <release_type>` (repeat if more release candidates are needed)
3. Set `"releaseCandidate": false` in `package.json`
4. `./scripts/publish <release_type>` (release_type is necessary)

### Testing & documentation
This change is primarily side effects, so thorough e2e testing is not feasible. After this is merged, I will release the following: 
* a patch no-op change to fully validate the main version release flow
* a release candidate no-op change to fully validate the release candidate flow

Releasing no-op changes through both flows should be safe in case something goes wrong because there will be no meaningful differences to the code being published.

In addition, I tested some the logic separately with a test script with the flag on and off, verifying the correct output:
```sh
#!/bin/bash
IS_RELEASE_CANDIDATE=$(node scripts/is_release_candidate.js)

if [ "$IS_RELEASE_CANDIDATE" -eq 1 ]; then
  echo "rc"
else
  echo "not rc"
fi
```

I also checked the exact semantics of `yarn version` in a test package.