### PR TITLE
Adding SPM option to StripeCheckoutElementsOptions

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3851,3 +3851,42 @@ stripe
       const {error} = result;
     }
   });
+
+// savedPaymentMethod variations for initCheckout:
+stripe.initCheckout({
+  fetchClientSecret: async () => 'cs_test_foo',
+  elementsOptions: {
+    savedPaymentMethod: {
+      enableSave: 'never',
+      enableRedisplay: 'auto',
+    },
+  },
+});
+
+// only enableSave
+stripe.initCheckout({
+  fetchClientSecret: async () => 'cs_test_foo',
+  elementsOptions: {
+    savedPaymentMethod: {
+      enableSave: 'auto',
+    },
+  },
+});
+
+// only enableRedisplay
+stripe.initCheckout({
+  fetchClientSecret: async () => 'cs_test_foo',
+  elementsOptions: {
+    savedPaymentMethod: {
+      enableRedisplay: 'never',
+    },
+  },
+});
+
+// empty savedPaymentMethod object
+stripe.initCheckout({
+  fetchClientSecret: async () => 'cs_test_foo',
+  elementsOptions: {
+    savedPaymentMethod: {},
+  },
+});

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -19,15 +19,16 @@ import {
   StripeTaxIdElementOptions,
 } from './elements';
 
-/**
- * Requires beta access:
- * Contact [Stripe support](https://support.stripe.com/) for more information.
- */
+type SavedPaymentMethodOption = {
+  enableSave?: 'auto' | 'never';
+  enableRedisplay?: 'auto' | 'never';
+};
 
 export interface StripeCheckoutElementsOptions {
   appearance?: Appearance;
   loader?: 'auto' | 'always' | 'never';
   fonts?: Array<CssFontSource | CustomFontSource>;
+  savedPaymentMethod?: SavedPaymentMethodOption;
 }
 
 export interface StripeCheckoutOptions {


### PR DESCRIPTION
### Summary & motivation

Adding SavedPaymentMethod options to `StripeCheckoutElementsOptions`

### Testing & documentation

Updated `valid.ts` file
