### PR TITLE
Add fields.name types to Address Element

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -288,6 +288,13 @@ currencySelectorElement.update({});
 // @ts-expect-error: AddressElement requires a mode
 elements.create('address');
 
+// @ts-expect-error: name must be "never" | "auto"
+elements.create('address', {
+  fields: {
+    name: 'always',
+  },
+});
+
 // @ts-expect-error: No overload matches this call
 elements.create('issuingCardNumberDisplay');
 
@@ -627,6 +634,20 @@ checkoutElementsSdk.loadActions().then((loadActionsResult) => {
 checkoutElementsSdk.createForm();
 // @ts-expect-error Property 'getForm' does not exist on type 'StripeCheckoutElementsSdk'.
 checkoutElementsSdk.getForm();
+
+checkoutElementsSdk.createBillingAddressElement({
+  fields: {
+    // @ts-expect-error name must be "never" | "auto"
+    name: 'always',
+  },
+});
+
+checkoutElementsSdk.createShippingAddressElement({
+  fields: {
+    // @ts-expect-error name must be "never" | "auto"
+    name: 'always',
+  },
+});
 
 const checkoutFormSdk = stripe.initCheckoutFormSdk({
   clientSecret: 'cs_test_foo',

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -968,6 +968,20 @@ const shippingAddressElement = elements.create('shippingAddress', {
   },
 });
 
+elements.create('address', {
+  mode: 'shipping',
+  fields: {
+    name: 'never',
+  },
+});
+
+elements.create('address', {
+  mode: 'shipping',
+  fields: {
+    name: 'auto',
+  },
+});
+
 shippingAddressElement
   .on('ready', (e: {elementType: 'shippingAddress'}) => {})
   .on('focus', (e: {elementType: 'shippingAddress'}) => {})
@@ -3664,6 +3678,30 @@ checkoutElementsSdk.createCurrencySelectorElement();
 checkoutElementsSdk.getCurrencySelectorElement();
 checkoutElementsSdk.createTaxIdElement();
 checkoutElementsSdk.getTaxIdElement();
+
+checkoutElementsSdk.createShippingAddressElement({
+  fields: {
+    name: 'never',
+  },
+});
+
+checkoutElementsSdk.createShippingAddressElement({
+  fields: {
+    name: 'auto',
+  },
+});
+
+checkoutElementsSdk.createBillingAddressElement({
+  fields: {
+    name: 'never',
+  },
+});
+
+checkoutElementsSdk.createBillingAddressElement({
+  fields: {
+    name: 'auto',
+  },
+});
 
 checkoutElementsSdk.loadFonts([
   {

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -391,6 +391,17 @@ export type StripeCheckoutAddressElementOptions = {
   display?: {
     name?: 'full' | 'split' | 'organization';
   };
+  /**
+   * Control which additional fields to display in the AddressElement.
+   */
+  fields?: {
+    phone?: 'always' | 'never' | 'auto';
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     */
+    name?: 'never' | 'auto';
+  };
 };
 
 export type StripeCheckoutContactDetailsElementOptions = Record<string, never>;

--- a/types/stripe-js/elements/address.d.ts
+++ b/types/stripe-js/elements/address.d.ts
@@ -198,6 +198,11 @@ export interface StripeAddressElementOptions {
    */
   fields?: {
     phone?: 'always' | 'never' | 'auto';
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     */
+    name?: 'never' | 'auto';
   };
 
   /**


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

Adds fields.name types (in private preview) for `elements.create("address")`, `createBillingAddressElement`, `createShippingAddressElement`.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Added valid and invalid cases to `tests/types`.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
