### PR TITLE
Set up version pinning

### DIFF
--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import {RELEASE_TRAIN} from './shared';
 
-const SCRIPT_SELECTOR = 'script[src^="https://js.stripe.com/v3"]';
+const SCRIPT_SRC =
+  RELEASE_TRAIN === 'v3'
+    ? `https://js.stripe.com/v3`
+    : `https://js.stripe.com/acacia/stripe.js`;
+const SCRIPT_SELECTOR = `script[src^="${SCRIPT_SRC}"]`;
 
 describe('pure module', () => {
   beforeEach(() => {
@@ -43,7 +48,7 @@ describe('pure module', () => {
 
     expect(
       document.querySelector(
-        'script[src^="https://js.stripe.com/v3?advancedFraudSignals=false"]'
+        `script[src^="${SCRIPT_SRC}?advancedFraudSignals=false"]`
       )
     ).not.toBe(null);
   });
@@ -58,7 +63,7 @@ describe('pure module', () => {
 
   test('it should warn when calling loadStripe if a script already exists when parameters are set', () => {
     const script = document.createElement('script');
-    script.src = 'https://js.stripe.com/v3';
+    script.src = SCRIPT_SRC;
     document.body.appendChild(script);
 
     const {loadStripe} = require('./pure');
@@ -76,7 +81,7 @@ describe('pure module', () => {
     loadStripe.setLoadParameters({advancedFraudSignals: true});
 
     const script = document.createElement('script');
-    script.src = 'https://js.stripe.com/v3';
+    script.src = SCRIPT_SRC;
     document.body.appendChild(script);
 
     loadStripe('pk_test_123');
@@ -102,7 +107,7 @@ describe('pure module', () => {
 
   test('it should not warn when a script already exists if parameters are not set', () => {
     const script = document.createElement('script');
-    script.src = 'https://js.stripe.com/v3';
+    script.src = SCRIPT_SRC;
     document.body.appendChild(script);
 
     const {loadStripe} = require('./pure');

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -179,7 +179,7 @@ export const initStripe = (
   const expectedVersion = RELEASE_TRAIN;
   if (isTestKey && version !== expectedVersion) {
     console.warn(
-      `Stripe.js@${version} was loaded on the page, but @stripe/stripe-js@${_VERSION} expected Stripe.js@${expectedVersion}. This may result in unexpected behavior.`
+      `Stripe.js@${version} was loaded on the page, but @stripe/stripe-js@${_VERSION} expected Stripe.js@${expectedVersion}. This may result in unexpected behavior. For more information see https://docs.stripe.com/sdks/stripejs-versioning`
     );
   }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,8 +12,17 @@ export interface LoadParams {
 // containing the package.json version
 declare const _VERSION: string;
 
+export const RELEASE_TRAIN = 'v3';
+
+const runtimeVersionToUrlVersion = (version: string | number) =>
+  version === 3 ? 'v3' : version;
+
 const ORIGIN = 'https://js.stripe.com';
-const STRIPE_JS_URL = `${ORIGIN}/v3`;
+const STRIPE_JS_URL =
+  RELEASE_TRAIN === 'v3'
+    ? `${ORIGIN}/v3`
+    : `${ORIGIN}/${RELEASE_TRAIN}/stripe.js`;
+
 const V3_URL_REGEX = /^https:\/\/js\.stripe\.com\/v3\/?(\?.*)?$/;
 const STRIPE_JS_URL_REGEX = /^https:\/\/js\.stripe\.com\/(v3|[a-z]+)\/stripe\.js(\?.*)?$/;
 const EXISTING_SCRIPT_MESSAGE =
@@ -160,6 +169,18 @@ export const initStripe = (
 ): Stripe | null => {
   if (maybeStripe === null) {
     return null;
+  }
+
+  const pk = args[0];
+  const isTestKey = pk.match(/^pk_test/);
+
+  // @ts-expect-error this is not publicly typed
+  const version = runtimeVersionToUrlVersion(maybeStripe.version);
+  const expectedVersion = RELEASE_TRAIN;
+  if (isTestKey && version !== expectedVersion) {
+    console.warn(
+      `Stripe.js@${version} was loaded on the page, but @stripe/stripe-js@${_VERSION} expected Stripe.js@${expectedVersion}. This may result in unexpected behavior.`
+    );
   }
 
   const stripe = maybeStripe.apply(undefined, args);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -179,7 +179,7 @@ export const initStripe = (
   const expectedVersion = RELEASE_TRAIN;
   if (isTestKey && version !== expectedVersion) {
     console.warn(
-      `Stripe.js@${version} was loaded on the page, but @stripe/stripe-js@${_VERSION} expected Stripe.js@${expectedVersion}. This may result in unexpected behavior. For more information see https://docs.stripe.com/sdks/stripejs-versioning`
+      `Stripe.js@${version} was loaded on the page, but @stripe/stripe-js@${_VERSION} expected Stripe.js@${expectedVersion}. This may result in unexpected behavior. For more information, see https://docs.stripe.com/sdks/stripejs-versioning`
     );
   }
 

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,0 +1,6 @@
+import {RELEASE_TRAIN} from './shared';
+
+export const SCRIPT_SRC =
+  RELEASE_TRAIN === 'v3'
+    ? `https://js.stripe.com/v3`
+    : `https://js.stripe.com/${RELEASE_TRAIN}/stripe.js`;


### PR DESCRIPTION
### Summary & motivation
This change sets up version pinning, which will always point `@stripe/stripe-js` to a specific version of Stripe.js which we can update as new versions are released.

### Testing & documentation
Tested payments on with `RELEASE_TRAIN=v3` and `RELEASE_TRAIN=acacia`. 

Tested the warnings with a `v3` script tag when `acacia` was expected:
<img width="483" alt="Screenshot 2025-03-06 at 11 09 04 AM" src="https://github.com/user-attachments/assets/648204fd-e228-47dc-9ecb-a47c0adb63d4" />

Tested the warnings with an `acacia` script tag when `v3` was expected:
<img width="481" alt="Screenshot 2025-03-06 at 11 07 55 AM" src="https://github.com/user-attachments/assets/9cf3b991-7e26-4d45-a614-88664b99b6db" />

### Release
I will release this change as-is in a minor version bump. Then, I will remove the `v3` branch and publish a release candidate for a major version that points to `acacia`.
