### PR TITLE
Add reject param to ECE click callback

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -1070,6 +1070,9 @@ expressCheckoutElement
       },
     });
   })
+  .on('click', (e: StripeExpressCheckoutElementClickEvent) => {
+    e.reject();
+  })
   .on('focus', (e: {elementType: 'expressCheckout'}) => {})
   .on('blur', (e: {elementType: 'expressCheckout'}) => {})
   .on('escape', (e: {elementType: 'expressCheckout'}) => {})

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -525,6 +525,12 @@ export interface StripeExpressCheckoutElementClickEvent {
    * This must be called within 1 second of the 'click' event being emitted.
    */
   resolve: (resolveDetails?: ClickResolveDetails) => void;
+
+  /**
+   * Callback to allow for cancellation of the payment interface.
+   * This must be called within 1 second of the 'click' event being emitted.
+   */
+  reject: () => void;
 }
 
 export interface StripeExpressCheckoutElementConfirmEvent {


### PR DESCRIPTION
### Summary & motivation

Updates a type interface for the ECE click callback param.

### Testing & documentation

I added a unit test and ran `yarn test`

Currently this is behind a beta flag.
