### PR TITLE
Add syncAddressCheckbox to StripeCheckoutElementsOptions

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3846,6 +3846,7 @@ stripe.initCheckout({
       enableSave: 'never',
       enableRedisplay: 'auto',
     },
+    syncAddressCheckbox: 'billing',
   },
 });
 
@@ -3856,6 +3857,7 @@ stripe.initCheckout({
     savedPaymentMethod: {
       enableSave: 'auto',
     },
+    syncAddressCheckbox: 'shipping',
   },
 });
 
@@ -3866,6 +3868,7 @@ stripe.initCheckout({
     savedPaymentMethod: {
       enableRedisplay: 'never',
     },
+    syncAddressCheckbox: 'none',
   },
 });
 

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -31,6 +31,7 @@ export interface StripeCheckoutElementsOptions {
   loader?: 'auto' | 'always' | 'never';
   fonts?: Array<CssFontSource | CustomFontSource>;
   savedPaymentMethod?: SavedPaymentMethodOption;
+  syncAddressCheckbox?: 'billing' | 'shipping' | 'none';
 }
 
 export interface StripeCheckoutOptions {


### PR DESCRIPTION
### Summary & motivation
Adds support for syncAddressCheckbox to checkout

### Testing & documentation
Added to `tests/types/src/valid.ts`
