### PR TITLE
Remove CPM beta references, add CPM to elements.update types

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -259,6 +259,14 @@ elements.update({
   setup_future_usage: 'off_session',
   capture_method: 'automatic',
   payment_method_types: ['card'],
+  customPaymentMethods: [
+    {
+      id: 'cpmt_123',
+      options: {
+        type: 'static',
+      },
+    },
+  ],
 });
 
 elements.on('update-end', () => {});

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -677,10 +677,9 @@ interface BaseStripeElementsOptions {
   customerSessionClientSecret?: string;
 
   /**
-   * Requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
-   *
    * Display Custom Payment Methods in the Payment Element that you are already registered with.
+   *
+   * @docs https://docs.stripe.com/js/elements_object/create#stripe_elements-options-customPaymentMethods
    */
   customPaymentMethods?: CustomPaymentMethod[];
 }
@@ -918,6 +917,13 @@ export interface StripeElementsUpdateOptions {
    * Display saved PaymentMethods and Customer information.
    */
   customerSessionClientSecret?: string;
+
+  /**
+   * Display Custom Payment Methods in the Payment Element that you are already registered with.
+   *
+   * @docs https://docs.stripe.com/js/elements_object/update#elements_update-options-customPaymentMethods
+   */
+  customPaymentMethods?: CustomPaymentMethod[];
 }
 
 /*


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Updates comments on CPM types to remove references to the private preview now that the feature is publicly available. Also adds CPM to the `elements.update` types.

### Testing & documentation

Added to `tests/types/src/valid.ts`

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
