### PR TITLE
Add paymentMethodCreation type to BaseStripeElementsOptions

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -210,6 +210,7 @@ const elementsClientSecret: StripeElements = stripe.elements({
     },
   ],
   syncAddressCheckbox: 'shipping',
+  paymentMethodCreation: 'manual',
 });
 
 const elementsPMCProvided = stripe.elements({

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -715,6 +715,13 @@ interface BaseStripeElementsOptions {
    * @docs https://docs.stripe.com/js/elements_object/create#stripe_elements-options-syncAddressCheckbox
    */
   syncAddressCheckbox?: 'billing' | 'shipping' | 'none';
+
+  /**
+   * Allows PaymentMethods to be created from the Elements instance.
+   *
+   * @docs https://docs.stripe.com/js/elements_object/create#stripe_elements-options-paymentMethodCreation
+   */
+  paymentMethodCreation?: 'manual';
 }
 
 export interface StripeElementsOptionsClientSecret
@@ -826,11 +833,6 @@ interface StripeElementsOptionsModeBase extends BaseStripeElementsOptions {
    * @docs https://stripe.com/docs/connect/payment-method-configurations
    */
   payment_method_configuration?: string;
-
-  /**
-   * Allows PaymentMethods to be created from the Elements instance.
-   */
-  paymentMethodCreation?: 'manual';
 
   /**
    * Additional payment-method-specific options for configuring Payment Element behavior.


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds `paymentMethodCreation` type to `BaseStripeElementsOptions` because it's supported for both deferred intent and intent-first Elements integrations.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->

Updated tests.