### PR TITLE
Checkout Form: add phone param to change event

### DIFF
--- a/types/stripe-js/elements/payment-form.d.ts
+++ b/types/stripe-js/elements/payment-form.d.ts
@@ -43,6 +43,7 @@ export interface StripeCheckoutFormChangeEvent {
       email: string;
       name?: string;
       businessName?: string;
+      phone?: string;
     };
     shippingOption?: {
       id: string;


### PR DESCRIPTION
### Summary & motivation

The Checkout Form may now collect a phone number which is returned in the change event 

