### PR TITLE
chore: add npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "author": "Stripe (https://www.stripe.com)",
   "license": "MIT",
   "homepage": "https://stripe.com/docs/js",
+  "bugs": {
+    "url": "https://github.com/stripe/stripe-js/issues"
+  },
   "files": [
     "dist",
     "lib",


### PR DESCRIPTION
## Summary
- add missing npm `bugs` metadata to `package.json`
- point npm users to the public GitHub issue tracker

## Testing
- `node -e "const p=require('./package.json'); if(p.repository!=='github:stripe/stripe-js'||p.homepage!=='https://stripe.com/docs/js'||p.bugs?.url!=='https://github.com/stripe/stripe-js/issues') process.exit(1); console.log(JSON.stringify({repository:p.repository,homepage:p.homepage,bugs:p.bugs}, null, 2))"`
- `npm pack --dry-run --ignore-scripts --json`
- `git diff --check`
