### PR TITLE
CPM in ECE - Update API types

### DIFF
--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -1423,12 +1423,27 @@ export interface CustomPaymentMethod {
     /**
      * The payment form type.
      */
-    type: 'static';
+    type: 'static' | 'embedded';
 
     /**
      * Display additional information about the payment method, max 100 characters.
      */
     subtitle?: string;
+
+    /**
+     * Options for the embedded Custom Payment Method.
+     */
+    embedded: {
+      /**
+       * Function for rendering custom content in the Custom Payment Method form, called on mount.
+       */
+      handleRender: (container: HTMLDivElement) => void;
+
+      /**
+       * Function for cleaning up the Custom Payment Method form, called when the Custom Payment Method is removed and on unmount.
+       */
+      handleDestroy?: () => void;
+    };
   };
 
   /**

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -1404,16 +1404,34 @@ export interface CustomPaymentMethod {
   /**
    * Additional options to configure the Custom Payment Method.
    */
-  options: {
+  options?: {
     /**
      * The payment form type.
      */
-    type: 'static';
+    type: 'static' | 'embedded';
 
     /**
      * Display additional information about the payment method, max 100 characters.
      */
     subtitle?: string;
+
+    /**
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Options for the embedded Custom Payment Method. Required for type: 'embedded'.
+     */
+    embedded?: {
+      /**
+       * Function for rendering custom content in the Custom Payment Method form, called on mount.
+       */
+      handleRender: (container: HTMLDivElement) => void;
+
+      /**
+       * Function for cleaning up the Custom Payment Method form, called when the Custom Payment Method is removed and on unmount.
+       */
+      handleDestroy?: () => void;
+    };
   };
 
   /**
@@ -1431,9 +1449,12 @@ export interface CustomPaymentMethod {
     subtitle?: string;
 
     /**
-     * Options for the embedded Custom Payment Method.
+     * Requires beta access:
+     * Contact [Stripe support](https://support.stripe.com/) for more information.
+     *
+     * Options for the embedded Custom Payment Method. Required for type: 'embedded'.
      */
-    embedded: {
+    embedded?: {
       /**
        * Function for rendering custom content in the Custom Payment Method form, called on mount.
        */

--- a/types/stripe-js/elements-group.d.ts
+++ b/types/stripe-js/elements-group.d.ts
@@ -1415,4 +1415,47 @@ export interface CustomPaymentMethod {
      */
     subtitle?: string;
   };
+
+  /**
+   * Additional options to configure the Custom Payment Method in the Payment Element. Alias for `options`.
+   */
+  payment?: {
+    /**
+     * The payment form type.
+     */
+    type: 'static';
+
+    /**
+     * Display additional information about the payment method, max 100 characters.
+     */
+    subtitle?: string;
+  };
+
+  /**
+   * Requires beta access:
+   * Contact [Stripe support](https://support.stripe.com/) for more information.
+   *
+   * Additional options to configure the Custom Payment Method in the Express Checkout Element.
+   */
+  expressCheckout?: {
+    /**
+     * The payment button type.
+     */
+    type: 'embedded';
+
+    /**
+     * Options for the embedded Custom Payment Method.
+     */
+    embedded: {
+      /**
+       * Function for rendering custom content in the Custom Payment Method button, called on mount.
+       */
+      handleRender: (container: HTMLDivElement) => void;
+
+      /**
+       * Function for cleaning up the Custom Payment Method button, called when the Custom Payment Method is removed and on unmount.
+       */
+      handleDestroy?: () => void;
+    };
+  };
 }

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -607,6 +607,9 @@ export interface StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent 
         paypal?: {available: boolean};
         amazonPay?: {available: boolean};
         klarna?: {available: boolean};
+        [customPaymentMethodId: `cpmt_${string}`]:
+          | {available: boolean}
+          | undefined;
       }
     | undefined;
 }

--- a/types/stripe-js/elements/express-checkout.d.ts
+++ b/types/stripe-js/elements/express-checkout.d.ts
@@ -607,9 +607,7 @@ export interface StripeExpressCheckoutElementAvailablePaymentMethodsChangeEvent 
         paypal?: {available: boolean};
         amazonPay?: {available: boolean};
         klarna?: {available: boolean};
-        [customPaymentMethodId: `cpmt_${string}`]:
-          | {available: boolean}
-          | undefined;
+        [customPaymentMethodId: string]: {available: boolean} | undefined;
       }
     | undefined;
 }


### PR DESCRIPTION
### Summary & motivation

Custom Payment Methods are now supported in Express Checkout Element. The new `payment` option is added as an alias for `options`, and the new `expressCheckout` option lets merchants specific ECE options. Additionally, "embedded" content in Payment Element can be specified in the `options` or `payment` objects.

Using `'embedded'` in PE and using CPMs at all in ECE are both currently gated features.

Additionally, CPM ids can now be present in the payload of the `'availablepaymentmethodschange'` event for ECE.

Design reviews and implementation are complete, launch preparation in progress.

[CPM in ECE Integration Guide](https://docs.stripe.com/payments/payment-element/custom-payment-methods?payment-ui=elements#cpm-express-checkout-element)