### PR TITLE
Add StripePaymentElementUpdateOptions

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -166,6 +166,13 @@ elements.create('payment', {
   },
 });
 
+paymentElement.update({
+  // @ts-expect-error: `wallets` option can't be updated
+  wallets: {
+    applePay: 'never',
+  },
+});
+
 paymentElement.on('change', (e) => {
   // @ts-expect-error: `error` is not present on PaymentElement "change" event.
   if (e.error) {

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -167,7 +167,7 @@ export type StripePaymentElement = StripeElementBase & {
    * Updates the options the `PaymentElement` was initialized with.
    * Updates are merged into the existing configuration.
    */
-  update(options: Partial<StripePaymentElementOptions>): StripePaymentElement;
+  update(options: Partial<StripePaymentElementUpdateOptions>): StripePaymentElement;
 
   /**
    * Collapses the Payment Element into a row of payment method tabs.
@@ -400,6 +400,24 @@ export interface StripePaymentElementOptions {
    */
   applePay?: ApplePayOption;
 }
+
+/**
+ * The subset of `StripePaymentElementOptions` that can be updated after the
+ * `PaymentElement` has been created.
+ *
+ * @see https://docs.stripe.com/js/elements_object/update_payment_element
+ */
+export type StripePaymentElementUpdateOptions = Pick<
+  StripePaymentElementOptions,
+  | 'defaultValues'
+  | 'business'
+  | 'paymentMethodOrder'
+  | 'fields'
+  | 'readOnly'
+  | 'terms'
+  | 'layout'
+  | 'applePay'
+>;
 
 export interface StripePaymentElementChangeEvent {
   /**

--- a/types/stripe-js/elements/payment.d.ts
+++ b/types/stripe-js/elements/payment.d.ts
@@ -167,7 +167,9 @@ export type StripePaymentElement = StripeElementBase & {
    * Updates the options the `PaymentElement` was initialized with.
    * Updates are merged into the existing configuration.
    */
-  update(options: Partial<StripePaymentElementUpdateOptions>): StripePaymentElement;
+  update(
+    options: Partial<StripePaymentElementUpdateOptions>
+  ): StripePaymentElement;
 
   /**
    * Collapses the Payment Element into a row of payment method tabs.


### PR DESCRIPTION
### Summary & motivation

Adds explicit `StripePaymentElementUpdateOptions` type, instead of the overly broad `Partial<StripePaymentElementOptions>` we were using earlier.

### Testing & documentation

<!-- How did you test this change? This can be as simple as "I wrote unit tests...". -->

Added a test.

<!-- If this is an API change, have you updated the documentation? -->

<!-- OTHER: Consider checking "Allow edits from maintainers" below. -->
