### PR TITLE
Add cardFunding to applePay paymentRequest option

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3499,6 +3499,7 @@ const paymentRequest: PaymentRequest = stripe.paymentRequest({
       },
       managementURL: 'https://atnnews.com/manage-subscription',
     },
+    cardFunding: 'supportsCredit',
   },
 });
 
@@ -3540,6 +3541,7 @@ paymentRequest.update({
       },
       managementURL: 'https://atnnews.com/manage-subscription',
     },
+    cardFunding: 'supportsDebit',
   },
 });
 

--- a/types/stripe-js/payment-request.d.ts
+++ b/types/stripe-js/payment-request.d.ts
@@ -159,7 +159,9 @@ export interface PaymentRequestUpdateOptions {
   /**
    * Specify the options to be used when the Apple Pay payment interface opens.
    */
-  applePay?: ApplePayOption;
+  applePay?: ApplePayOption & {
+    cardFunding?: 'supportsCredit' | 'supportsDebit';
+  };
 }
 
 /**
@@ -235,7 +237,9 @@ export interface PaymentRequestOptions {
   /**
    * Specify the options to be used when the Apple Pay payment interface opens.
    */
-  applePay?: ApplePayOption;
+  applePay?: ApplePayOption & {
+    cardFunding?: 'supportsCredit' | 'supportsDebit';
+  };
 
   /**
    * The Stripe account ID which is the business of record.


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Adds the new `cardFunding` parameter to Apple Pay in the `paymentRequest` object.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Added tests to `valid.ts`