### PR TITLE
Switch to clover release candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",
-  "releaseCandidate": false,
+  "releaseCandidate": true,
   "scripts": {
     "test": "yarn lint && yarn test:unit && yarn test:package-types && yarn test:types && yarn typecheck",
     "test:unit": "jest",

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,7 +12,7 @@ export interface LoadParams {
 // containing the package.json version
 declare const _VERSION: string;
 
-export const RELEASE_TRAIN = 'basil';
+export const RELEASE_TRAIN = 'clover';
 
 const runtimeVersionToUrlVersion = (version: string | number) =>
   version === 3 ? 'v3' : version;


### PR DESCRIPTION
### Summary & motivation
Switch to the clover release candidate by updating the release train and `release_candidate` flag