### PR TITLE
Add types for `session.surcharge` and `session.surcharge` for automatic surcharge support

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -203,6 +203,11 @@ export type StripeCheckoutStatus =
       paymentStatus: 'paid' | 'unpaid' | 'no_payment_required';
     };
 
+export type StripeCheckoutSurchargeStatus =
+  | {status: 'requires_input'}
+  | {status: 'complete'}
+  | {status: 'failed'};
+
 export type StripeCheckoutTaxStatus =
   | {status: 'ready'}
   | {status: 'requires_shipping_address'}
@@ -214,6 +219,7 @@ export type StripeCheckoutTotalSummary = {
   discount: StripeCheckoutAmount;
   shippingRate: StripeCheckoutAmount;
   subtotal: StripeCheckoutAmount;
+  surcharge: StripeCheckoutAmount;
   taxExclusive: StripeCheckoutAmount;
   taxInclusive: StripeCheckoutAmount;
   total: StripeCheckoutAmount;
@@ -363,6 +369,7 @@ export interface StripeCheckoutSession {
   shippingAddress: StripeCheckoutContact | null;
   shippingOptions: Array<StripeCheckoutShippingOption>;
   status: StripeCheckoutStatus;
+  surcharge: StripeCheckoutSurchargeStatus | null;
   tax: StripeCheckoutTaxStatus;
   taxAmounts: Array<StripeCheckoutTaxAmount> | null;
   taxIdInfo: StripeCheckoutTaxIdInfo | null;


### PR DESCRIPTION
### Summary & motivation
https://jira.corp.stripe.com/browse/OCS_API-6944 
<!-- Simple summary of what the code does or what you have changed. -->

Adds the following changes to stripe.js types

```
export type StripeCheckoutSurchargeStatus = 
 | {status: 'complete'} 
 | {status: 'requires_input'} 
 | {status: 'failed'}

export interface StripeCheckoutSession {
  //... existing fields
  surcharge: StripeCheckoutSurchargeStatus | null;
}

export interface StripeCheckoutTotalSummary {
  // ... existing fields
  surcharge?: StripeCheckoutAmount;
}
```

As specified in [API Review: automatic surcharge via 3rd party in Checkout payment mode](https://docs.google.com/document/d/1G1oDqo1IzJcrJQElPuL9FPeUpl2Odt1wmZChpl-u5Lw/edit?tab=t.0#heading=h.mccsuyzh1pm1)

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->
API reference updated in https://git.corp.stripe.com/stripe-internal/mint/pull/2072037 , behind gate

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
