### PR TITLE
Add validateElements type to Custom Checkout actions

### DIFF
--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -638,6 +638,26 @@ export type StripeCheckoutRunServerUpdateResult =
   | {type: 'success'; session: StripeCheckoutSession}
   | {type: 'error'; error: AnyBuyerError};
 
+type ValidateElementsValidationError = {
+  message: string;
+  element:
+    | 'payment'
+    | 'checkoutForm'
+    | 'contactDetails'
+    | 'shippingAddress'
+    | 'billingAddress'
+    | 'taxId'
+    | 'linkAuthentication';
+};
+type ValidateElementsError = {
+  code: 'validation_error' | 'no_elements' | null;
+  message: string;
+  validation_errors: ValidateElementsValidationError[];
+};
+export type StripeCheckoutValidateElementsResult =
+  | {type: 'success'; session: StripeCheckoutSession}
+  | {type: 'error'; error: ValidateElementsError};
+
 type LoadActionsError = {message: string; code: null};
 export type StripeCheckoutLoadActionsSuccess = {
   applyPromotionCode: (
@@ -683,6 +703,7 @@ export type StripeCheckoutLoadActionsSuccess = {
   runServerUpdate: (
     userFunction: RunServerUpdateFunction
   ) => Promise<StripeCheckoutRunServerUpdateResult>;
+  validateElements: () => Promise<StripeCheckoutValidateElementsResult>;
 };
 export type StripeCheckoutLoadActionsResult =
   | {type: 'success'; actions: StripeCheckoutLoadActionsSuccess}


### PR DESCRIPTION
## Summary
- Adds `validateElements()` method type to `StripeCheckoutLoadActionsSuccess`
- Adds `StripeCheckoutValidateElementsResult` discriminated union (success returns session, error includes code + per-element validation errors)
- Method exists at runtime since v9.2.0 and is documented but was missing from the public type definitions

## Test plan
- [x] `tsc --noEmit` passes cleanly
- [ ] Confirm type is accessible via `actions.validateElements()` in a consuming project

🤖 Generated with [Claude Code](https://claude.ai/code)