### PR TITLE
Validate pk is string with helpful error message

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -169,6 +169,13 @@ export const initStripe = (
   }
 
   const pk = args[0];
+
+  if (typeof pk !== 'string') {
+    throw new Error(
+      `Expected publishable key to be of type string, got type ${typeof pk} instead.`
+    );
+  }
+
   const isTestKey = pk.match(/^pk_test/);
 
   // @ts-expect-error this is not publicly typed


### PR DESCRIPTION
### Summary & motivation

When a user passes in a pk that isn't a string, there isn't a clear error explaining the issue. Typescript should help prevent this issue, but it can also pop up easily with an environment variable that isn't defined, so this PR adds a more helpful message.

### Testing & documentation

This PR was tested with a basic app that calls `loadStripe(undefined)`.
<img width="878" height="45" alt="image" src="https://github.com/user-attachments/assets/8799317b-91a1-400e-8e37-fe26e8d82893" />
