### PR TITLE
Update checkout.d.ts

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -342,7 +342,7 @@ export interface StripeCheckoutSession {
 export type StripeCheckoutPaymentElementOptions = {
   layout?: Layout | LayoutObject;
   paymentMethodOrder?: Array<string>;
-  readonly?: boolean;
+  readOnly?: boolean;
   terms?: TermsOption;
   fields?: FieldsOption;
 };


### PR DESCRIPTION
### Summary & motivation

Fix typo to correctly change the option from `readonly` to `readOnly`.
To match the types for PE:
https://github.com/stripe/stripe-js/blob/f7171c0f05b8b20f2abdb9a52f939f024cea3c21/types/stripe-js/elements/payment.d.ts#L259

### Testing & documentation

Manual
