### PR TITLE
chore: add fonts to elements.update() types

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -870,6 +870,11 @@ export interface StripeElementsUpdateOptions {
   locale?: StripeElementLocale;
 
   /**
+   * An array of custom fonts to update, which elements created from the `Elements` object can use.
+   */
+  fonts?: Array<CssFontSource | CustomFontSource>;
+
+  /**
    * Match the design of your site with the appearance option.
    * The layout of each Element stays consistent, but you can modify colors, fonts, borders, padding, and more.
    *


### PR DESCRIPTION
### Summary & motivation

Updated `elements.update()` to add `fonts: [...]` as a valid option.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
