### PR TITLE
Fix master failing test:types

### DIFF
--- a/tests/types/scripts/test.mjs
+++ b/tests/types/scripts/test.mjs
@@ -25,10 +25,6 @@ const VERSIONS = [
 
 const TYPE_TESTS_DIR = `${__dirname}/..`;
 
-const rootPackageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
-
-const rootTypesNodeVersion = rootPackageJson.devDependencies?.['@types/node'];
-
 // Ensure working directory is test directory
 cd(TYPE_TESTS_DIR);
 
@@ -66,8 +62,9 @@ for (const version of VERSIONS) {
 
   // Temporary fix for TS 5.2 as https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73924/files
   // actually breaks with TS 5.2 and their npm is marking it as the tag for ts5.2.
+  // pin to latest working version of @types/node for TS 5.2.
   if (version === '5.2') {
-    tag = rootTypesNodeVersion;
+    tag = '24.10.3';
   }
 
   await $`yarn add -s --no-progress @types/node@${tag}`;


### PR DESCRIPTION
### Summary & motivation

From a recent change from @types/node at https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73924/files, they actually made it incompatible with their `25.0.0` version that they are still marking it with the tag `ts5.2`. Temporarily falling back to latest working version for `@types/node`.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Ran yarn test:types locally and it passed all ts versions.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
