### PR TITLE
[breaking] Add a retry to the loader

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -110,6 +110,10 @@ describe('Stripe module loader', () => {
       await Promise.resolve();
       dispatchScriptEvent('error');
 
+      // Wait for the retry attempt to set up a new script element
+      await new Promise((resolve) => setTimeout(resolve));
+      dispatchScriptEvent('error');
+
       await expect(stripePromise).rejects.toEqual(
         new Error('Failed to load Stripe.js')
       );
@@ -124,6 +128,10 @@ describe('Stripe module loader', () => {
       await Promise.resolve();
       dispatchScriptEvent('load');
 
+      // Wait for the retry attempt to set up a new script element
+      await new Promise((resolve) => setTimeout(resolve));
+      dispatchScriptEvent('load');
+
       return expect(stripePromise).rejects.toEqual(
         new Error('Stripe.js not available')
       );
@@ -132,10 +140,14 @@ describe('Stripe module loader', () => {
     it('rejects on first load, and succeeds on second load resolving with Stripe object', async () => {
       const {loadStripe} = require(requirePath);
 
-      // start of first load, expect load failure
+      // start of first load, expect load failure (both initial attempt and retry fail)
       let stripePromise = loadStripe('pk_test_foo');
 
       await Promise.resolve();
+      dispatchScriptEvent('error');
+
+      // Wait for the retry attempt to set up a new script element
+      await new Promise((resolve) => setTimeout(resolve));
       dispatchScriptEvent('error');
 
       await expect(stripePromise).rejects.toEqual(
@@ -157,10 +169,13 @@ describe('Stripe module loader', () => {
     it('rejects on first load and second load but succeeds on third load resolving with Stripe object', async () => {
       const {loadStripe} = require(requirePath);
 
-      // start of first load, expect load failure
+      // start of first load, expect load failure (both initial attempt and retry fail)
       let stripePromise = loadStripe('pk_test_foo');
 
       await Promise.resolve();
+      dispatchScriptEvent('error');
+
+      await new Promise((resolve) => setTimeout(resolve));
       dispatchScriptEvent('error');
 
       await expect(stripePromise).rejects.toEqual(
@@ -169,10 +184,13 @@ describe('Stripe module loader', () => {
 
       expect(console.warn).not.toHaveBeenCalled();
 
-      // start of second load, expect load failure
+      // start of second load, expect load failure (both initial attempt and retry fail)
       stripePromise = loadStripe('pk_test_foo');
 
       await Promise.resolve();
+      dispatchScriptEvent('error');
+
+      await new Promise((resolve) => setTimeout(resolve));
       dispatchScriptEvent('error');
 
       await expect(stripePromise).rejects.toEqual(
@@ -193,10 +211,18 @@ describe('Stripe module loader', () => {
   });
 
   describe('loadStripe (index.ts)', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockReturnValue();
+    });
+
     it('does not cause unhandled rejects when the script fails', async () => {
       require('./index');
 
       await Promise.resolve();
+      dispatchScriptEvent('error');
+
+      // Wait for the retry attempt to set up a new script element
+      await new Promise((resolve) => setTimeout(resolve));
       dispatchScriptEvent('error');
 
       // Turn the task loop to make sure the internal promise handler has been invoked

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -137,6 +137,21 @@ describe('Stripe module loader', () => {
       );
     });
 
+    it('resolves with Stripe object when a single load failure is followed by a load success', async () => {
+      const {loadStripe} = require(requirePath);
+      const stripePromise = loadStripe('pk_test_foo');
+
+      await Promise.resolve();
+      dispatchScriptEvent('error');
+
+      // Wait for the retry attempt to set up a new script element
+      await new Promise((resolve) => setTimeout(resolve));
+      window.Stripe = jest.fn((key) => ({key})) as any;
+      dispatchScriptEvent('load');
+
+      await expect(stripePromise).resolves.toEqual({key: 'pk_test_foo'});
+    });
+
     it('rejects on first load, and succeeds on second load resolving with Stripe object', async () => {
       const {loadStripe} = require(requirePath);
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -103,60 +103,65 @@ export const loadScript = (
     return stripePromise;
   }
 
-  stripePromise = new Promise((resolve, reject) => {
-    if (typeof window === 'undefined' || typeof document === 'undefined') {
-      // Resolve to null when imported server side. This makes the module
-      // safe to import in an isomorphic code base.
-      resolve(null);
-      return;
-    }
-
-    if (window.Stripe && params) {
-      console.warn(EXISTING_SCRIPT_MESSAGE);
-    }
-
-    if (window.Stripe) {
-      resolve(window.Stripe);
-      return;
-    }
-
-    try {
-      let script = findScript();
-
-      if (script && params) {
-        console.warn(EXISTING_SCRIPT_MESSAGE);
-      } else if (!script) {
-        script = injectScript(params);
-      } else if (
-        script &&
-        onLoadListener !== null &&
-        onErrorListener !== null
-      ) {
-        // remove event listeners
-        script.removeEventListener('load', onLoadListener);
-        script.removeEventListener('error', onErrorListener);
-
-        // if script exists, but we are reloading due to an error,
-        // reload script to trigger 'load' event
-        script.parentNode?.removeChild(script);
-        script = injectScript(params);
+  const load = () =>
+    new Promise<StripeConstructor | null>((resolve, reject) => {
+      if (typeof window === 'undefined' || typeof document === 'undefined') {
+        // Resolve to null when imported server side. This makes the module
+        // safe to import in an isomorphic code base.
+        resolve(null);
+        return;
       }
 
-      onLoadListener = onLoad(resolve, reject);
-      onErrorListener = onError(reject);
-      script.addEventListener('load', onLoadListener);
+      if (window.Stripe && params) {
+        console.warn(EXISTING_SCRIPT_MESSAGE);
+      }
 
-      script.addEventListener('error', onErrorListener);
-    } catch (error) {
-      reject(error);
-      return;
-    }
-  });
+      if (window.Stripe) {
+        resolve(window.Stripe);
+        return;
+      }
+
+      try {
+        let script = findScript();
+
+        if (script && params) {
+          console.warn(EXISTING_SCRIPT_MESSAGE);
+        } else if (!script) {
+          script = injectScript(params);
+        } else if (
+          script &&
+          onLoadListener !== null &&
+          onErrorListener !== null
+        ) {
+          // remove event listeners
+          script.removeEventListener('load', onLoadListener);
+          script.removeEventListener('error', onErrorListener);
+
+          // if script exists, but we are reloading due to an error,
+          // reload script to trigger 'load' event
+          script.parentNode?.removeChild(script);
+          script = injectScript(params);
+        }
+
+        onLoadListener = onLoad(resolve, reject);
+        onErrorListener = onError(reject);
+        script.addEventListener('load', onLoadListener);
+
+        script.addEventListener('error', onErrorListener);
+      } catch (error) {
+        reject(error);
+        return;
+      }
+    });
+
+  const retryableLoad = async () =>
+    load().catch((error) => {
+      stripePromise = null;
+      return Promise.reject(error);
+    });
+
   // Resets stripePromise on error
-  return stripePromise.catch((error) => {
-    stripePromise = null;
-    return Promise.reject(error);
-  });
+  return retryableLoad().catch(() => retryableLoad());
 };
 
 export const initStripe = (


### PR DESCRIPTION
### Summary & motivation
This change adds one automatic retry to the loader code. Most of the source change is whitespace, so you can hide whitespace to make the review easier.

This is marked as breaking because it changes the loading behavior. If merchants already have retries, they may get more retries than they want.

### Testing & documentation
* Added/updated automated tests
* Tested in the demo app to make sure the Card element can load <img width="441" height="147" alt="Screenshot 2026-03-23 at 5 51 29 PM" src="https://github.com/user-attachments/assets/bfaf287b-1287-460f-b4b3-4e71e308ccb6" />
* Tested the demo app with the SJS URL blocked to make sure the loader runs exactly twice. <img width="766" height="784" alt="Screenshot 2026-03-23 at 5 48 34 PM" src="https://github.com/user-attachments/assets/aee4a474-3ece-4b11-8a68-3f4f99ba914b" />
