### PR TITLE
add contactDetails element

### DIFF
--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -32,6 +32,8 @@ import {
   StripePaymentMethodMessagingElement,
   StripeLinkAuthenticationElementChangeEvent,
   StripeLinkAuthenticationElement,
+  StripeContactDetailsElement,
+  StripeContactDetailsElementChangeEvent,
   StripeShippingAddressElementChangeEvent,
   StripeShippingAddressElement,
   StripeAddressElementChangeEvent,
@@ -767,6 +769,35 @@ const retrievedLinkAuthenticationElement: StripeLinkAuthenticationElement | null
   'linkAuthentication'
 );
 
+let contactDetailsElementDefaults: StripeContactDetailsElement = elements.create(
+  'contactDetails'
+);
+contactDetailsElementDefaults = elements.create('contactDetails', {});
+
+const contactDetailsElement = elements.create('contactDetails', {
+  defaultValues: {email: 'foo@bar.com'},
+});
+
+contactDetailsElement
+  .on('ready', (e: {elementType: 'contactDetails'}) => {})
+  .on('focus', (e: {elementType: 'contactDetails'}) => {})
+  .on('blur', (e: {elementType: 'contactDetails'}) => {})
+  .on('change', (e: StripeContactDetailsElementChangeEvent) => {})
+  .on('loaderstart', (e: {elementType: 'contactDetails'}) => {})
+  .on(
+    'loaderror',
+    (e: {
+      elementType: 'contactDetails';
+      error: {
+        type: string;
+      };
+    }) => {}
+  );
+
+const retrievedContactDetailsElement: StripeContactDetailsElement | null = elements.getElement(
+  'contactDetails'
+);
+
 let addressElementDefaults: StripeAddressElement = elements.create('address', {
   mode: 'shipping',
 });
@@ -1317,6 +1348,7 @@ cardElement.destroy();
 cardNumberElement.destroy();
 cardCvcElement.destroy();
 cardExpiryElement.destroy();
+contactDetailsElement.destroy();
 currencySelectorElement.destroy();
 ibanElement.destroy();
 paymentRequestButtonElement.destroy();

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -21,6 +21,7 @@ import {
   PaymentWalletsOption,
   StripeCheckoutFormConfirmEvent,
   ExpressCheckoutPaymentMethodsOption,
+  StripeContactDetailsElement,
 } from './elements';
 
 type SavedPaymentMethodOption = {
@@ -384,6 +385,8 @@ export type StripeCheckoutAddressElementOptions = {
   };
 };
 
+export type StripeCheckoutContactDetailsElementOptions = Record<string, never>;
+
 /**
  * Wallet button theme options for CheckoutForm.
  */
@@ -702,6 +705,9 @@ export interface StripeCheckoutElementsSdk {
   createCurrencySelectorElement(): StripeCurrencySelectorElement;
   /* Requires beta header when initializing Stripe: @docs https://docs.stripe.com/tax/advanced/tax-ids?payment-ui=embedded-components#render-tax-id-element */
   createTaxIdElement(options?: StripeTaxIdElementOptions): StripeTaxIdElement;
+  createContactDetailsElement(
+    options?: StripeCheckoutContactDetailsElementOptions
+  ): StripeContactDetailsElement;
 }
 
 /* Requires beta access: Contact [Stripe support](https://support.stripe.com/) for more information. */

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -10,6 +10,8 @@ import {
   StripePaymentElementOptions,
   StripeLinkAuthenticationElement,
   StripeLinkAuthenticationElementOptions,
+  StripeContactDetailsElement,
+  StripeContactDetailsElementOptions,
   StripeIbanElement,
   StripeIbanElementOptions,
   StripeCardCvcElement,
@@ -241,6 +243,23 @@ export interface StripeElements {
   ): StripeLinkAuthenticationElement | null;
 
   /////////////////////////////
+  /// contactDetails
+  /////////////////////////////
+
+  /**
+   * Creates a `ContactDetailsElement`.
+   */
+  create(
+    elementType: 'contactDetails',
+    options?: StripeContactDetailsElementOptions
+  ): StripeContactDetailsElement;
+
+  /**
+   * Looks up a previously created `Element` by its type.
+   */
+  getElement(elementType: 'contactDetails'): StripeContactDetailsElement | null;
+
+  /////////////////////////////
   /// expressCheckout
   /////////////////////////////
 
@@ -409,6 +428,7 @@ export type StripeElementType =
   | 'cardNumber'
   | 'cardExpiry'
   | 'cardCvc'
+  | 'contactDetails'
   | 'currencySelector'
   | 'expressCheckout'
   | 'iban'
@@ -434,6 +454,7 @@ export type StripeElement =
   | StripeCardExpiryElement
   | StripeCardCvcElement
   | StripeIbanElement
+  | StripeContactDetailsElement
   | StripeCurrencySelectorElement
   | StripeExpressCheckoutElement
   | StripePaymentElement
@@ -685,7 +706,7 @@ interface BaseStripeElementsOptions {
 
   /**
    * Display skeleton loader UI while waiting for Elements to be fully loaded, after they are mounted.
-   * Supported for the `payment`, `shippingAddress`, and `linkAuthentication` Elements.
+   * Supported for the `payment`, `shippingAddress`, `linkAuthentication`, and `contactDetails` Elements.
    * Default is `'auto'` (Stripe determines if a loader UI should be shown).
    */
   loader?: 'auto' | 'always' | 'never';
@@ -695,7 +716,7 @@ interface BaseStripeElementsOptions {
    * Contact [Stripe support](https://support.stripe.com/) for more information.
    *
    * Display saved PaymentMethods and Customer information.
-   * Supported for the `payment`, `shippingAddress`, and `linkAuthentication` Elements.
+   * Supported for the `payment`, `shippingAddress`, `linkAuthentication`, and `contactDetails` Elements.
    */
   customerOptions?: CustomerOptions;
 

--- a/types/stripe-js/elements/contact-details.d.ts
+++ b/types/stripe-js/elements/contact-details.d.ts
@@ -1,0 +1,152 @@
+import {StripeElementBase} from './base';
+import {StripeError} from '../stripe';
+
+export type StripeContactDetailsElement = StripeElementBase & {
+  /**
+   * The change event is triggered when the `Element`'s value changes.
+   */
+  on(
+    eventType: 'change',
+    handler: (event: StripeContactDetailsElementChangeEvent) => any
+  ): StripeContactDetailsElement;
+  once(
+    eventType: 'change',
+    handler: (event: StripeContactDetailsElementChangeEvent) => any
+  ): StripeContactDetailsElement;
+  off(
+    eventType: 'change',
+    handler?: (event: StripeContactDetailsElementChangeEvent) => any
+  ): StripeContactDetailsElement;
+
+  /**
+   * Triggered when the element is fully rendered and can accept `element.focus` calls.
+   */
+  on(
+    eventType: 'ready',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  once(
+    eventType: 'ready',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  off(
+    eventType: 'ready',
+    handler?: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+
+  /**
+   * Triggered when the element gains focus.
+   */
+  on(
+    eventType: 'focus',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  once(
+    eventType: 'focus',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  off(
+    eventType: 'focus',
+    handler?: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+
+  /**
+   * Triggered when the element loses focus.
+   */
+  on(
+    eventType: 'blur',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  once(
+    eventType: 'blur',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  off(
+    eventType: 'blur',
+    handler?: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+
+  /**
+   * Triggered when the escape key is pressed within the element.
+   */
+  on(
+    eventType: 'escape',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  once(
+    eventType: 'escape',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  off(
+    eventType: 'escape',
+    handler?: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+
+  /**
+   * Triggered when the element fails to load.
+   */
+  on(
+    eventType: 'loaderror',
+    handler: (event: {elementType: 'contactDetails'; error: StripeError}) => any
+  ): StripeContactDetailsElement;
+  once(
+    eventType: 'loaderror',
+    handler: (event: {elementType: 'contactDetails'; error: StripeError}) => any
+  ): StripeContactDetailsElement;
+  off(
+    eventType: 'loaderror',
+    handler?: (event: {
+      elementType: 'contactDetails';
+      error: StripeError;
+    }) => any
+  ): StripeContactDetailsElement;
+
+  /**
+   * Triggered when the loader UI is mounted to the DOM and ready to be displayed.
+   */
+  on(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  once(
+    eventType: 'loaderstart',
+    handler: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+  off(
+    eventType: 'loaderstart',
+    handler?: (event: {elementType: 'contactDetails'}) => any
+  ): StripeContactDetailsElement;
+};
+
+export interface StripeContactDetailsElementOptions {
+  /**
+   * Default values for ContactDetailsElement fields
+   */
+  defaultValues?: {
+    email: string;
+  };
+}
+
+export interface StripeContactDetailsElementChangeEvent {
+  /**
+   * The type of element that emitted this event.
+   */
+  elementType: 'contactDetails';
+
+  /**
+   * Whether or not the ContactDetails Element is currently empty.
+   */
+  empty: boolean;
+
+  /**
+   * Whether or not the ContactDetails Element is complete.
+   */
+  complete: boolean;
+
+  /**
+   * An object containing the current email.
+   */
+  value: {
+    email: string;
+  };
+}

--- a/types/stripe-js/elements/index.d.ts
+++ b/types/stripe-js/elements/index.d.ts
@@ -7,6 +7,7 @@ export * from './card-cvc';
 export * from './card-expiry';
 export * from './card-number';
 export * from './card';
+export * from './contact-details';
 export * from './currency-selector';
 export * from './express-checkout';
 export * from './iban';


### PR DESCRIPTION
### Summary & motivation

Adds  the `contactDetails` element, which is a clone of `linkAuthentication` element that will possibly collect values other than an email.
The element is also going to be available with Checkout elements.

### Testing & documentation

Tested locally. Documentation will be updated soon.
