### PR TITLE
Add bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "author": "Stripe (https://www.stripe.com)",
   "license": "MIT",
   "homepage": "https://stripe.com/docs/js",
+  "bugs": {
+    "url": "https://github.com/stripe/stripe-js/issues"
+  },
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
## Summary
- add `bugs.url` metadata pointing to the GitHub issue tracker

## Verification
- `node -e` exact package metadata assertion
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`

Related metadata bounty: charles-openclaw/charles-microbounties#662