### PR TITLE
Acacia (v6) GA

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",
-  "releaseCandidate": true,
+  "releaseCandidate": false,
   "scripts": {
     "test": "yarn lint && yarn test:unit && yarn test:package-types && yarn test:types && yarn typecheck",
     "test:unit": "jest",


### PR DESCRIPTION
### Summary & motivation
This change will cut over `@stripe/stripe-js@6` to GA. v6 points to Stripe.js `acacia`.

### Testing & documentation
Testing is done on 6.0.0-rc.0
