### PR TITLE
Use —prerelease for non-typed release candidate versions

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -158,7 +158,7 @@ if [ "$IS_RELEASE_CANDIDATE" -eq 1 ]; then
     # increment only the prerelease version if necessary, e.g. 
     # 1.2.3-rc.0 -> 1.2.3-rc.1
     # 1.2.3 -> 1.2.3-rc.0
-    yarn version --preid=rc
+    yarn version --prerelease --preid=rc
   else
     # always increment the main version, e.g. 
     # patch: 1.2.3-rc.0 -> 1.2.4-rc.0


### PR DESCRIPTION
### Summary & motivation
The `--prerelease` flag is necessary to automatically increment the prerelease version, even though there is a preid. 

### Testing & documentation
Did some quick testing of the semantics in a test repo
