### PR TITLE
[breaking] Replace optional stripe.elements mode params with discriminated union

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -31,6 +31,15 @@ const elements = stripe.elements(options);
 // @ts-expect-error mode must be one of payment, setup, or subscription
 stripe.elements({mode: 'test'});
 
+// @ts-expect-error: currency is required when using mode
+stripe.elements({mode: 'payment'});
+
+// @ts-expect-error: amount is required when using mode='payment'
+stripe.elements({mode: 'payment', currency: 'usd'});
+
+// @ts-expect-error: amount is required when using mode='subscription'
+stripe.elements({mode: 'subscription', currency: 'usd'});
+
 elements.update({
   // @ts-expect-error: `clientSecret` is not updatable
   clientSecret: 'pk_foo_secret_bar',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -161,6 +161,12 @@ stripe.elements({
   on_behalf_of: 'acct_id',
 });
 
+stripe.elements({
+  mode: 'subscription',
+  currency: 'usd',
+  amount: 1000,
+});
+
 const elementsClientSecret: StripeElements = stripe.elements({
   fonts: [OPEN_SANS, AVENIR],
   locale: 'auto',
@@ -197,6 +203,7 @@ const elementsClientSecret: StripeElements = stripe.elements({
 const elementsPMCProvided = stripe.elements({
   mode: 'payment',
   currency: 'usd',
+  amount: 1000,
   setup_future_usage: 'off_session',
   capture_method: 'automatic',
   payment_method_configuration: 'pmc_12345678901234567890',

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -708,21 +708,11 @@ export interface StripeElementsOptionsClientSecret
   mode?: never;
 }
 
-export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
-  /**
-   * Whether the Payment Element will be used to create a PaymentIntent, SetupIntent, or Subscription.
-   */
-  mode?: 'payment' | 'setup' | 'subscription';
-
+interface StripeElementsOptionsModeBase extends BaseStripeElementsOptions {
   /**
    * Three character currency code (e.g., usd).
    */
-  currency?: string;
-
-  /**
-   * The amount to be charged. Shown in Apple Pay, Google Pay, or Buy now pay later UIs, and influences available payment methods.
-   */
-  amount?: number;
+  currency: string;
 
   /**
    * Indicates that you intend to make future payments with this PaymentIntent’s payment method.
@@ -827,6 +817,33 @@ export interface StripeElementsOptionsMode extends BaseStripeElementsOptions {
    */
   externalPaymentMethodTypes?: string[];
 }
+
+type StripeElementsOptionsModePayment = StripeElementsOptionsModeBase & {
+  mode: 'payment';
+
+  /**
+   * The amount to be charged. Shown in Apple Pay, Google Pay, or Buy now pay later UIs, and influences available payment methods.
+   */
+  amount: number;
+};
+
+type StripeElementsOptionsModeSubscription = StripeElementsOptionsModeBase & {
+  mode: 'subscription';
+
+  /**
+   * The amount to be charged. Shown in Apple Pay, Google Pay, or Buy now pay later UIs, and influences available payment methods.
+   */
+  amount: number;
+};
+
+type StripeElementsOptionsModeSetup = StripeElementsOptionsModeBase & {
+  mode: 'setup';
+};
+
+export type StripeElementsOptionsMode =
+  | StripeElementsOptionsModePayment
+  | StripeElementsOptionsModeSubscription
+  | StripeElementsOptionsModeSetup;
 
 export type StripeElementsOptions =
   | StripeElementsOptionsClientSecret


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Updates `StripeElementsOptionsMode` to use a discriminated union on `mode` for better type safety around conditionally required parameters `amount` and `currency`. See the updated tests for examples!

This is a breaking change because these type changes are not backwards compatible, although no behavior has actually changed (the types are just more accurate).

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Added valid and invalid test cases, and fixed a valid test case that was not actually valid but was caught by this change.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
