### PR TITLE
Add CurrencySelector element definitions for getElement and create 

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -240,10 +240,6 @@ expressCheckoutElement.on('click', ({resolve}) => {
   });
 });
 
-// @ts-expect-error: CurrencySelector cannot be created from Elements
-elements.create('currencySelector');
-// @ts-expect-error: CurrencySelector cannot be retrieved from Elements
-elements.getElement('currencySelector');
 // @ts-expect-error: CurrencySelector cannot be updated
 currencySelectorElement.update({});
 

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -195,7 +195,7 @@ stripe.elements({
   mode: 'payment',
   currency: 'usd',
   amount: 1000,
-  adaptivePricing: {},
+  adaptivePricing: {allowed: false},
 });
 
 const elementsClientSecret: StripeElements = stripe.elements({

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -183,7 +183,7 @@ stripe.elements({
   amount: 1000,
 });
 
-// adaptivePricing 
+// adaptivePricing
 stripe.elements({
   mode: 'payment',
   currency: 'usd',
@@ -327,9 +327,8 @@ const handleSubmit = async () => {
 
 const auBankAccountElement = elements.create('auBankAccount', {});
 
-const retrievedAuBankAccountElement: StripeAuBankAccountElement | null = elements.getElement(
-  'auBankAccount'
-);
+const retrievedAuBankAccountElement: StripeAuBankAccountElement | null =
+  elements.getElement('auBankAccount');
 
 const cardElement: StripeCardElement = elements.create('card', {
   classes: {base: '', focus: ''},
@@ -349,9 +348,8 @@ elements.create('card', {style: {base: {fontWeight: 500}}});
 
 const cardElementDefaults: StripeCardElement = elements.create('card');
 
-const retrievedCardElement: StripeCardElement | null = elements.getElement(
-  'card'
-);
+const retrievedCardElement: StripeCardElement | null =
+  elements.getElement('card');
 
 const cardNumberElement: StripeCardNumberElement = elements.create(
   'cardNumber',
@@ -373,30 +371,26 @@ elements.create('cardNumber', {style: {base: {fontWeight: 500}}});
 elements.create('cardCvc', {style: {base: {fontWeight: 500}}});
 elements.create('cardExpiry', {style: {base: {fontWeight: 500}}});
 
-const retrievedCardNumberElement: StripeCardNumberElement | null = elements.getElement(
-  'cardNumber'
-);
+const retrievedCardNumberElement: StripeCardNumberElement | null =
+  elements.getElement('cardNumber');
 
 const cardExpiryElement: StripeCardExpiryElement = elements.create(
   'cardExpiry',
   {style: MY_STYLE}
 );
 
-const retrievedCardExpiryElement: StripeCardExpiryElement | null = elements.getElement(
-  'cardExpiry'
-);
+const retrievedCardExpiryElement: StripeCardExpiryElement | null =
+  elements.getElement('cardExpiry');
 
 const cardCvcElement: StripeCardCvcElement = elements.create('cardCvc');
 
-const retrievedCardCvcElement: StripeCardCvcElement | null = elements.getElement(
-  'cardCvc'
-);
+const retrievedCardCvcElement: StripeCardCvcElement | null =
+  elements.getElement('cardCvc');
 
 const ibanElement = elements.create('iban', {supportedCountries: ['']});
 
-const retrievedIbanElement: StripeIbanElement | null = elements.getElement(
-  'iban'
-);
+const retrievedIbanElement: StripeIbanElement | null =
+  elements.getElement('iban');
 
 const paymentRequestButtonElement = elements.create('paymentRequestButton', {
   style: {
@@ -418,9 +412,8 @@ const paymentRequestButtonElement = elements.create('paymentRequestButton', {
   disableMultipleButtons: false,
 });
 
-const retrievedPaymentRequestButtonElement: StripePaymentRequestButtonElement | null = elements.getElement(
-  'paymentRequestButton'
-);
+const retrievedPaymentRequestButtonElement: StripePaymentRequestButtonElement | null =
+  elements.getElement('paymentRequestButton');
 
 // Make sure that `paymentRequest` is at least optional;
 retrievedPaymentRequestButtonElement!.update({});
@@ -549,9 +542,8 @@ paymentElement.update({
 let paymentElementDefaults: StripePaymentElement = elements.create('payment');
 paymentElementDefaults = elements.create('payment', {});
 
-const retrievedPaymentElement: StripePaymentElement | null = elements.getElement(
-  'payment'
-);
+const retrievedPaymentElement: StripePaymentElement | null =
+  elements.getElement('payment');
 
 paymentElement
   .on('ready', (e: {elementType: 'payment'}) => {})
@@ -672,9 +664,8 @@ paymentMethodMessagingElement.on(
   (e: {elementType: 'paymentMethodMessaging'}) => {}
 );
 
-const retrievedPaymentMethodMessagingElement: StripePaymentMethodMessagingElement | null = elements.getElement(
-  'paymentMethodMessaging'
-);
+const retrievedPaymentMethodMessagingElement: StripePaymentMethodMessagingElement | null =
+  elements.getElement('paymentMethodMessaging');
 
 retrievedPaymentMethodMessagingElement!.update({amount: 10000});
 
@@ -756,9 +747,8 @@ paymentRequestButtonElement.on(
   }
 );
 
-let linkAuthenticationElementDefaults: StripeLinkAuthenticationElement = elements.create(
-  'linkAuthentication'
-);
+let linkAuthenticationElementDefaults: StripeLinkAuthenticationElement =
+  elements.create('linkAuthentication');
 linkAuthenticationElementDefaults = elements.create('linkAuthentication', {});
 
 const linkAuthenticationElement = elements.create('linkAuthentication', {
@@ -781,13 +771,11 @@ linkAuthenticationElement
     }) => {}
   );
 
-const retrievedLinkAuthenticationElement: StripeLinkAuthenticationElement | null = elements.getElement(
-  'linkAuthentication'
-);
+const retrievedLinkAuthenticationElement: StripeLinkAuthenticationElement | null =
+  elements.getElement('linkAuthentication');
 
-let contactDetailsElementDefaults: StripeContactDetailsElement = elements.create(
-  'contactDetails'
-);
+let contactDetailsElementDefaults: StripeContactDetailsElement =
+  elements.create('contactDetails');
 contactDetailsElementDefaults = elements.create('contactDetails', {});
 
 const contactDetailsElement = elements.create('contactDetails', {
@@ -810,9 +798,8 @@ contactDetailsElement
     }) => {}
   );
 
-const retrievedContactDetailsElement: StripeContactDetailsElement | null = elements.getElement(
-  'contactDetails'
-);
+const retrievedContactDetailsElement: StripeContactDetailsElement | null =
+  elements.getElement('contactDetails');
 
 let addressElementDefaults: StripeAddressElement = elements.create('address', {
   mode: 'shipping',
@@ -902,13 +889,11 @@ addressElement.getValue({format: 'localized'}).then((res) => {
   }
 });
 
-const retrievedAddressElement: StripeAddressElement | null = elements.getElement(
-  'address'
-);
+const retrievedAddressElement: StripeAddressElement | null =
+  elements.getElement('address');
 
-let shippingAddressElementDefaults: StripeShippingAddressElement = elements.create(
-  'shippingAddress'
-);
+let shippingAddressElementDefaults: StripeShippingAddressElement =
+  elements.create('shippingAddress');
 shippingAddressElementDefaults = elements.create('shippingAddress', {});
 
 const shippingAddressElement = elements.create('shippingAddress', {
@@ -958,9 +943,8 @@ shippingAddressElement.update({
   },
 });
 
-const retrievedShippingAddressElement: StripeShippingAddressElement | null = elements.getElement(
-  'shippingAddress'
-);
+const retrievedShippingAddressElement: StripeShippingAddressElement | null =
+  elements.getElement('shippingAddress');
 
 const expressCheckoutElementDefault = elements.create('expressCheckout');
 
@@ -1313,9 +1297,8 @@ const createdTaxIdElement: StripeTaxIdElement = elements.create('taxId', {
   },
 });
 
-const retrievedTaxIdElement: StripeTaxIdElement | null = elements.getElement(
-  'taxId'
-);
+const retrievedTaxIdElement: StripeTaxIdElement | null =
+  elements.getElement('taxId');
 
 createdTaxIdElement.mount('#bogus-container');
 retrievedTaxIdElement?.mount('#bogus-container');
@@ -3383,7 +3366,7 @@ paymentRequest.update({
   },
 });
 
-paymentRequest.on('paymentmethod', function(ev) {
+paymentRequest.on('paymentmethod', function (ev) {
   console.log(ev.paymentMethod.id);
   ev.complete('success');
   ev.complete('fail');
@@ -3393,13 +3376,13 @@ paymentRequest.on('paymentmethod', function(ev) {
   ev.complete('invalid_shipping_address');
 });
 
-paymentRequest.on('token', function(ev) {
+paymentRequest.on('token', function (ev) {
   console.log(ev.token.id);
   console.log(ev.payerEmail);
   ev.complete('success');
 });
 
-paymentRequest.on('source', function(ev) {
+paymentRequest.on('source', function (ev) {
   console.log(ev.source.id);
   console.log(ev.walletName);
   console.log(ev.methodName);
@@ -3419,17 +3402,17 @@ paymentRequest.on('source', function(ev) {
   } = ev.shippingAddress!;
 });
 
-paymentRequest.on('shippingaddresschange', function(ev) {
+paymentRequest.on('shippingaddresschange', function (ev) {
   if (ev.shippingAddress.country !== 'US') {
     ev.updateWith({status: 'invalid_shipping_address'});
   } else {
     fetch('/calculateShipping', {
       body: JSON.stringify({shippingAddress: ev.shippingAddress}),
     })
-      .then(function(response) {
+      .then(function (response) {
         return response.json();
       })
-      .then(function(result) {
+      .then(function (result) {
         ev.updateWith({
           status: 'success',
           shippingOptions: result.supportedShippingOptions,
@@ -3484,13 +3467,8 @@ paymentRequest.on(
 declare const issuingAddToWalletButtonElement: StripeIssuingAddToWalletButtonElement;
 declare const issuingAddToWalletButtonOptions: StripeIssuingAddToWalletButtonElementOptions;
 
-const {
-  buttonHeight,
-  wallet,
-  issuingCard,
-  nonce,
-  ephemeralKeySecret,
-} = issuingAddToWalletButtonOptions;
+const {buttonHeight, wallet, issuingCard, nonce, ephemeralKeySecret} =
+  issuingAddToWalletButtonOptions;
 
 issuingAddToWalletButtonElement.mount('#bogus-container');
 issuingAddToWalletButtonElement.update({
@@ -3618,9 +3596,11 @@ stripe.initCheckoutElementsSdk({clientSecret: Promise.resolve('cs_test_foo')});
 const checkoutElementsSdk = stripe.initCheckoutElementsSdk({
   clientSecret: 'cs_test_foo',
 });
-const checkoutPaymentElement: StripePaymentElement = checkoutElementsSdk.createPaymentElement();
+const checkoutPaymentElement: StripePaymentElement =
+  checkoutElementsSdk.createPaymentElement();
 checkoutElementsSdk.getPaymentElement();
-const checkoutAddressElement: StripeAddressElement = checkoutElementsSdk.createBillingAddressElement();
+const checkoutAddressElement: StripeAddressElement =
+  checkoutElementsSdk.createBillingAddressElement();
 checkoutElementsSdk.getBillingAddressElement();
 checkoutElementsSdk.createShippingAddressElement();
 checkoutElementsSdk.getShippingAddressElement();
@@ -3845,7 +3825,8 @@ checkoutFormSdk.createForm({
     buttonHeight: 50,
   },
 });
-const retrievedCheckoutForm: StripeCheckoutForm | null = checkoutFormSdk.getForm();
+const retrievedCheckoutForm: StripeCheckoutForm | null =
+  checkoutFormSdk.getForm();
 
 checkoutFormSdk.createCurrencySelectorElement();
 checkoutFormSdk.getCurrencySelectorElement();

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -184,6 +184,8 @@ stripe.elements({
 });
 
 // adaptivePricing
+elements.create('currencySelector')
+
 stripe.elements({
   mode: 'payment',
   currency: 'usd',
@@ -198,7 +200,6 @@ stripe.elements({
   adaptivePricing: {allowed: false},
 });
 
-elements.create('currencySelector')
 
 const elementsClientSecret: StripeElements = stripe.elements({
   fonts: [OPEN_SANS, AVENIR],

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -186,6 +186,8 @@ stripe.elements({
 // adaptivePricing
 elements.create('currencySelector')
 
+elements.getElement('currencySelector')
+
 stripe.elements({
   mode: 'payment',
   currency: 'usd',
@@ -199,7 +201,6 @@ stripe.elements({
   amount: 1000,
   adaptivePricing: {allowed: false},
 });
-
 
 const elementsClientSecret: StripeElements = stripe.elements({
   fonts: [OPEN_SANS, AVENIR],

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -183,7 +183,7 @@ stripe.elements({
   amount: 1000,
 });
 
-// adaptivePricing
+// adaptivePricing 
 stripe.elements({
   mode: 'payment',
   currency: 'usd',
@@ -195,7 +195,7 @@ stripe.elements({
   mode: 'payment',
   currency: 'usd',
   amount: 1000,
-  adaptivePricing: {allowed: false},
+  adaptivePricing: {},
 });
 
 const elementsClientSecret: StripeElements = stripe.elements({

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -184,9 +184,9 @@ stripe.elements({
 });
 
 // adaptivePricing
-elements.create('currencySelector')
+elements.create('currencySelector');
 
-elements.getElement('currencySelector')
+elements.getElement('currencySelector');
 
 stripe.elements({
   mode: 'payment',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -198,6 +198,8 @@ stripe.elements({
   adaptivePricing: {allowed: false},
 });
 
+elements.create('currencySelector')
+
 const elementsClientSecret: StripeElements = stripe.elements({
   fonts: [OPEN_SANS, AVENIR],
   locale: 'auto',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -327,8 +327,9 @@ const handleSubmit = async () => {
 
 const auBankAccountElement = elements.create('auBankAccount', {});
 
-const retrievedAuBankAccountElement: StripeAuBankAccountElement | null =
-  elements.getElement('auBankAccount');
+const retrievedAuBankAccountElement: StripeAuBankAccountElement | null = elements.getElement(
+  'auBankAccount'
+);
 
 const cardElement: StripeCardElement = elements.create('card', {
   classes: {base: '', focus: ''},
@@ -348,8 +349,9 @@ elements.create('card', {style: {base: {fontWeight: 500}}});
 
 const cardElementDefaults: StripeCardElement = elements.create('card');
 
-const retrievedCardElement: StripeCardElement | null =
-  elements.getElement('card');
+const retrievedCardElement: StripeCardElement | null = elements.getElement(
+  'card'
+);
 
 const cardNumberElement: StripeCardNumberElement = elements.create(
   'cardNumber',
@@ -371,26 +373,30 @@ elements.create('cardNumber', {style: {base: {fontWeight: 500}}});
 elements.create('cardCvc', {style: {base: {fontWeight: 500}}});
 elements.create('cardExpiry', {style: {base: {fontWeight: 500}}});
 
-const retrievedCardNumberElement: StripeCardNumberElement | null =
-  elements.getElement('cardNumber');
+const retrievedCardNumberElement: StripeCardNumberElement | null = elements.getElement(
+  'cardNumber'
+);
 
 const cardExpiryElement: StripeCardExpiryElement = elements.create(
   'cardExpiry',
   {style: MY_STYLE}
 );
 
-const retrievedCardExpiryElement: StripeCardExpiryElement | null =
-  elements.getElement('cardExpiry');
+const retrievedCardExpiryElement: StripeCardExpiryElement | null = elements.getElement(
+  'cardExpiry'
+);
 
 const cardCvcElement: StripeCardCvcElement = elements.create('cardCvc');
 
-const retrievedCardCvcElement: StripeCardCvcElement | null =
-  elements.getElement('cardCvc');
+const retrievedCardCvcElement: StripeCardCvcElement | null = elements.getElement(
+  'cardCvc'
+);
 
 const ibanElement = elements.create('iban', {supportedCountries: ['']});
 
-const retrievedIbanElement: StripeIbanElement | null =
-  elements.getElement('iban');
+const retrievedIbanElement: StripeIbanElement | null = elements.getElement(
+  'iban'
+);
 
 const paymentRequestButtonElement = elements.create('paymentRequestButton', {
   style: {
@@ -412,8 +418,9 @@ const paymentRequestButtonElement = elements.create('paymentRequestButton', {
   disableMultipleButtons: false,
 });
 
-const retrievedPaymentRequestButtonElement: StripePaymentRequestButtonElement | null =
-  elements.getElement('paymentRequestButton');
+const retrievedPaymentRequestButtonElement: StripePaymentRequestButtonElement | null = elements.getElement(
+  'paymentRequestButton'
+);
 
 // Make sure that `paymentRequest` is at least optional;
 retrievedPaymentRequestButtonElement!.update({});
@@ -542,8 +549,9 @@ paymentElement.update({
 let paymentElementDefaults: StripePaymentElement = elements.create('payment');
 paymentElementDefaults = elements.create('payment', {});
 
-const retrievedPaymentElement: StripePaymentElement | null =
-  elements.getElement('payment');
+const retrievedPaymentElement: StripePaymentElement | null = elements.getElement(
+  'payment'
+);
 
 paymentElement
   .on('ready', (e: {elementType: 'payment'}) => {})
@@ -664,8 +672,9 @@ paymentMethodMessagingElement.on(
   (e: {elementType: 'paymentMethodMessaging'}) => {}
 );
 
-const retrievedPaymentMethodMessagingElement: StripePaymentMethodMessagingElement | null =
-  elements.getElement('paymentMethodMessaging');
+const retrievedPaymentMethodMessagingElement: StripePaymentMethodMessagingElement | null = elements.getElement(
+  'paymentMethodMessaging'
+);
 
 retrievedPaymentMethodMessagingElement!.update({amount: 10000});
 
@@ -747,8 +756,9 @@ paymentRequestButtonElement.on(
   }
 );
 
-let linkAuthenticationElementDefaults: StripeLinkAuthenticationElement =
-  elements.create('linkAuthentication');
+let linkAuthenticationElementDefaults: StripeLinkAuthenticationElement = elements.create(
+  'linkAuthentication'
+);
 linkAuthenticationElementDefaults = elements.create('linkAuthentication', {});
 
 const linkAuthenticationElement = elements.create('linkAuthentication', {
@@ -771,11 +781,13 @@ linkAuthenticationElement
     }) => {}
   );
 
-const retrievedLinkAuthenticationElement: StripeLinkAuthenticationElement | null =
-  elements.getElement('linkAuthentication');
+const retrievedLinkAuthenticationElement: StripeLinkAuthenticationElement | null = elements.getElement(
+  'linkAuthentication'
+);
 
-let contactDetailsElementDefaults: StripeContactDetailsElement =
-  elements.create('contactDetails');
+let contactDetailsElementDefaults: StripeContactDetailsElement = elements.create(
+  'contactDetails'
+);
 contactDetailsElementDefaults = elements.create('contactDetails', {});
 
 const contactDetailsElement = elements.create('contactDetails', {
@@ -798,8 +810,9 @@ contactDetailsElement
     }) => {}
   );
 
-const retrievedContactDetailsElement: StripeContactDetailsElement | null =
-  elements.getElement('contactDetails');
+const retrievedContactDetailsElement: StripeContactDetailsElement | null = elements.getElement(
+  'contactDetails'
+);
 
 let addressElementDefaults: StripeAddressElement = elements.create('address', {
   mode: 'shipping',
@@ -889,11 +902,13 @@ addressElement.getValue({format: 'localized'}).then((res) => {
   }
 });
 
-const retrievedAddressElement: StripeAddressElement | null =
-  elements.getElement('address');
+const retrievedAddressElement: StripeAddressElement | null = elements.getElement(
+  'address'
+);
 
-let shippingAddressElementDefaults: StripeShippingAddressElement =
-  elements.create('shippingAddress');
+let shippingAddressElementDefaults: StripeShippingAddressElement = elements.create(
+  'shippingAddress'
+);
 shippingAddressElementDefaults = elements.create('shippingAddress', {});
 
 const shippingAddressElement = elements.create('shippingAddress', {
@@ -943,8 +958,9 @@ shippingAddressElement.update({
   },
 });
 
-const retrievedShippingAddressElement: StripeShippingAddressElement | null =
-  elements.getElement('shippingAddress');
+const retrievedShippingAddressElement: StripeShippingAddressElement | null = elements.getElement(
+  'shippingAddress'
+);
 
 const expressCheckoutElementDefault = elements.create('expressCheckout');
 
@@ -1297,8 +1313,9 @@ const createdTaxIdElement: StripeTaxIdElement = elements.create('taxId', {
   },
 });
 
-const retrievedTaxIdElement: StripeTaxIdElement | null =
-  elements.getElement('taxId');
+const retrievedTaxIdElement: StripeTaxIdElement | null = elements.getElement(
+  'taxId'
+);
 
 createdTaxIdElement.mount('#bogus-container');
 retrievedTaxIdElement?.mount('#bogus-container');
@@ -3366,7 +3383,7 @@ paymentRequest.update({
   },
 });
 
-paymentRequest.on('paymentmethod', function (ev) {
+paymentRequest.on('paymentmethod', function(ev) {
   console.log(ev.paymentMethod.id);
   ev.complete('success');
   ev.complete('fail');
@@ -3376,13 +3393,13 @@ paymentRequest.on('paymentmethod', function (ev) {
   ev.complete('invalid_shipping_address');
 });
 
-paymentRequest.on('token', function (ev) {
+paymentRequest.on('token', function(ev) {
   console.log(ev.token.id);
   console.log(ev.payerEmail);
   ev.complete('success');
 });
 
-paymentRequest.on('source', function (ev) {
+paymentRequest.on('source', function(ev) {
   console.log(ev.source.id);
   console.log(ev.walletName);
   console.log(ev.methodName);
@@ -3402,17 +3419,17 @@ paymentRequest.on('source', function (ev) {
   } = ev.shippingAddress!;
 });
 
-paymentRequest.on('shippingaddresschange', function (ev) {
+paymentRequest.on('shippingaddresschange', function(ev) {
   if (ev.shippingAddress.country !== 'US') {
     ev.updateWith({status: 'invalid_shipping_address'});
   } else {
     fetch('/calculateShipping', {
       body: JSON.stringify({shippingAddress: ev.shippingAddress}),
     })
-      .then(function (response) {
+      .then(function(response) {
         return response.json();
       })
-      .then(function (result) {
+      .then(function(result) {
         ev.updateWith({
           status: 'success',
           shippingOptions: result.supportedShippingOptions,
@@ -3467,8 +3484,13 @@ paymentRequest.on(
 declare const issuingAddToWalletButtonElement: StripeIssuingAddToWalletButtonElement;
 declare const issuingAddToWalletButtonOptions: StripeIssuingAddToWalletButtonElementOptions;
 
-const {buttonHeight, wallet, issuingCard, nonce, ephemeralKeySecret} =
-  issuingAddToWalletButtonOptions;
+const {
+  buttonHeight,
+  wallet,
+  issuingCard,
+  nonce,
+  ephemeralKeySecret,
+} = issuingAddToWalletButtonOptions;
 
 issuingAddToWalletButtonElement.mount('#bogus-container');
 issuingAddToWalletButtonElement.update({
@@ -3596,11 +3618,9 @@ stripe.initCheckoutElementsSdk({clientSecret: Promise.resolve('cs_test_foo')});
 const checkoutElementsSdk = stripe.initCheckoutElementsSdk({
   clientSecret: 'cs_test_foo',
 });
-const checkoutPaymentElement: StripePaymentElement =
-  checkoutElementsSdk.createPaymentElement();
+const checkoutPaymentElement: StripePaymentElement = checkoutElementsSdk.createPaymentElement();
 checkoutElementsSdk.getPaymentElement();
-const checkoutAddressElement: StripeAddressElement =
-  checkoutElementsSdk.createBillingAddressElement();
+const checkoutAddressElement: StripeAddressElement = checkoutElementsSdk.createBillingAddressElement();
 checkoutElementsSdk.getBillingAddressElement();
 checkoutElementsSdk.createShippingAddressElement();
 checkoutElementsSdk.getShippingAddressElement();
@@ -3825,8 +3845,7 @@ checkoutFormSdk.createForm({
     buttonHeight: 50,
   },
 });
-const retrievedCheckoutForm: StripeCheckoutForm | null =
-  checkoutFormSdk.getForm();
+const retrievedCheckoutForm: StripeCheckoutForm | null = checkoutFormSdk.getForm();
 
 checkoutFormSdk.createCurrencySelectorElement();
 checkoutFormSdk.getCurrencySelectorElement();

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -442,7 +442,9 @@ export interface StripeElements {
    *
    * Looks up a previously created `Element` by its type.
    */
-  getElement(elementType: 'currencySelector'): StripeCurrencySelectorElement | null;
+  getElement(
+    elementType: 'currencySelector'
+  ): StripeCurrencySelectorElement | null;
 }
 
 export type StripeElementType =

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -749,10 +749,8 @@ interface BaseStripeElementsOptions {
   paymentMethodCreation?: 'manual';
 
   /**
-   * Configure [Adaptive Pricing](https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing) behavior.
-   * Set `allowed: true` to enable Adaptive Pricing for this Elements instance.
-   *
-   * @docs https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing?payment-ui=payment-element#mark-integration-ready
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
    */
   adaptivePricing?: {allowed?: boolean};
 }

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -747,12 +747,6 @@ interface BaseStripeElementsOptions {
    * @docs https://docs.stripe.com/js/elements_object/create#stripe_elements-options-paymentMethodCreation
    */
   paymentMethodCreation?: 'manual';
-
-  /**
-   * Requires beta access:
-   * Contact [Stripe support](https://support.stripe.com/) for more information.
-   */
-  adaptivePricing?: {allowed?: boolean};
 }
 
 export interface StripeElementsOptionsClientSecret

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -2,6 +2,7 @@ import {
   StripeAddressElement,
   StripeAddressElementOptions,
   StripeCurrencySelectorElement,
+  StripeCurrencySelectorElementOptions,
   StripeShippingAddressElement,
   StripeShippingAddressElementOptions,
   StripePaymentRequestButtonElement,
@@ -419,6 +420,29 @@ export interface StripeElements {
    * Looks up a previously created `Element` by its type.
    */
   getElement(elementType: 'taxId'): StripeTaxIdElement | null;
+
+  /////////////////////////////
+  /// currencySelector
+  /////////////////////////////
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Creates a `CurrencySelectorElement`.
+   */
+  create(
+    elementType: 'currencySelector',
+    options?: StripeCurrencySelectorElementOptions
+  ): StripeCurrencySelectorElement;
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Looks up a previously created `Element` by its type.
+   */
+  getElement(elementType: 'currencySelector'): StripeCurrencySelectorElement | null;
 }
 
 export type StripeElementType =

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -747,6 +747,14 @@ interface BaseStripeElementsOptions {
    * @docs https://docs.stripe.com/js/elements_object/create#stripe_elements-options-paymentMethodCreation
    */
   paymentMethodCreation?: 'manual';
+
+  /**
+   * Configure [Adaptive Pricing](https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing) behavior.
+   * Set `allowed: true` to enable Adaptive Pricing for this Elements instance.
+   *
+   * @docs https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing?payment-ui=payment-element#mark-integration-ready
+   */
+  adaptivePricing?: {allowed?: boolean};
 }
 
 export interface StripeElementsOptionsClientSecret

--- a/types/stripe-js/elements/currency-selector.d.ts
+++ b/types/stripe-js/elements/currency-selector.d.ts
@@ -91,3 +91,5 @@ export type StripeCurrencySelectorElement = StripeElementBase & {
     }) => any
   ): StripeCurrencySelectorElement;
 };
+
+export interface StripeCurrencySelectorElementOptions {}


### PR DESCRIPTION
### Summary & motivation
Adds elements.create('currencySelector') and elements.getElement('currencySelector') to allowed types. 

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
