### PR TITLE
Remove client-only actions from form SDK

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -678,3 +678,21 @@ checkoutFormSdk.createForm({
 
 // @ts-expect-error: contacts must be an array of ContactOption
 checkoutFormSdk.createForm({contacts: 'invalid'});
+
+// StripeCheckoutFormSdk.loadActions() omits client-only update methods that
+// are driven by the CheckoutForm UI rather than imperative calls.
+checkoutFormSdk.loadActions().then((loadActionsResult) => {
+  if (loadActionsResult.type === 'success') {
+    const {actions} = loadActionsResult;
+    // @ts-expect-error Property 'updateEmail' does not exist on StripeCheckoutFormLoadActionsSuccess.
+    actions.updateEmail('test@example.com');
+    // @ts-expect-error Property 'updatePhoneNumber' does not exist on StripeCheckoutFormLoadActionsSuccess.
+    actions.updatePhoneNumber('+1234567890');
+    // @ts-expect-error Property 'updateShippingAddress' does not exist on StripeCheckoutFormLoadActionsSuccess.
+    actions.updateShippingAddress(null);
+    // @ts-expect-error Property 'updateBillingAddress' does not exist on StripeCheckoutFormLoadActionsSuccess.
+    actions.updateBillingAddress(null);
+    // @ts-expect-error Property 'updateTaxIdInfo' does not exist on StripeCheckoutFormLoadActionsSuccess.
+    actions.updateTaxIdInfo(null);
+  }
+});

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3832,6 +3832,11 @@ checkoutFormSdk.loadActions().then((loadActionsResult) => {
     const {actions} = loadActionsResult;
     actions.getSession();
     actions.confirm();
+    actions.applyPromotionCode('code');
+    actions.removePromotionCode();
+    actions.updateLineItemQuantity({lineItem: 'li_1', quantity: 2});
+    actions.updateShippingOption('so_1');
+    actions.runServerUpdate(() => Promise.resolve());
   } else {
     const {error} = loadActionsResult;
   }

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -626,7 +626,7 @@ export type StripeCheckoutRunServerUpdateResult =
   | {type: 'error'; error: AnyBuyerError};
 
 type LoadActionsError = {message: string; code: null};
-type LoadActionsSuccess = {
+export type StripeCheckoutLoadActionsSuccess = {
   applyPromotionCode: (
     promotionCode: string
   ) => Promise<StripeCheckoutApplyPromotionCodeResult>;
@@ -672,7 +672,24 @@ type LoadActionsSuccess = {
   ) => Promise<StripeCheckoutRunServerUpdateResult>;
 };
 export type StripeCheckoutLoadActionsResult =
-  | {type: 'success'; actions: LoadActionsSuccess}
+  | {type: 'success'; actions: StripeCheckoutLoadActionsSuccess}
+  | {type: 'error'; error: LoadActionsError};
+
+/**
+ * Form SDK actions omit the client-only update methods that are handled
+ * internally by the CheckoutForm UI. Merchants using `initCheckoutFormSdk`
+ * should drive these fields via the form, not via imperative action calls.
+ */
+export type StripeCheckoutFormLoadActionsSuccess = Omit<
+  StripeCheckoutLoadActionsSuccess,
+  | 'updateEmail'
+  | 'updatePhoneNumber'
+  | 'updateShippingAddress'
+  | 'updateBillingAddress'
+  | 'updateTaxIdInfo'
+>;
+export type StripeCheckoutFormLoadActionsResult =
+  | {type: 'success'; actions: StripeCheckoutFormLoadActionsSuccess}
   | {type: 'error'; error: LoadActionsError};
 
 export interface StripeCheckoutElementsSdk {
@@ -713,7 +730,7 @@ export interface StripeCheckoutElementsSdk {
 /* Requires beta access: Contact [Stripe support](https://support.stripe.com/) for more information. */
 export interface StripeCheckoutFormSdk {
   on: (event: 'change', handler: StripeCheckoutUpdateHandler) => void;
-  loadActions: () => Promise<StripeCheckoutLoadActionsResult>;
+  loadActions: () => Promise<StripeCheckoutFormLoadActionsResult>;
 
   changeAppearance: (appearance: Omit<Appearance, 'rules'>) => void;
   loadFonts: (fonts: Array<CssFontSource | CustomFontSource>) => void;


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Removing the types for client-only update actions that are returned from form SDk

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
