### PR TITLE
Use stored manifest for ts testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:unit": "jest",
     "test:package-types": "attw --pack . --entrypoints ./lib ./pure",
     "test:types": "zx ./tests/types/scripts/test.mjs",
+    "update-ts-snapshot": "zx ./tests/types/scripts/update-ts-snapshot.mjs",
     "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-check",
     "typecheck": "tsc",
     "copy-types": "./scripts/copy-types",

--- a/tests/types/scripts/ts-version-snapshot.json
+++ b/tests/types/scripts/ts-version-snapshot.json
@@ -1,0 +1,134 @@
+[
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 9,
+      "patch": 3
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 8,
+      "patch": 3
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 7,
+      "patch": 3
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 6,
+      "patch": 3
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 5,
+      "patch": 4
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 4,
+      "patch": 5
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 3,
+      "patch": 3
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 2,
+      "patch": 2
+    },
+    "nodeTypes": {
+      "major": 25,
+      "minor": 0,
+      "patch": 3
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 1,
+      "patch": 6
+    },
+    "nodeTypes": {
+      "major": 24,
+      "minor": 1,
+      "patch": 0
+    }
+  },
+  {
+    "typescript": {
+      "major": 5,
+      "minor": 0,
+      "patch": 4
+    },
+    "nodeTypes": {
+      "major": 22,
+      "minor": 13,
+      "patch": 14
+    }
+  },
+  {
+    "typescript": {
+      "major": 4,
+      "minor": 9,
+      "patch": 5
+    },
+    "nodeTypes": {
+      "major": 22,
+      "minor": 9,
+      "patch": 3
+    }
+  }
+]

--- a/tests/types/scripts/update-ts-snapshot.mjs
+++ b/tests/types/scripts/update-ts-snapshot.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env zx
+
+import 'zx/globals';
+import fs from 'fs';
+import path from 'path';
+
+const allVersions = JSON.parse(await $`yarn info typescript versions --json`)
+  .data;
+const timestamps = JSON.parse(await $`yarn info typescript time --json`).data;
+const nodeTypesTags = JSON.parse(
+  await $`yarn info @types/node dist-tags --json`
+).data;
+
+const threeYearsAgo = Date.now() - 3 * 365 * 24 * 60 * 60 * 1000;
+
+const selectedVersions = allVersions
+  .filter((el) => el.match(/^\d+\.\d+\.\d+$/))
+  .reverse()
+  .filter((version) => {
+    const releaseDate = new Date(timestamps[version]).getTime();
+    return releaseDate > threeYearsAgo;
+  })
+  .map((tsVersion) => {
+    const parseVersion = (version) => {
+      const [major, minor, patch] = version.split('.');
+      return {
+        major: parseInt(major, 10),
+        minor: parseInt(minor, 10),
+        patch: parseInt(patch, 10),
+      };
+    };
+
+    const typescript = parseVersion(tsVersion);
+
+    const nodeTypesTag = `ts${typescript.major}.${typescript.minor}`;
+    const nodeTypes = parseVersion(nodeTypesTags[nodeTypesTag]);
+
+    return {
+      typescript,
+      nodeTypes,
+    };
+  })
+  .reduce((acc, release) => {
+    const {typescript} = release;
+    const key = `${typescript.major}.${typescript.minor}`;
+    if (!acc.has(key) || acc.get(key).patch < typescript.patch) {
+      acc.set(key, release);
+    }
+    return acc;
+  }, new Map())
+  .values();
+
+fs.writeFileSync(
+  path.join(__dirname, 'ts-version-snapshot.json'),
+  JSON.stringify(Array.from(selectedVersions), null, 2)
+);


### PR DESCRIPTION
### Summary & motivation
Our type tests have several issues this addresses:
1. It relies on the most recent versions and `@types/node` tags that can change and break our tests without any changes to Stripe.js
2. There is no systematic way to add new versions
3. There is no systematic way to remove old versions

These issues are solved with an `update-ts-snapshot.mjs` script that can lock in all the versions used at a particular time, so we control when the versions change. We can update this when we do major version releases for this package.

### Testing & documentation
`yarn run update-ts-snapshot && yarn test`