### PR TITLE
Setup basil release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pinned versions are as follows:
 | --------------------- | ------------- |
 | <6                    | v3            |
 | v6                    | acacia        |
+| v7                    | basil         |
 
 ## Usage
 
@@ -122,7 +123,7 @@ one. When you call `loadStripe`, it will use the existing script tag.
 
 ```html
 <!-- Somewhere in your site's <head> -->
-<script src="https://js.stripe.com/acacia/stripe.js" async></script>
+<script src="https://js.stripe.com/basil/stripe.js" async></script>
 ```
 
 ### Importing `loadStripe` without side effects

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",
-  "releaseCandidate": false,
+  "releaseCandidate": true,
   "scripts": {
     "test": "yarn lint && yarn test:unit && yarn test:package-types && yarn test:types && yarn typecheck",
     "test:unit": "jest",

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,7 +12,7 @@ export interface LoadParams {
 // containing the package.json version
 declare const _VERSION: string;
 
-export const RELEASE_TRAIN = 'acacia';
+export const RELEASE_TRAIN = 'basil';
 
 const runtimeVersionToUrlVersion = (version: string | number) =>
   version === 3 ? 'v3' : version;


### PR DESCRIPTION
### Summary & motivation

This change has four pieces parts:

- `RELEASE_TRAIN = basil`
- `releaseCandidate: true`
- Update readme example script tag to use basil
- Add basil to readme pinned version list