### PR TITLE
Fix test order in publish script

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -147,9 +147,6 @@ fi
 echo "Installing dependencies according to lockfile"
 yarn install --frozen-lockfile
 
-echo "Running tests"
-yarn run test
-
 echo "Bumping package.json $RELEASE_TYPE version and tagging commit"
 if [ "$IS_RELEASE_CANDIDATE" -eq 1 ]; then
   # The Github changelog is based on tag history, so do not create tags for beta versions
@@ -175,6 +172,9 @@ fi
 
 echo "Building"
 yarn run build
+
+echo "Running tests"
+yarn run test
 
 verify_commit_is_signed
 


### PR DESCRIPTION
### Summary & motivation
If the publish script is run without the dist folder, it fails. This commit moves the test section after the build to fix this problem.

Previously, I moved the build after the version so the new version is in the output, but I did not move the test section also. This meant the tests were running on an outdated build and would fail if a build had not been run.
