### PR TITLE
fix: narrow update() type, document Apple Pay WebKit bug, add SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ of features of Stripe.js.
 
 [![npm version](https://img.shields.io/npm/v/@stripe/stripe-js.svg?style=flat-square)](https://www.npmjs.com/package/@stripe/stripe-js)
 
+## Security
+
+For details on Stripe.js security design — including why SRI hashes are not
+supported and why the `__stripe_mid`/`__stripe_sid` cookies lack `HttpOnly` —
+see [SECURITY.md](SECURITY.md) and
+[Stripe's security guide](https://stripe.com/docs/security/guide).
+
 ## Minimum requirements
 
 - Node.js: v12.16
@@ -162,6 +169,25 @@ const stripe = await loadStripe('pk_test_TYooMQauvdEDq54NiTphI7jx');
 
 The `loadStripe.setLoadParameters` function is only available when importing
 `loadStripe` from `@stripe/stripe-js/pure`.
+
+### Apple Pay on Safari/WebKit
+
+On iOS 18+ and certain Safari versions, Apple Pay capability detection may
+trigger an unhandled promise rejection (`InvalidAccessError`) originating from
+Stripe's internal iframe. This does not affect non-Apple Pay payment methods.
+To prevent the error from surfacing and degrade gracefully when Apple Pay is
+unavailable, add a global listener before calling `loadStripe`:
+
+```js
+window.addEventListener('unhandledrejection', (event) => {
+  if (event.reason?.name === 'InvalidAccessError') {
+    event.preventDefault(); // suppress the unhandled rejection
+    // treat Apple Pay as unavailable and hide related UI
+  }
+});
+```
+
+See [issue #909](https://github.com/stripe/stripe-js/issues/909) for context.
 
 ## Stripe.js Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security
+
+## Reporting Security Issues
+
+To report a security vulnerability in Stripe.js or any Stripe product, please
+use Stripe's responsible disclosure program described at
+https://stripe.com/docs/security. Do not open a public GitHub issue for
+security vulnerabilities.
+
+## Why SRI is Not Supported
+
+Stripe.js is loaded directly from Stripe's CDN (`https://js.stripe.com`) and
+is updated continuously to respond to emerging fraud vectors and PCI DSS
+compliance requirements. Pinning a specific version via a Subresource Integrity
+(SRI) hash would prevent these security updates from reaching your users, which
+could result in outdated fraud detection and potential PCI compliance issues.
+
+The CDN serves Stripe.js exclusively over HTTPS. The integrity of the
+connection is ensured by TLS and Stripe's certificate — not SRI. This is
+consistent with Stripe's PCI DSS obligations, which require that the script be
+loaded from Stripe's servers at all times. See:
+https://stripe.com/docs/security/guide#validating-pci-compliance
+
+Customers who need additional assurance can restrict which scripts are
+permitted to load by configuring a Content Security Policy (CSP) with
+`script-src` set to allowlist only `https://js.stripe.com`. See the README for
+CSP guidance.
+
+## Stripe.js Cookies (`__stripe_mid`, `__stripe_sid`)
+
+The `__stripe_mid` and `__stripe_sid` cookies are set and managed entirely by
+Stripe.js for fraud detection and abuse prevention (for example, card testing
+detection). They are device- and browser-level identifiers used by Stripe's
+risk models.
+
+These cookies intentionally do **not** have the `HttpOnly` attribute because
+Stripe.js reads them client-side for cross-tab session continuity and
+correlation. They do **not** contain user session credentials or authentication
+tokens, so the standard motivation for `HttpOnly` (preventing script access to
+session cookies) does not apply here.
+
+Security scanners may flag the absence of `HttpOnly` on these cookies. This is
+a known, intentional design decision and is not a vulnerability. See:
+https://stripe.com/docs/security/guide

--- a/types/stripe-js/elements/apple-pay.d.ts
+++ b/types/stripe-js/elements/apple-pay.d.ts
@@ -120,6 +120,25 @@ export interface ApplePayDeferredPaymentRequest {
   freeCancellationDateTimeZone?: string;
 }
 
+/**
+ * @remarks
+ * **WebKit/Safari `InvalidAccessError` warning:** On iOS 18+ and certain Safari
+ * versions, Apple Pay capability detection may throw an unhandled
+ * `InvalidAccessError` when Stripe.js initializes inside a nested iframe. To
+ * handle this gracefully and treat Apple Pay as unavailable, add a global
+ * listener before calling `loadStripe`:
+ *
+ * ```ts
+ * window.addEventListener('unhandledrejection', (event) => {
+ *   if (event.reason?.name === 'InvalidAccessError') {
+ *     event.preventDefault(); // suppress console noise
+ *     // Apple Pay is unavailable — hide the Apple Pay button or fall back
+ *   }
+ * });
+ * ```
+ *
+ * See https://github.com/stripe/stripe-js/issues/909 for details.
+ */
 export type ApplePayOption =
   | {
       recurringPaymentRequest: ApplePayRecurringPaymentRequest;

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -145,7 +145,7 @@ export type StripePaymentElement = StripeElementBase & {
    * Updates the options the `PaymentElement` was initialized with.
    * Updates are merged into the existing configuration.
    */
-  update(options: Partial<StripePaymentElementOptions>): StripePaymentElement;
+  update(options: Partial<StripePaymentElementUpdateOptions>): StripePaymentElement;
 
   /**
    * Collapses the Payment Element into a row of payment method tabs.
@@ -286,6 +286,22 @@ export interface StripePaymentElementOptions {
    */
   applePay?: ApplePayOption;
 }
+
+/**
+ * Options accepted by the `update()` method on `StripePaymentElement`.
+ * This is a subset of `StripePaymentElementOptions` — `layout` and `applePay`
+ * are initialization-only and cannot be changed after the element is created.
+ */
+export type StripePaymentElementUpdateOptions = Pick<
+  StripePaymentElementOptions,
+  | 'business'
+  | 'defaultValues'
+  | 'fields'
+  | 'paymentMethodOrder'
+  | 'readOnly'
+  | 'terms'
+  | 'wallets'
+>;
 
 export interface StripePaymentElementChangeEvent {
   /**


### PR DESCRIPTION
## Summary

This PR addresses three open issues:

### Fix #908 — `update()` accepts invalid options silently

The `update()` method on `StripePaymentElement` was typed as `Partial<StripePaymentElementOptions>`, which means passing `layout` or `applePay` (initialization-only options) would pass typecheck without error. This adds a new `StripePaymentElementUpdateOptions` type that picks only the 7 actually-updatable fields, and updates the `update()` signature to use it.

**Files changed:** `types/stripe-js/elements/payment.d.ts`

### Refs #909 — Apple Pay `InvalidAccessError` on Safari/WebKit

The underlying fix for this needs to happen in Stripe's internal CDN bundle (wrapping `new ApplePaySession()` in try/catch inside `m-outer`), but in the meantime this adds a JSDoc warning on `ApplePayOption` and a README section documenting the known behavior and the recommended `window.addEventListener('unhandledrejection', ...)` defensive pattern for integrators.

**Files changed:** `types/stripe-js/elements/apple-pay.d.ts`, `README.md`

### Closes #906 — Security questions: SRI support and cookie `HttpOnly`

Adds a `SECURITY.md` that explains why SRI is not supported (CDN must stay updatable for PCI compliance and fraud detection) and why `__stripe_mid`/`__stripe_sid` intentionally lack `HttpOnly` (they are read client-side by Stripe.js, not auth tokens). Also adds a short Security section in the README pointing to it.

**Files changed:** `SECURITY.md`, `README.md`

## Test plan

- [x] `yarn tsc --noEmit` passes with no errors
- [x] `update({ layout: 'tabs' })` now produces a TypeScript type error (previously silently accepted)
- [x] `update({ business: { name: 'Acme' } })` still type-checks correctly