### PR TITLE
Add features.promotionCodeCollection types for Checkout form 👾

### DIFF
--- a/tests/types/src/invalid.ts
+++ b/tests/types/src/invalid.ts
@@ -759,6 +759,13 @@ checkoutFormSdk.createForm({
 // @ts-expect-error: contacts must be an array of ContactOption
 checkoutFormSdk.createForm({contacts: 'invalid'});
 
+checkoutFormSdk.createForm({
+  features: {
+    // @ts-expect-error: promotionCodeCollection must be 'auto' | 'never'
+    promotionCodeCollection: 'invalid',
+  },
+});
+
 // StripeCheckoutFormSdk.loadActions() omits client-only update methods that
 // are driven by the CheckoutForm UI rather than imperative calls.
 checkoutFormSdk.loadActions().then((loadActionsResult) => {

--- a/tests/types/src/valid.ts
+++ b/tests/types/src/valid.ts
@@ -3949,6 +3949,16 @@ checkoutFormSdk.createForm({
     buttonHeight: 50,
   },
 });
+checkoutFormSdk.createForm({
+  features: {
+    promotionCodeCollection: 'auto',
+  },
+});
+checkoutFormSdk.createForm({
+  features: {
+    promotionCodeCollection: 'never',
+  },
+});
 const retrievedCheckoutForm: StripeCheckoutForm | null = checkoutFormSdk.getForm();
 
 checkoutFormSdk.createCurrencySelectorElement();

--- a/types/stripe-js/checkout.d.ts
+++ b/types/stripe-js/checkout.d.ts
@@ -468,6 +468,21 @@ export type StripeCheckoutFormOptions = {
      */
     paymentMethods?: ExpressCheckoutPaymentMethodsOption;
   };
+
+  /**
+   * Client-side feature configuration for the CheckoutForm.
+   */
+  features?: {
+    /**
+     * Control whether the promotion code collection UI is displayed in the CheckoutForm.
+     *
+     * Only applies when `allow_promotion_codes`is enabled on the Checkout Session.
+     *
+     * @default 'auto'
+     * @docs https://stripe.com/docs/checkout/promotion-codes
+     */
+    promotionCodeCollection?: 'auto' | 'never';
+  };
 };
 
 export type StripeCheckoutExpressCheckoutElementOptions = {


### PR DESCRIPTION
### Summary & motivation

<!-- Simple summary of what the code does or what you have changed. -->
:)
```
checkoutFormSdk.createForm({
  features: {
    promotionCodeCollection: 'auto' | 'never',
  },
});
```