### PR TITLE
Switch over to clover

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pinned versions are as follows:
 | <6                    | v3            |
 | v6                    | acacia        |
 | v7                    | basil         |
+| v8                    | clover        |
 
 ## Usage
 
@@ -123,7 +124,7 @@ one. When you call `loadStripe`, it will use the existing script tag.
 
 ```html
 <!-- Somewhere in your site's <head> -->
-<script src="https://js.stripe.com/basil/stripe.js" async></script>
+<script src="https://js.stripe.com/clover/stripe.js" async></script>
 ```
 
 ### Importing `loadStripe` without side effects

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "jsnext:main": "lib/index.mjs",
   "types": "lib/index.d.ts",
   "typings": "lib/index.d.ts",
-  "releaseCandidate": true,
+  "releaseCandidate": false,
   "scripts": {
     "test": "yarn lint && yarn test:unit && yarn test:package-types && yarn test:types && yarn typecheck",
     "test:unit": "jest",


### PR DESCRIPTION
### Summary & motivation
Releasing Stripe.js clover today. After merging this PR, we'll be able to run the publish script to switch from `8.0.0-rc.x -> 8.0.0`
