### PR TITLE
Add types for new PE and ECE  `availablepaymentmethodschange` event

### DIFF
--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -181,6 +181,28 @@ export type StripeExpressCheckoutElement = StripeElementBase & {
   ): StripeExpressCheckoutElement;
 
   /**
+   * Triggered when the available payment methods change.
+   */
+  on(
+    eventType: 'availablepaymentmethodschange',
+    handler: (
+      event: StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent
+    ) => any
+  ): StripeExpressCheckoutElement;
+  once(
+    eventType: 'availablepaymentmethodschange',
+    handler: (
+      event: StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent
+    ) => any
+  ): StripeExpressCheckoutElement;
+  off(
+    eventType: 'availablepaymentmethodschange',
+    handler?: (
+      event: StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent
+    ) => any
+  ): StripeExpressCheckoutElement;
+
+  /**
    * Updates the options the `ExpressCheckoutElement` was initialized with.
    * Updates are merged into the existing configuration.
    */
@@ -573,4 +595,18 @@ export interface StripeExpressCheckoutElementShippingRateChangeEvent {
   shippingRate: ShippingRate;
   resolve: (resolveDetails?: ChangeResolveDetails) => void;
   reject: () => void;
+}
+
+export interface StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent {
+  elementType: 'expressCheckout';
+  paymentMethods:
+    | {
+        link?: {available: boolean};
+        applePay?: {available: boolean};
+        googlePay?: {available: boolean};
+        paypal?: {available: boolean};
+        amazonPay?: {available: boolean};
+        klarna?: {available: boolean};
+      }
+    | undefined;
 }

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -142,6 +142,24 @@ export type StripePaymentElement = StripeElementBase & {
   ): StripePaymentElement;
 
   /**
+   * Triggered when the available payment methods change.
+   */
+  on(
+    eventType: 'availablepaymentmethodschange',
+    handler: (event: StripePaymentElementAvailablePaymentMethodsChangeEvent) => any
+  ): StripePaymentElement;
+  once(
+    eventType: 'availablepaymentmethodschange',
+    handler: (event: StripePaymentElementAvailablePaymentMethodsChangeEvent) => any
+  ): StripePaymentElement;
+  off(
+    eventType: 'availablepaymentmethodschange',
+    handler?: (
+      event: StripePaymentElementAvailablePaymentMethodsChangeEvent
+    ) => any
+  ): StripePaymentElement;
+
+  /**
    * Updates the options the `PaymentElement` was initialized with.
    * Updates are merged into the existing configuration.
    */
@@ -448,4 +466,10 @@ export interface StripePaymentElementSavedPaymentMethodRemoveEvent {
       phone: null | string;
     };
   };
+}
+
+
+export interface StripePaymentElementAvailablePaymentMethodsChangeEvent {
+  elementType: 'payment';
+  paymentMethods: Record<string, {available: boolean}> | undefined;
 }

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -146,11 +146,15 @@ export type StripePaymentElement = StripeElementBase & {
    */
   on(
     eventType: 'availablepaymentmethodschange',
-    handler: (event: StripePaymentElementAvailablePaymentMethodsChangeEvent) => any
+    handler: (
+      event: StripePaymentElementAvailablePaymentMethodsChangeEvent
+    ) => any
   ): StripePaymentElement;
   once(
     eventType: 'availablepaymentmethodschange',
-    handler: (event: StripePaymentElementAvailablePaymentMethodsChangeEvent) => any
+    handler: (
+      event: StripePaymentElementAvailablePaymentMethodsChangeEvent
+    ) => any
   ): StripePaymentElement;
   off(
     eventType: 'availablepaymentmethodschange',
@@ -467,7 +471,6 @@ export interface StripePaymentElementSavedPaymentMethodRemoveEvent {
     };
   };
 }
-
 
 export interface StripePaymentElementAvailablePaymentMethodsChangeEvent {
   elementType: 'payment';


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
Add types for new PE and ECE  `availablepaymentmethodschange` event. Both events have `elementType` and `paymentMethods` fields. The ECE implementation has 5 possible payment methods, so they are fully defined. The PE implementation has many more possible payment methods, so the type is generalized to improve maintainability.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->
Updated reference documentation:
https://docs.stripe.com/js/elements_object/payment_element_availablepaymentmethodschange_event
https://docs.stripe.com/js/elements_object/express_checkout_element_availablepaymentmethodschange_event

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
