### PR TITLE
Add cancel event to ECE + EwCS

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -471,6 +471,22 @@ export type StripeCheckoutExpressCheckoutElement = StripeElementBase & {
   ): StripeCheckoutExpressCheckoutElement;
 
   /**
+   * Triggered when a payment interface is dismissed (e.g., a buyer closes the payment interface)
+   */
+  on(
+    eventType: 'cancel',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCheckoutExpressCheckoutElement;
+  once(
+    eventType: 'cancel',
+    handler: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCheckoutExpressCheckoutElement;
+  off(
+    eventType: 'cancel',
+    handler?: (event: {elementType: 'expressCheckout'}) => any
+  ): StripeCheckoutExpressCheckoutElement;
+
+  /**
    * Updates the options the `ExpressCheckoutElement` was initialized with.
    * Updates are merged into the existing configuration.
    */


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
- `.on('cancel')` event is missing from ECE + EwCS
- Adding it in this PR

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
- No unit tests for EwCS
