### PR TITLE
Add PMC types to PE update options 👾

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -1028,6 +1028,22 @@ export interface StripeElementsUpdateOptions {
   allowedPaymentMethodTypes?: string[];
 
   /**
+   * When using automatic payment methods (omitting paymentMethodTypes), provide a
+   * payment method configuration ID for deriving payment methods.
+   *
+   * @docs https://stripe.com/docs/connect/payment-method-configurations
+   */
+  paymentMethodConfiguration?: string;
+
+  /**
+   * When using automatic payment methods (omitting payment_method_types), provide a
+   * payment method configuration ID for deriving payment methods.
+   *
+   * @docs https://stripe.com/docs/connect/payment-method-configurations
+   */
+  payment_method_configuration?: string;
+
+  /**
    * The Stripe account ID which is the business of record.
    *
    * @docs https://stripe.com/docs/js/elements_object/create_without_intent#stripe_elements_no_intent-options-onBehalfOf


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

#### 💰 Add paymentMethodConfiguration types to the Payment Element update options
This was an oversight! These types were added to the create options, but not the update options.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->
Going to add some docs in our JS ref.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
