### PR TITLE
Add types for new issuingAddToWalletButton

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -253,6 +253,23 @@ elements.create('issuingCardCopyButton', {
   toCopy: 'non_existent',
 });
 
+// @ts-expect-error `wallet` prop is required
+elements.create('issuingAddToWalletButton', {
+  nonce: '',
+  issuingCard: 'ic_123',
+  ephemeralKeySecret: '',
+  buttonHeight: 40,
+});
+
+// @ts-expect-error wallet must be 'apple'
+elements.create('issuingAddToWalletButton', {
+  wallet: 'google',
+  nonce: '',
+  issuingCard: 'ic_123',
+  ephemeralKeySecret: '',
+  buttonHeight: 40,
+});
+
 // @ts-expect-error: `white-outline` is only supported by apple pay
 elements.create('expressCheckout', {
   buttonTheme: {

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -253,17 +253,12 @@ elements.create('issuingCardCopyButton', {
   toCopy: 'non_existent',
 });
 
-// @ts-expect-error `wallet` prop is required
-elements.create('issuingAddToWalletButton', {
-  nonce: '',
-  issuingCard: 'ic_123',
-  ephemeralKeySecret: '',
-  buttonHeight: 40,
-});
+// @ts-expect-error `issuingAddToWalletButton` is not available yet
+elements.create('issuingAddToWalletButton');
 
-// @ts-expect-error wallet must be 'apple'
+// @ts-expect-error `issuingAddToWalletButton` is not available yet, despite all correct options
 elements.create('issuingAddToWalletButton', {
-  wallet: 'google',
+  wallet: 'apple',
   nonce: '',
   issuingCard: 'ic_123',
   ephemeralKeySecret: '',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -58,6 +58,8 @@ import {
   StripeTaxIdElement,
   ExternalTaxIdType,
   TaxIdType,
+  StripeIssuingAddToWalletButtonElementOptions,
+  StripeIssuingAddToWalletButtonElement,
 } from '../../../types';
 
 const stripePromise: Promise<Stripe | null> = loadStripe('');
@@ -3690,16 +3692,16 @@ paymentRequest.on(
   }
 );
 
-const issuingAddToWalletButtonElement = elements.create(
-  'issuingAddToWalletButton',
-  {
-    issuingCard: '',
-    nonce: '',
-    ephemeralKeySecret: '',
-    wallet: 'apple',
-    buttonHeight: 44,
-  }
-);
+declare const issuingAddToWalletButtonElement: StripeIssuingAddToWalletButtonElement;
+declare const issuingAddToWalletButtonOptions: StripeIssuingAddToWalletButtonElementOptions;
+
+const {
+  buttonHeight,
+  wallet,
+  issuingCard,
+  nonce,
+  ephemeralKeySecret,
+} = issuingAddToWalletButtonOptions;
 
 issuingAddToWalletButtonElement.mount('#bogus-container');
 issuingAddToWalletButtonElement.update({

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3690,6 +3690,30 @@ paymentRequest.on(
   }
 );
 
+const issuingAddToWalletButtonElement = elements.create(
+  'issuingAddToWalletButton',
+  {
+    issuingCard: '',
+    nonce: '',
+    ephemeralKeySecret: '',
+    wallet: 'apple',
+    buttonHeight: 44,
+  }
+);
+
+issuingAddToWalletButtonElement.mount('#bogus-container');
+issuingAddToWalletButtonElement.update({
+  buttonHeight: 44,
+});
+
+issuingAddToWalletButtonElement.on('click', () => {});
+issuingAddToWalletButtonElement.once('click', () => {});
+issuingAddToWalletButtonElement.off('click', () => {});
+
+issuingAddToWalletButtonElement.on('success', () => {});
+issuingAddToWalletButtonElement.once('success', () => {});
+issuingAddToWalletButtonElement.off('success', () => {});
+
 const issuingCardElement = elements.create('issuingCardNumberDisplay', {
   issuingCard: '',
   nonce: '',

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -50,6 +50,8 @@ import {
   StripeExpressCheckoutElementOptions,
   StripeAddressElementGetElementOptions,
   StripeTaxIdElement,
+  StripeIssuingAddToWalletButtonElementOptions,
+  StripeIssuingAddToWalletButtonElement,
 } from './elements';
 import {StripeError} from './stripe';
 
@@ -443,6 +445,17 @@ export interface StripeElements {
   /////////////////////////////
   /// issuing
   /////////////////////////////
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Creates an `issuingAddToWalletButton` Element.
+   */
+  create(
+    elementType: 'issuingAddToWalletButton',
+    options: StripeIssuingAddToWalletButtonElementOptions
+  ): StripeIssuingAddToWalletButtonElement;
 
   /**
    * Creates an `issuingCardNumberDisplay` Element

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -50,8 +50,6 @@ import {
   StripeExpressCheckoutElementOptions,
   StripeAddressElementGetElementOptions,
   StripeTaxIdElement,
-  StripeIssuingAddToWalletButtonElementOptions,
-  StripeIssuingAddToWalletButtonElement,
 } from './elements';
 import {StripeError} from './stripe';
 
@@ -445,17 +443,6 @@ export interface StripeElements {
   /////////////////////////////
   /// issuing
   /////////////////////////////
-
-  /**
-   * Requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
-   *
-   * Creates an `issuingAddToWalletButton` Element.
-   */
-  create(
-    elementType: 'issuingAddToWalletButton',
-    options: StripeIssuingAddToWalletButtonElementOptions
-  ): StripeIssuingAddToWalletButtonElement;
 
   /**
    * Creates an `issuingCardNumberDisplay` Element

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -534,7 +534,8 @@ export type StripeElementType =
   | 'issuingCardExpiryDisplay'
   | 'issuingCardPinDisplay'
   | 'issuingCardCopyButton'
-  | 'taxId';
+  | 'taxId'
+  | 'issuingAddToWalletButton';
 
 export type StripeElement =
   | StripeAddressElement

--- a/types/stripe-js/elements/issuing/index.d.ts
+++ b/types/stripe-js/elements/issuing/index.d.ts
@@ -1,3 +1,4 @@
+export * from './issuing-add-to-wallet-button';
 export * from './issuing-card-number-display';
 export * from './issuing-card-cvc-display';
 export * from './issuing-card-expiry-display';

--- a/types/stripe-js/elements/issuing/issuing-add-to-wallet-button.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-add-to-wallet-button.d.ts
@@ -51,21 +51,21 @@ export interface StripeIssuingAddToWalletButtonElementOptions {
    * The secret component of the ephemeral key with which to authenticate this sensitive
    * card provisioning request
    */
-  ephemeralKeySecret?: string;
+  ephemeralKeySecret: string;
 
   /**
    * The nonce used to mint the ephemeral key provided in `ephemeralKeySecret`
    */
-  nonce?: string;
-
-  /**
-   * The height of the button in pixels.
-   * Must be between 36px and 55px.
-   */
-  buttonHeight?: number;
+  nonce: string;
 
   /**
    * The type of Add to Wallet button to display. For now, only 'apple' is supported.
    */
   wallet: 'apple';
+
+  /**
+   * The height of the button in pixels. Defaults to 44px.
+   * Must be between 36px and 55px.
+   */
+  buttonHeight?: number;
 }

--- a/types/stripe-js/elements/issuing/issuing-add-to-wallet-button.d.ts
+++ b/types/stripe-js/elements/issuing/issuing-add-to-wallet-button.d.ts
@@ -1,0 +1,71 @@
+import {StripeElementBase} from '../base';
+
+export type StripeIssuingAddToWalletButtonElement = StripeElementBase & {
+  /**
+   * Triggered when the element is clicked.
+   */
+  on(
+    eventType: 'click',
+    // TODO find
+    handler: (event: {elementType: 'issuingAddToWalletButton'}) => any
+  ): StripeIssuingAddToWalletButtonElement;
+  once(
+    eventType: 'click',
+    handler: (event: {elementType: 'issuingAddToWalletButton'}) => any
+  ): StripeIssuingAddToWalletButtonElement;
+  off(
+    eventType: 'click',
+    handler?: (event: {elementType: 'issuingAddToWalletButton'}) => any
+  ): StripeIssuingAddToWalletButtonElement;
+
+  /**
+   * Triggered when add to wallet flow is complete.
+   */
+  on(
+    eventType: 'success',
+    handler: (event: {elementType: 'issuingAddToWalletButton'}) => any
+  ): StripeIssuingAddToWalletButtonElement;
+  once(
+    eventType: 'success',
+    handler: (event: {elementType: 'issuingAddToWalletButton'}) => any
+  ): StripeIssuingAddToWalletButtonElement;
+  off(
+    eventType: 'success',
+    handler?: (event: {elementType: 'issuingAddToWalletButton'}) => any
+  ): StripeIssuingAddToWalletButtonElement;
+
+  /**
+   * Updates the options the `IssuingAddToWalletButtonElement` was initialized with.
+   * Updates are merged into the existing configuration.
+   */
+  update(options: Partial<StripeIssuingAddToWalletButtonElementOptions>): void;
+};
+
+export interface StripeIssuingAddToWalletButtonElementOptions {
+  /**
+   * The token (e.g. `ic_abc123`) of the issued card to add to the user's wallet.
+   */
+  issuingCard: string;
+
+  /**
+   * The secret component of the ephemeral key with which to authenticate this sensitive
+   * card provisioning request
+   */
+  ephemeralKeySecret?: string;
+
+  /**
+   * The nonce used to mint the ephemeral key provided in `ephemeralKeySecret`
+   */
+  nonce?: string;
+
+  /**
+   * The height of the button in pixels.
+   * Must be between 36px and 55px.
+   */
+  buttonHeight?: number;
+
+  /**
+   * The type of Add to Wallet button to display. For now, only 'apple' is supported.
+   */
+  wallet: 'apple';
+}


### PR DESCRIPTION
### Summary & motivation
<!-- Simple summary of what the code does or what you have changed. -->
Add types for new `issuingAddToWalletButton` in public beta. 

I did not add `issuingAddToWalletButton` type support in the create() call, since it's still behind beta flag.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->
* Confirmed that 'issuingAddToWalletButton' is not exposed during `create`
* Confirmed type support for Options and Events, once a beta user `ts-ignore`'s the create() call.

[See API review](https://docs.google.com/document/d/135DsQ0t2UoJ9RXUHIv0Ef3sblBxmXHHnwRC_KwLKVcg/edit?tab=t.0#heading=h.qarkdnrrshe0)

<!-- If this is an API change, have you updated the documentation? -->
No documentation updates yet during beta.

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
