### PR TITLE
Add Klarna to ECE types

### DIFF
--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -194,7 +194,8 @@ export type ExpressPaymentType =
   | 'apple_pay'
   | 'amazon_pay'
   | 'link'
-  | 'paypal';
+  | 'paypal'
+  | 'klarna';
 
 export type ExpressCheckoutPartialAddress = {
   city: string;
@@ -261,6 +262,7 @@ export type ExpressCheckoutPaymentMethodsOption = {
   googlePay?: ExpressCheckoutPaymentMethodOptionWithAlways;
   link?: ExpressCheckoutPaymentMethodOption;
   paypal?: ExpressCheckoutPaymentMethodOption;
+  klarna?: ExpressCheckoutPaymentMethodOption;
 };
 
 export type ExpressCheckoutWalletsOption = {
@@ -446,6 +448,7 @@ export type AvailablePaymentMethods = {
   googlePay: boolean;
   link: boolean;
   paypal: boolean;
+  klarna: boolean;
 };
 
 export interface StripeExpressCheckoutElementReadyEvent {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Klarna is available publicly in the Express Checkout Element now so we can update the types

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

[Documentation](https://docs.stripe.com/elements/express-checkout-element) reflects this

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
