### PR TITLE
Support expand on confirmAcssDebitSetup() in Stripe.js types

### DIFF
--- a/types/stripe-js/setup-intents.d.ts
+++ b/types/stripe-js/setup-intents.d.ts
@@ -245,6 +245,11 @@ export interface ConfirmBancontactSetupData extends SetupIntentConfirmParams {
  */
 export interface ConfirmAcssDebitSetupData extends SetupIntentConfirmParams {
   /**
+   * Specifies which fields in the response should be expanded.
+   */
+  expand?: Array<string>;
+
+  /**
    * Either the `id` of an existing [PaymentMethod](https://stripe.com/docs/api/payment_methods), or an object containing data to create a `PaymentMethod` with.
    * This field is optional if a `PaymentMethod` has already been attached to this `SetupIntent`.
    *


### PR DESCRIPTION
### Summary & motivation

Support `expand` on `confirmAcssDebitSetup()` in Stripe.js types

### Testing & documentation

Manually testing this change locally by overriding the types I installed and confirmed they fix the type error
