### PR TITLE
Add `allow_redisplay` to 'PaymentMethodCreateParams' Type

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -2593,6 +2593,7 @@ stripe.createPaymentMethod({
     billing_details: {
       name: 'Jenny Rosen',
     },
+    allow_redisplay: 'always',
   },
 });
 

--- a/types/api/payment-methods.d.ts
+++ b/types/api/payment-methods.d.ts
@@ -365,6 +365,11 @@ export interface PaymentMethodCreateParams {
    * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type. Required unless `payment_method` is specified (see the [Cloning PaymentMethods](https://stripe.com/docs/payments/payment-methods/connect#cloning-payment-methods) guide)
    */
   type?: string;
+
+  /**
+   * Specifies if the PaymentMethod should be redisplayed when using the Saved Payment Method feature.
+   */
+  allow_redisplay?: 'always' | 'limited' | 'unspecified';
 }
 
 export interface CreatePaymentMethodFromElements {


### PR DESCRIPTION
### Summary & motivation

Similarly to https://github.com/stripe/stripe-js/pull/572, this also adds the `allow_redisplay` parameter to `PaymentMethodCreateParams`. `params` are forward to the PaymentMethod API, and the corresponding parameter documentation is [here](https://docs.stripe.com/api/payment_methods/create#create_payment_method-allow_redisplay).

### Testing & documentation

I have added a test to `valid.ts`, and tested this it against my project where I am using this value.
