### PR TITLE
Fix release candidate logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-js",
-  "version": "5.9.1",
+  "version": "5.9.2-rc.0",
   "description": "Stripe.js loading utility",
   "repository": "github:stripe/stripe-js",
   "main": "lib/index.js",

--- a/scripts/publish
+++ b/scripts/publish
@@ -23,8 +23,8 @@ create_github_release() {
     return
   fi
 
-  # Get the last two releases. For example, `("v1.3.1" "v1.3.2")`
-  local versions=($(git tag --sort version:refname | grep '^v' | tail -n 2))
+  # Get the last two non-release-candidate releases. For example, `("v1.3.1" "v1.3.2")`
+  local versions=($(git tag --sort version:refname | grep '^v' | grep -v "rc" | tail -n 2))
 
   # If we didn't find exactly two previous version versions, give up
   if [ ${#versions[@]} -ne 2 ]; then
@@ -157,13 +157,13 @@ if [ "$IS_RELEASE_CANDIDATE" -eq 1 ]; then
     # increment only the prerelease version if necessary, e.g. 
     # 1.2.3-rc.0 -> 1.2.3-rc.1
     # 1.2.3 -> 1.2.3-rc.0
-    yarn version --tag=rc --preid=rc --no-git-tag-version
+    yarn version --preid=rc
   else
     # always increment the main version, e.g. 
     # patch: 1.2.3-rc.0 -> 1.2.4-rc.0
     # patch: 1.2.3 -> 1.2.4-rc.0
     # major: 1.2.3 -> 2.0.0-rc.0
-    yarn version "--pre$RELEASE_TYPE" --tag=rc --preid=rc --no-git-tag-version
+    yarn version "--pre$RELEASE_TYPE" --preid=rc
   fi
 else
   # increment the main version with no prerelease version, e.g.
@@ -187,7 +187,11 @@ if [ "$IS_RELEASE_CANDIDATE" -ne 1 ]; then
 fi
 
 echo "Publishing release"
-yarn --ignore-scripts publish --non-interactive --access=public
+if [ "$IS_RELEASE_CANDIDATE" -eq 1 ]; then
+  yarn --ignore-scripts publish --tag=rc --non-interactive --access=public
+else
+  yarn --ignore-scripts publish --non-interactive --access=public
+fi
 
 echo "Publish successful!"
 echo ""


### PR DESCRIPTION
### Summary & motivation
This fixes three issues:
1. The `--no-git-tag-version` doesn't create commits in addition to tags, so we switch back to using the flag for all new versions and filter on `rc` being in the commit name
2. The `--tag` flag should be on `yarn publish`, not on `yarn version`
3. Because of (1), this change also increments the version to sync with the npm version

Because of (2), the `latest` tag was incorrectly pointing to [5.9.2-rc.0](https://www.npmjs.com/package/@stripe/stripe-js/v/5.9.2-rc.0) for about 5 minutes until I manually fixed the tag. Because this was a no-op change, there should be no real issues. However, anyone upgrading to latest at that time might be surprised with the release candidate version.

### Testing & documentation
Once merged, I will run another release candidate publish to verify the state of the system.
