### PR TITLE
Add Types for Condensed Inputs

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -1215,7 +1215,7 @@ export interface Appearance {
    * The style of labels associated with input fields to use for the Elements. Defaults to 'auto'.
    * @docs https://stripe.com/docs/stripe-js/appearance-api#labels
    */
-  labels?: 'auto' | 'above' | 'floating' | 'none';
+  labels?: 'auto' | 'above' | 'floating';
 
   /**
    * The style of input fields to use for the Elements. Defaults to 'spaced'.


### PR DESCRIPTION
### Summary & motivation

Adding new `inputs` and `labels` types within the Appearance API for condensed inputs.
* added `inputs`: `spaced` | `condensed`
* added `labels`: `auto`