### PR TITLE
fix: add missing npm metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "ts-jest": "^24.3.0",
     "typescript": "~4.8.0",
     "zx": "^8.8.5"
+  },
+  "bugs": {
+    "url": "https://github.com/stripe/stripe-js/issues"
   }
 }


### PR DESCRIPTION
Adds missing npm metadata fields to improve package discoverability.