### PR TITLE
Add optional line item types to Checkout SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/stripe-js",
-  "version": "9.10.0",
+  "version": "9.11.0",
   "description": "Stripe.js loading utility",
   "repository": "github:stripe/stripe-js",
   "main": "lib/index.js",

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -175,8 +175,8 @@ export type StripeCheckoutLineItem = {
   } | null;
   adjustableQuantity: StripeCheckoutAdjustableQuantity | null;
   images: string[];
-  priceId?: string;
-  isRemovable?: boolean;
+  priceId: string;
+  isRemovable: boolean;
 };
 
 export type StripeCheckoutRecurring = {

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -175,6 +175,8 @@ export type StripeCheckoutLineItem = {
   } | null;
   adjustableQuantity: StripeCheckoutAdjustableQuantity | null;
   images: string[];
+  priceId?: string | null;
+  isRemovable?: boolean;
 };
 
 export type StripeCheckoutRecurring = {
@@ -230,6 +232,23 @@ export type StripeCheckoutTotalSummary = {
 export type StripeCheckoutTrial = {
   trialEnd: number;
   trialPeriodDays: number;
+};
+
+export type StripeCheckoutOptionalItem = {
+  priceId: string;
+  name: string;
+  description: string | null;
+  unitAmount: StripeCheckoutAmount;
+  unitAmountDecimal: StripeCheckoutAmount | null;
+  unitLabel: string | null;
+  quantity: number;
+  adjustableQuantity: StripeCheckoutAdjustableQuantity | null;
+  recurring: {
+    interval: StripeCheckoutBillingInterval;
+    intervalCount: number;
+  } | null;
+  images: string[];
+  isSelected: boolean;
 };
 
 export type StripeCheckoutCurrencyOption = StripeCheckoutAmount & {
@@ -376,6 +395,7 @@ export interface StripeCheckoutSession {
   taxAmounts: Array<StripeCheckoutTaxAmount> | null;
   taxIdInfo: StripeCheckoutTaxIdInfo | null;
   total: StripeCheckoutTotalSummary;
+  optionalItems: Array<StripeCheckoutOptionalItem> | null;
 }
 
 export type StripeCheckoutPaymentElementOptions = {
@@ -623,6 +643,27 @@ export type StripeCheckoutUpdateLineItemQuantityResult =
   | {type: 'success'; session: StripeCheckoutSession}
   | {type: 'error'; error: AnyBuyerError};
 
+export type StripeCheckoutAddOptionalLineItemResult =
+  | {type: 'success'; session: StripeCheckoutSession}
+  | {type: 'error'; error: {message: string; code: null}};
+
+export type StripeCheckoutRemoveOptionalLineItemResult =
+  | {type: 'success'; session: StripeCheckoutSession}
+  | {
+      type: 'error';
+      error:
+        | {
+            message: string;
+            code: 'promotionCodeAmountInsufficient';
+            promotionCodeAmountInsufficient: {
+              minimumAmount: number;
+              minimumAmountCurrency: string;
+            };
+          }
+        | {message: string; code: 'couponAppliesToNothing'}
+        | {message: string; code: null};
+    };
+
 export type StripeCheckoutUpdateShippingOptionResult =
   | {type: 'success'; session: StripeCheckoutSession}
   | {type: 'error'; error: AnyBuyerError};
@@ -719,6 +760,12 @@ export type StripeCheckoutLoadActionsSuccess = {
     userFunction: RunServerUpdateFunction
   ) => Promise<StripeCheckoutRunServerUpdateResult>;
   validateElements: () => Promise<StripeCheckoutValidateElementsResult>;
+  addOptionalLineItem: (
+    priceId: string
+  ) => Promise<StripeCheckoutAddOptionalLineItemResult>;
+  removeOptionalLineItem: (
+    priceId: string
+  ) => Promise<StripeCheckoutRemoveOptionalLineItemResult>;
 };
 export type StripeCheckoutLoadActionsResult =
   | {type: 'success'; actions: StripeCheckoutLoadActionsSuccess}

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -175,7 +175,7 @@ export type StripeCheckoutLineItem = {
   } | null;
   adjustableQuantity: StripeCheckoutAdjustableQuantity | null;
   images: string[];
-  priceId?: string | null;
+  priceId?: string;
   isRemovable?: boolean;
 };
 


### PR DESCRIPTION
Adds StripeCheckoutOptionalItem, two new result types (StripeCheckoutAddOptionalLineItemResult,
StripeCheckoutRemoveOptionalLineItemResult), optionalItems on StripeCheckoutSession, priceId/isRemovable on StripeCheckoutLineItem, and addOptionalLineItem/removeOptionalLineItem actions on StripeCheckoutLoadActionsSuccess.

### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
