### PR TITLE
Add default billing/shipping address to checkout types

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -36,6 +36,10 @@ export interface StripeCheckoutElementsOptions {
 export interface StripeCheckoutOptions {
   clientSecret: Promise<string> | string;
   elementsOptions?: StripeCheckoutElementsOptions;
+  defaultValues?: {
+    billingAddress?: StripeCheckoutContact;
+    shippingAddress?: StripeCheckoutContact;
+  };
 }
 
 /* Elements with CheckoutSessions API types */


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds types to billingAddress and shippingAddress defaultValues when initializing checkout.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
