### PR TITLE
Add buttonHeight types to createForm

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -679,7 +679,7 @@ checkoutFormSdk.createForm({
 
 checkoutFormSdk.createForm({
   expressCheckout: {
-    buttonHeight: 'invalid'
+    buttonHeight: 'invalid',
   },
 });
 

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -679,6 +679,7 @@ checkoutFormSdk.createForm({
 
 checkoutFormSdk.createForm({
   expressCheckout: {
+    // @ts-expect-error: buttonHeight must be number
     buttonHeight: 'invalid',
   },
 });

--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -677,6 +677,12 @@ checkoutFormSdk.createForm({
   },
 });
 
+checkoutFormSdk.createForm({
+  expressCheckout: {
+    buttonHeight: 'invalid'
+  },
+});
+
 // @ts-expect-error: contacts must be an array of ContactOption
 checkoutFormSdk.createForm({contacts: 'invalid'});
 

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3827,7 +3827,7 @@ checkoutFormSdk.createForm({
       googlePay: 'always',
       link: 'never',
     },
-    buttonHeight: 50
+    buttonHeight: 50,
   },
 });
 const retrievedCheckoutForm: StripeCheckoutForm | null = checkoutFormSdk.getForm();

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3827,6 +3827,7 @@ checkoutFormSdk.createForm({
       googlePay: 'always',
       link: 'never',
     },
+    buttonHeight: 50
   },
 });
 const retrievedCheckoutForm: StripeCheckoutForm | null = checkoutFormSdk.getForm();

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -420,6 +420,11 @@ export type StripeCheckoutFormOptions = {
    */
   expressCheckout?: {
     /**
+     * By default, the height of the buttons are 44px.
+     * You can override this to specify a custom button height in the range of 40px-55px.
+     */
+    buttonHeight?: number;
+    /**
      * Button theme options for express checkout payment methods.
      */
     buttonTheme?: PaymentFormWalletButtonTheme;


### PR DESCRIPTION
### Summary & motivation

Updates types to include `buttonHeight` on `createForm`: https://docs.stripe.com/js/custom_checkout/create_form#custom_checkout_create_form-options-expressCheckout-buttonHeight

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Added valid and invalid tests.

<!-- If this is an API change, have you updated the documentation? -->

Docs: https://docs.stripe.com/js/custom_checkout/create_form#custom_checkout_create_form-options-expressCheckout-buttonHeight

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
