### PR TITLE
Add wallet type to Checkout Payment Element

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -17,6 +17,7 @@ import {
   StripeExpressCheckoutElementReadyEvent,
   StripeTaxIdElement,
   StripeTaxIdElementOptions,
+  PaymentWalletsOption,
 } from './elements';
 
 type SavedPaymentMethodOption = {
@@ -345,6 +346,7 @@ export type StripeCheckoutPaymentElementOptions = {
   readOnly?: boolean;
   terms?: TermsOption;
   fields?: FieldsOption;
+  wallets?: PaymentWalletsOption;
 };
 
 export type StripeCheckoutAddressElementOptions = {


### PR DESCRIPTION
### Summary & motivation

Adds the [wallets](https://docs.stripe.com/js/custom_checkout/create_payment_element#custom_checkout_create_payment_element-options-wallets) option to checkout types

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
