### PR TITLE
Add missing link PaymentWalletsOption type

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -502,7 +502,7 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
   wallets: {
     applePay: 'never',
     googlePay: 'auto',
-    link: 'auto'
+    link: 'auto',
   },
   layout: {
     type: 'accordion',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -502,6 +502,7 @@ const paymentElement: StripePaymentElement = elements.create('payment', {
   wallets: {
     applePay: 'never',
     googlePay: 'auto',
+    link: 'auto'
   },
   layout: {
     type: 'accordion',

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -216,6 +216,7 @@ export type PaymentWalletOption = 'auto' | 'never';
 export interface PaymentWalletsOption {
   applePay?: PaymentWalletOption;
   googlePay?: PaymentWalletOption;
+  link?: PaymentWalletOption;
 }
 
 export type Layout = 'tabs' | 'accordion' | 'auto';


### PR DESCRIPTION
### Summary & motivation
- `link` is a [wallet option](https://docs.stripe.com/js/elements_object/create_payment_element#payment_element_create-options-wallets-link) for Payment Element but it is absent from types. Update the types to reflect the documentation and real PE logic
- Not a breaking change

### Testing & documentation
- Update tests to show that `link` is a valid wallet option
