### PR TITLE
Add typings for confirmBilliePayment function

### DIFF
--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -20,6 +20,7 @@ export type CreatePaymentMethodData =
   | CreatePaymentMethodAuBecsDebitData
   | CreatePaymentMethodBacsDebitData
   | CreatePaymentMethodBancontactData
+  | CreatePaymentMethodBillieData
   | CreatePaymentMethodBlikData
   | CreatePaymentMethodBoletoData
   | CreatePaymentMethodCardData
@@ -94,6 +95,20 @@ export interface CreatePaymentMethodBancontactData
   billing_details: PaymentMethodCreateParams.BillingDetails & {
     name: string;
   };
+}
+
+export interface CreatePaymentMethodBillieData
+  extends PaymentMethodCreateParams {
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   */
+  type: 'billie';
+
+  /**
+    * Details about the Billie pament method. Currently there are no supported child attributes for this field, but sending an empty object is mandatory.
+    */
+  billie: {}; // eslint-disable-line @typescript-eslint/ban-types
 }
 
 export interface CreatePaymentMethodBlikData extends PaymentMethodCreateParams {
@@ -668,6 +683,38 @@ export interface ConfirmAlipayPaymentOptions {
 export interface ConfirmBancontactPaymentOptions {
   /**
    * Set this to `false` if you want to [manually handle the authorization redirect](https://stripe.com/docs/payments/bancontact#handle-redirect).
+   * Default is `true`.
+   */
+  handleActions?: boolean;
+}
+
+/**
+ * Data to be sent with a `stripe.confirmBilliePayment` request.
+ * Refer to the [Payment Intents API](https://stripe.com/docs/api/payment_intents/confirm) for a full list of parameters.
+ */
+export interface ConfirmBilliePaymentData extends PaymentIntentConfirmParams {
+  /**
+   * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
+   * This field is optional if a `PaymentMethod` has already been attached to this `PaymentIntent`.
+   *
+   * @recommended
+   */
+  payment_method?: string | Omit<CreatePaymentMethodBillieData, 'type'>;
+
+  /**
+   * The url your customer will be directed to after they complete authentication.
+   *
+   * @recommended
+   */
+  return_url?: string;
+}
+
+/**
+ * An options object to control the behavior of `stripe.confirmBilliePayment`.
+ */
+export interface ConfirmBilliePaymentOptions {
+  /**
+   * Set this to `false` if you want to [manually handle the authorization redirect](https://docs.stripe.com/payments/billie/accept-a-payment#handle-redirect).
    * Default is `true`.
    */
   handleActions?: boolean;

--- a/types/stripe-js/stripe.d.ts
+++ b/types/stripe-js/stripe.d.ts
@@ -210,6 +210,24 @@ export interface Stripe {
   ): Promise<PaymentIntentResult>;
 
   /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Use `stripe.confirmBilliePayment` in the [Billie Payments](https://stripe.com/docs/payments/billie) with Payment Methods flow when the customer submits your payment form.
+   * When called, it will confirm the [PaymentIntent](https://stripe.com/docs/api/payment_intents) with `data` you provide, and it will automatically redirect the customer to authorize the transaction.
+   * Once authorization is complete, the customer will be redirected back to your specified `return_url`.
+   *
+   * When you confirm a `PaymentIntent`, it needs to have an attached [PaymentMethod](https://stripe.com/docs/api/payment_methods).
+   * In addition to confirming the `PaymentIntent`, this method can automatically create and attach a new PaymentMethod for you.
+   * If you have already attached a `PaymentMethod` you can call this method without needing to provide any additional data.
+   */
+  confirmBilliePayment(
+    clientSecret: string,
+    data?: paymentIntents.ConfirmBilliePaymentData,
+    options?: paymentIntents.ConfirmBilliePaymentOptions
+  ): Promise<PaymentIntentResult>;
+
+  /**
    * Use `stripe.confirmBlikPayment` in the [BLIK Payments with Payment Methods](https://stripe.com/docs/payments/blik) flow when the customer submits your payment form.
    * When called, it will confirm the PaymentIntent with data you provide, and it will automatically prompt the customer to authorize the transaction.
    *


### PR DESCRIPTION
### Summary & motivation

This PR adds typings for the `confirmBilliePayment` function, used to confirm a [Billie payment](https://docs.stripe.com/payments/billie/accept-a-payment).

### Testing & documentation

I tested this change by using it in our test-environment web app, where I have now added support for Billie. In order to test, I ran `yarn build` and manually copied the `dist` folder into `node_modules/@stripe/stripe-js/dist`.

-----

Please let me know if there is anything else that needs to be done! We are trying to roll out Billie to one of our customers asap, and having them work on web (in addition to native) is one step on the way.