### PR TITLE
Set up acacia release candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",
-  "releaseCandidate": false,
+  "releaseCandidate": true,
   "scripts": {
     "test": "yarn lint && yarn test:unit && yarn test:package-types && yarn test:types && yarn typecheck",
     "test:unit": "jest",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,4 @@
 import {SCRIPT_SRC} from './testUtils';
-import {RELEASE_TRAIN} from './shared';
 /* eslint-disable @typescript-eslint/no-var-requires */
 
 const dispatchScriptEvent = (eventType: string): void => {
@@ -48,22 +47,6 @@ describe('Stripe module loader', () => {
   });
 
   describe('does not inject a duplicate script when one is already present', () => {
-    if (RELEASE_TRAIN === 'v3') {
-      test('when the script does not have a trailing slash', () => {
-        require('./index');
-
-        const script = document.createElement('script');
-        script.src = 'https://js.stripe.com/v3';
-        document.body.appendChild(script);
-
-        return Promise.resolve().then(() => {
-          expect(
-            document.querySelectorAll(`script[src="${SCRIPT_SRC}"]`)
-          ).toHaveLength(1);
-        });
-      });
-    }
-
     test('when the script has a trailing slash', () => {
       require('./index');
 

--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import {RELEASE_TRAIN} from './shared';
 
-const SCRIPT_SRC =
-  RELEASE_TRAIN === 'v3'
-    ? `https://js.stripe.com/v3`
-    : `https://js.stripe.com/acacia/stripe.js`;
+const SCRIPT_SRC = `https://js.stripe.com/${RELEASE_TRAIN}/stripe.js`;
 const SCRIPT_SELECTOR = `script[src^="${SCRIPT_SRC}"]`;
 
 describe('pure module', () => {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,16 +12,13 @@ export interface LoadParams {
 // containing the package.json version
 declare const _VERSION: string;
 
-export const RELEASE_TRAIN = 'v3';
+export const RELEASE_TRAIN = 'acacia';
 
 const runtimeVersionToUrlVersion = (version: string | number) =>
   version === 3 ? 'v3' : version;
 
 const ORIGIN = 'https://js.stripe.com';
-const STRIPE_JS_URL =
-  RELEASE_TRAIN === 'v3'
-    ? `${ORIGIN}/v3`
-    : `${ORIGIN}/${RELEASE_TRAIN}/stripe.js`;
+const STRIPE_JS_URL = `${ORIGIN}/${RELEASE_TRAIN}/stripe.js`;
 
 const V3_URL_REGEX = /^https:\/\/js\.stripe\.com\/v3\/?(\?.*)?$/;
 const STRIPE_JS_URL_REGEX = /^https:\/\/js\.stripe\.com\/(v3|[a-z]+)\/stripe\.js(\?.*)?$/;

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,6 +1,3 @@
 import {RELEASE_TRAIN} from './shared';
 
-export const SCRIPT_SRC =
-  RELEASE_TRAIN === 'v3'
-    ? `https://js.stripe.com/v3`
-    : `https://js.stripe.com/${RELEASE_TRAIN}/stripe.js`;
+export const SCRIPT_SRC = `https://js.stripe.com/${RELEASE_TRAIN}/stripe.js`;


### PR DESCRIPTION
### Summary & motivation
This change has two core parts:
* `RELEASE_TRAIN = acacia`
* `releaseCandidate: true`

All the other changes are downstream of the RELEASE_TRAIN change.

### Testing & documentation
On the example server, verified:
* I could make a payment
* `Stripe.version == 'acacia'`
