### PR TITLE
Move isProrated to StripeCheckoutRecurring

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -170,7 +170,6 @@ export type StripeCheckoutLineItem = {
   recurring: {
     interval: StripeCheckoutBillingInterval;
     intervalCount: number;
-    isProrated: boolean;
     usageType: 'metered' | 'licensed';
   } | null;
   adjustableQuantity: StripeCheckoutAdjustableQuantity | null;
@@ -180,6 +179,7 @@ export type StripeCheckoutLineItem = {
 export type StripeCheckoutRecurring = {
   interval: StripeCheckoutBillingInterval;
   intervalCount: number;
+  isProrated: boolean;
   dueNext: StripeCheckoutDueNext;
   trial: StripeCheckoutTrial | null;
 };


### PR DESCRIPTION
### Summary & motivation

- Adds new `isProrated` field to the recurring types.
- Removes `isProrated` from the lineItems[].recurring types.
  - Field is still accessible through `as any`, but is now hidden as it's deprecated.

### Testing & documentation

Tested in a local demo by running `yarn build && yarn link` on this project and `yarn link "@stripe/stripe-js"` on my demo.

Both top-level recurring and lineItems recurring fields always output the same result.
```
  const isProratedLineItems = (
    actions.getSession().lineItems[0]?.recurring as any
  )?.isProrated;
  const isProratedRecurring = actions.getSession().recurring?.isProrated;
  console.log("isProratedLineItems", isProratedLineItems);
  console.log("isProratedRecurring", isProratedRecurring);
```