### PR TITLE
Add Types for metadata field

### DIFF
--- a/types/api/confirmation-tokens.d.ts
+++ b/types/api/confirmation-tokens.d.ts
@@ -91,6 +91,7 @@ export interface ConfirmationTokenCreateParams {
     /**
      * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
      * Individual keys can be unset by posting an empty value to them
+     * @docs https://docs.stripe.com/metadata
      */
     metadata?: Record<string, string>;
   };

--- a/types/stripe-js/payment-intents.d.ts
+++ b/types/stripe-js/payment-intents.d.ts
@@ -572,6 +572,7 @@ export interface CollectBankAccountPaymentMethodData {
   /**
    * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
    * Individual keys can be unset by posting an empty value to them
+   * @docs https://docs.stripe.com/metadata
    */
   metadata?: Record<string, string>;
 }
@@ -1599,6 +1600,7 @@ export interface ConfirmPaymentData extends PaymentIntentConfirmParams {
     /**
      * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
      * Individual keys can be unset by posting an empty value to them
+     * @docs https://docs.stripe.com/metadata
      */
     metadata?: Record<string, string>;
   };

--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -49,6 +49,7 @@ export interface ConfirmSetupData extends SetupIntentConfirmParams {
     /**
      * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
      * Individual keys can be unset by posting an empty value to them
+     * @docs https://docs.stripe.com/metadata
      */
     metadata?: Record<string, string>;
   };


### PR DESCRIPTION
### Summary & motivation

Added some missing types for `payment_method_data` `metadata` field. described in documentation [here](https://docs.stripe.com/api/payment_intents/confirm#confirm_payment_intent-payment_method_data-metadata)
