### PR TITLE
Add types for Elements with Checkout Session beta 6

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -484,11 +484,14 @@ elements.create('paymentMethodMessaging', {
   paymentMethodOrder: ['invalid_type'],
 });
 
-const checkout = await stripe.initCheckout({
-  // @ts-expect-error Object literal may only specify known properties, and 'clientSecret' does not exist in type 'StripeCheckoutOptions'.
-  clientSecret: 'cs_test_foo',
-});
-// @ts-expect-error Property 'createElement' does not exist on type 'StripeCheckout'.
-checkout.createElement('payment');
-// @ts-expect-error Type 'StripeCheckoutAmount' is not assignable to type 'number'.
-const subtotal: number = checkout.session().total.subtotal;
+stripe
+  .initCheckout({
+    // @ts-expect-error Object literal may only specify known properties, and 'clientSecret' does not exist in type 'StripeCheckoutOptions'.
+    clientSecret: 'cs_test_foo',
+  })
+  .then((checkout) => {
+    // @ts-expect-error Property 'createElement' does not exist on type 'StripeCheckout'.
+    checkout.createElement('payment');
+    // @ts-expect-error Type 'StripeCheckoutAmount' is not assignable to type 'number'.
+    const subtotal: number = checkout.session().total.subtotal;
+  });

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -483,3 +483,12 @@ elements.create('paymentMethodMessaging', {
   currency: 'USD',
   paymentMethodOrder: ['invalid_type'],
 });
+
+const checkout = await stripe.initCheckout({
+  // @ts-expect-error Object literal may only specify known properties, and 'clientSecret' does not exist in type 'StripeCheckoutOptions'.
+  clientSecret: 'cs_test_foo',
+});
+// @ts-expect-error Property 'createElement' does not exist on type 'StripeCheckout'.
+checkout.createElement('payment');
+// @ts-expect-error Type 'StripeCheckoutAmount' is not assignable to type 'number'.
+const subtotal: number = checkout.session().total.subtotal;

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3714,21 +3714,24 @@ stripe.createEphemeralKeyNonce({
   issuingCard: '',
 });
 
-const checkout = await stripe.initCheckout({
-  fetchClientSecret: async () => 'cs_test_foo',
-});
-const checkoutPaymentElement: StripePaymentElement = checkout.createPaymentElement();
-checkout.getPaymentElement();
-const checkoutAddressElement: StripeAddressElement = checkout.createBillingAddressElement();
-checkout.getBillingAddressElement();
-checkout.applyPromotionCode('code');
-const {
-  minorUnitsAmountDivisor,
-  lineItems,
-  total: {
-    taxExclusive: {amount, minorUnitsAmount},
-  },
-} = checkout.session();
-const {
-  subtotal: {amount: _, minorUnitsAmount: __},
-} = lineItems[0];
+stripe
+  .initCheckout({
+    fetchClientSecret: async () => 'cs_test_foo',
+  })
+  .then((checkout) => {
+    const checkoutPaymentElement: StripePaymentElement = checkout.createPaymentElement();
+    checkout.getPaymentElement();
+    const checkoutAddressElement: StripeAddressElement = checkout.createBillingAddressElement();
+    checkout.getBillingAddressElement();
+    checkout.applyPromotionCode('code');
+    const {
+      minorUnitsAmountDivisor,
+      lineItems,
+      total: {
+        taxExclusive: {amount, minorUnitsAmount},
+      },
+    } = checkout.session();
+    const {
+      subtotal: {amount: _, minorUnitsAmount: __},
+    } = lineItems[0];
+  });

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3713,3 +3713,22 @@ issuingCopyButtonElement.update({
 stripe.createEphemeralKeyNonce({
   issuingCard: '',
 });
+
+const checkout = await stripe.initCheckout({
+  fetchClientSecret: async () => 'cs_test_foo',
+});
+const checkoutPaymentElement: StripePaymentElement = checkout.createPaymentElement();
+checkout.getPaymentElement();
+const checkoutAddressElement: StripeAddressElement = checkout.createBillingAddressElement();
+checkout.getBillingAddressElement();
+checkout.applyPromotionCode('code');
+const {
+  minorUnitsAmountDivisor,
+  lineItems,
+  total: {
+    taxExclusive: {amount, minorUnitsAmount},
+  },
+} = checkout.session();
+const {
+  subtotal: {amount: _, minorUnitsAmount: __},
+} = lineItems[0];


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds in our type changes for EwCS beta 6:
* Changes how amounts work
* Adds in `total` to line item
* Changes `clientSecret` to `fetchClientSecret`
* Removes `confirmationRequirements`
* Reworks createElement and getElement to be create*Element and get*Element

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Added in some tests to valid.ts and invalid.ts
