### PR TITLE
Add release train type

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,9 +12,7 @@ export interface LoadParams {
 // containing the package.json version
 declare const _VERSION: string;
 
-export type ReleaseTrain = 'dahlia';
-
-export const RELEASE_TRAIN: ReleaseTrain = 'dahlia';
+export const RELEASE_TRAIN = 'dahlia';
 
 const runtimeVersionToUrlVersion = (version: string | number) =>
   version === 3 ? 'v3' : version;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-import {Stripe, StripeConstructor} from '../types';
+import {Stripe, StripeConstructor, ReleaseTrain} from '../types';
 
 export type LoadStripe = (
   ...args: Parameters<StripeConstructor>
@@ -12,7 +12,7 @@ export interface LoadParams {
 // containing the package.json version
 declare const _VERSION: string;
 
-export const RELEASE_TRAIN = 'dahlia';
+export const RELEASE_TRAIN: ReleaseTrain = 'dahlia';
 
 const runtimeVersionToUrlVersion = (version: string | number) =>
   version === 3 ? 'v3' : version;

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -12,7 +12,9 @@ export interface LoadParams {
 // containing the package.json version
 declare const _VERSION: string;
 
-export const RELEASE_TRAIN = 'dahlia';
+export type ReleaseTrain = 'dahlia';
+
+export const RELEASE_TRAIN: ReleaseTrain = 'dahlia';
 
 const runtimeVersionToUrlVersion = (version: string | number) =>
   version === 3 ? 'v3' : version;

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -7,6 +7,7 @@ import {
   StripeExpressCheckoutElement,
   StripeElementsOptions,
   StripeCurrencySelectorElement,
+  ReleaseTrain,
 } from '../../../types';
 import {ApplePayUpdateOption} from '../../../types/stripe-js/elements/apple-pay';
 
@@ -696,3 +697,6 @@ checkoutFormSdk.loadActions().then((loadActionsResult) => {
     actions.updateTaxIdInfo(null);
   }
 });
+
+// @ts-expect-error: Type '"clover"' is not assignable to type '"dahlia"'.
+const releaseTrain: ReleaseTrain = 'clover';

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -58,6 +58,7 @@ import {
   StripeCheckoutFormConfirmEvent,
   StripeIssuingAddToWalletButtonElementOptions,
   StripeIssuingAddToWalletButtonElement,
+  ReleaseTrain,
 } from '../../../types';
 
 const stripePromise: Promise<Stripe | null> = loadStripe('');
@@ -3849,3 +3850,6 @@ stripe.createEmbeddedCheckoutPage({
 stripe.createEmbeddedCheckoutPage({
   clientSecret: 'cs_test_foo',
 });
+
+// ReleaseTrain type
+const releaseTrain: ReleaseTrain = 'dahlia';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ export * from './stripe-js';
 
 import {StripeConstructor} from './stripe-js';
 
-export {loadStripe} from './shared';
+export {loadStripe, ReleaseTrain} from './shared';
 
 declare global {
   interface Window {

--- a/types/pure.d.ts
+++ b/types/pure.d.ts
@@ -1,5 +1,7 @@
 import {loadStripe as _loadStripe} from './shared';
 
+export {ReleaseTrain} from './shared';
+
 export const loadStripe: typeof _loadStripe & {
   setLoadParameters: (params: {advancedFraudSignals: boolean}) => void;
 };

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -1,5 +1,7 @@
 import {StripeConstructorOptions, Stripe} from './stripe-js';
 
+export type ReleaseTrain = 'dahlia';
+
 export const loadStripe: (
   publishableKey: string,
   options?: StripeConstructorOptions | undefined


### PR DESCRIPTION
### Summary & motivation

Exports a `ReleaseTrain` type from the package's public API so consumers who load Stripe.js via a <script> tag can pin their release train name to the installed package version at type-check time.

Issue: https://github.com/stripe/stripe-js/issues/919

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

 **Local testing**

_Created a temp project with "@stripe/stripe-js": "file:/path/to/stripe-js" in package.json to simulate the issue reporter's use case:_

```
  // @ts-check

  /** @typedef {import("@stripe/stripe-js").ReleaseTrain} ReleaseTrain */

  /** @type {ReleaseTrain} */
  const release = "dahlia"; // passes
```

  Confirmed that assigning "wrong" produces the expected type error:

  `error TS2322: Type '"wrong"' is not assignable to type '"dahlia"'.`

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
